### PR TITLE
fix(security): Update out-of-date envs of proxy-setup service

### DIFF
--- a/compose-builder/add-security.yml
+++ b/compose-builder/add-security.yml
@@ -214,8 +214,8 @@ services:
       - common-sec-stage-gate.env
     environment:
       KONGURL_SERVER: kong
-      SECRETSERVICE_SERVER: edgex-vault
-      SECRETSERVICE_TOKENPATH: /tmp/edgex/secrets/edgex-security-proxy-setup/secrets-token.json
+      SECRETSTORE_HOST: edgex-vault
+      SECRETSTORE_TOKENPATH: /tmp/edgex/secrets/edgex-security-proxy-setup/secrets-token.json
     volumes:
       - edgex-init:/edgex-init:ro,z
       - /tmp/edgex/secrets/edgex-security-proxy-setup:/tmp/edgex/secrets/edgex-security-proxy-setup:ro,z

--- a/releases/pre-release/docker-compose-pre-release-arm64.yml
+++ b/releases/pre-release/docker-compose-pre-release-arm64.yml
@@ -580,8 +580,8 @@ services:
       KONGURL_SERVER: kong
       PROXY_SETUP_HOST: edgex-proxy-setup
       REGISTRY_HOST: edgex-core-consul
-      SECRETSERVICE_SERVER: edgex-vault
-      SECRETSERVICE_TOKENPATH: /tmp/edgex/secrets/edgex-security-proxy-setup/secrets-token.json
+      SECRETSTORE_HOST: edgex-vault
+      SECRETSTORE_TOKENPATH: /tmp/edgex/secrets/edgex-security-proxy-setup/secrets-token.json
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
       STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
       STAGEGATE_DATABASE_HOST: edgex-redis

--- a/releases/pre-release/docker-compose-pre-release.yml
+++ b/releases/pre-release/docker-compose-pre-release.yml
@@ -580,8 +580,8 @@ services:
       KONGURL_SERVER: kong
       PROXY_SETUP_HOST: edgex-proxy-setup
       REGISTRY_HOST: edgex-core-consul
-      SECRETSERVICE_SERVER: edgex-vault
-      SECRETSERVICE_TOKENPATH: /tmp/edgex/secrets/edgex-security-proxy-setup/secrets-token.json
+      SECRETSTORE_HOST: edgex-vault
+      SECRETSTORE_TOKENPATH: /tmp/edgex/secrets/edgex-security-proxy-setup/secrets-token.json
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
       STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
       STAGEGATE_DATABASE_HOST: edgex-redis

--- a/releases/pre-release/taf/docker-compose-taf-arm64.yml
+++ b/releases/pre-release/taf/docker-compose-taf-arm64.yml
@@ -868,8 +868,8 @@ services:
       KONGURL_SERVER: kong
       PROXY_SETUP_HOST: edgex-proxy-setup
       REGISTRY_HOST: edgex-core-consul
-      SECRETSERVICE_SERVER: edgex-vault
-      SECRETSERVICE_TOKENPATH: /tmp/edgex/secrets/edgex-security-proxy-setup/secrets-token.json
+      SECRETSTORE_HOST: edgex-vault
+      SECRETSTORE_TOKENPATH: /tmp/edgex/secrets/edgex-security-proxy-setup/secrets-token.json
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
       STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
       STAGEGATE_DATABASE_HOST: edgex-redis

--- a/releases/pre-release/taf/docker-compose-taf-perf-arm64.yml
+++ b/releases/pre-release/taf/docker-compose-taf-perf-arm64.yml
@@ -626,8 +626,8 @@ services:
       KONGURL_SERVER: kong
       PROXY_SETUP_HOST: edgex-proxy-setup
       REGISTRY_HOST: edgex-core-consul
-      SECRETSERVICE_SERVER: edgex-vault
-      SECRETSERVICE_TOKENPATH: /tmp/edgex/secrets/edgex-security-proxy-setup/secrets-token.json
+      SECRETSTORE_HOST: edgex-vault
+      SECRETSTORE_TOKENPATH: /tmp/edgex/secrets/edgex-security-proxy-setup/secrets-token.json
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
       STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
       STAGEGATE_DATABASE_HOST: edgex-redis

--- a/releases/pre-release/taf/docker-compose-taf-perf.yml
+++ b/releases/pre-release/taf/docker-compose-taf-perf.yml
@@ -626,8 +626,8 @@ services:
       KONGURL_SERVER: kong
       PROXY_SETUP_HOST: edgex-proxy-setup
       REGISTRY_HOST: edgex-core-consul
-      SECRETSERVICE_SERVER: edgex-vault
-      SECRETSERVICE_TOKENPATH: /tmp/edgex/secrets/edgex-security-proxy-setup/secrets-token.json
+      SECRETSTORE_HOST: edgex-vault
+      SECRETSTORE_TOKENPATH: /tmp/edgex/secrets/edgex-security-proxy-setup/secrets-token.json
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
       STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
       STAGEGATE_DATABASE_HOST: edgex-redis

--- a/releases/pre-release/taf/docker-compose-taf.yml
+++ b/releases/pre-release/taf/docker-compose-taf.yml
@@ -868,8 +868,8 @@ services:
       KONGURL_SERVER: kong
       PROXY_SETUP_HOST: edgex-proxy-setup
       REGISTRY_HOST: edgex-core-consul
-      SECRETSERVICE_SERVER: edgex-vault
-      SECRETSERVICE_TOKENPATH: /tmp/edgex/secrets/edgex-security-proxy-setup/secrets-token.json
+      SECRETSTORE_HOST: edgex-vault
+      SECRETSTORE_TOKENPATH: /tmp/edgex/secrets/edgex-security-proxy-setup/secrets-token.json
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
       STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
       STAGEGATE_DATABASE_HOST: edgex-redis


### PR DESCRIPTION
Change `SECRETSERVICE_SERVER` to `SECRETSTORE_HOST` and
`SECRETSERVICE_TOKENPATH` to `SECRETSTORE_TOKENPATH`

Fixes: #11

Signed-off-by: Jim Wang <yutsung.jim.wang@intel.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-examples/blob/master/.github/CONTRIBUTING.md.

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->
env vars of proxy-setup is out-dated since new go-mod-secret version is used

## Issue Number: #11 


## What is the new behavior?
Updated the env key names.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x ] No

## New Imports
Are there any new imports or modules? If so, what are they used for and why?

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information