### PR TITLE
fix: Add read-only flag to device-virtual

### DIFF
--- a/compose-builder/add-device-virtual.yml
+++ b/compose-builder/add-device-virtual.yml
@@ -22,6 +22,7 @@ services:
     - "127.0.0.1:49990:49990"
     container_name: edgex-device-virtual
     hostname: edgex-device-virtual
+    read_only: true
     networks:
       - edgex-network
     env_file:

--- a/releases/pre-release/docker-compose-pre-release-arm64.yml
+++ b/releases/pre-release/docker-compose-pre-release-arm64.yml
@@ -357,6 +357,7 @@ services:
       edgex-network: {}
     ports:
     - 127.0.0.1:49990:49990/tcp
+    read_only: true
     security_opt:
     - no-new-privileges:true
     user: 2002:2001

--- a/releases/pre-release/docker-compose-pre-release-no-secty-arm64.yml
+++ b/releases/pre-release/docker-compose-pre-release-no-secty-arm64.yml
@@ -230,6 +230,7 @@ services:
       edgex-network: {}
     ports:
     - 127.0.0.1:49990:49990/tcp
+    read_only: true
     security_opt:
     - no-new-privileges:true
     user: 2002:2001

--- a/releases/pre-release/docker-compose-pre-release-no-secty.yml
+++ b/releases/pre-release/docker-compose-pre-release-no-secty.yml
@@ -230,6 +230,7 @@ services:
       edgex-network: {}
     ports:
     - 127.0.0.1:49990:49990/tcp
+    read_only: true
     security_opt:
     - no-new-privileges:true
     user: 2002:2001

--- a/releases/pre-release/docker-compose-pre-release.yml
+++ b/releases/pre-release/docker-compose-pre-release.yml
@@ -357,6 +357,7 @@ services:
       edgex-network: {}
     ports:
     - 127.0.0.1:49990:49990/tcp
+    read_only: true
     security_opt:
     - no-new-privileges:true
     user: 2002:2001

--- a/releases/pre-release/taf/docker-compose-taf-arm64.yml
+++ b/releases/pre-release/taf/docker-compose-taf-arm64.yml
@@ -640,6 +640,7 @@ services:
       edgex-network: {}
     ports:
     - 127.0.0.1:49990:49990/tcp
+    read_only: true
     security_opt:
     - no-new-privileges:true
     user: 2002:2001

--- a/releases/pre-release/taf/docker-compose-taf-no-secty-arm64.yml
+++ b/releases/pre-release/taf/docker-compose-taf-no-secty-arm64.yml
@@ -372,6 +372,7 @@ services:
       edgex-network: {}
     ports:
     - 127.0.0.1:49990:49990/tcp
+    read_only: true
     security_opt:
     - no-new-privileges:true
     user: 2002:2001

--- a/releases/pre-release/taf/docker-compose-taf-no-secty.yml
+++ b/releases/pre-release/taf/docker-compose-taf-no-secty.yml
@@ -372,6 +372,7 @@ services:
       edgex-network: {}
     ports:
     - 127.0.0.1:49990:49990/tcp
+    read_only: true
     security_opt:
     - no-new-privileges:true
     user: 2002:2001

--- a/releases/pre-release/taf/docker-compose-taf-perf-arm64.yml
+++ b/releases/pre-release/taf/docker-compose-taf-perf-arm64.yml
@@ -394,6 +394,7 @@ services:
       edgex-network: {}
     ports:
     - 127.0.0.1:49990:49990/tcp
+    read_only: true
     security_opt:
     - no-new-privileges:true
     user: 2002:2001

--- a/releases/pre-release/taf/docker-compose-taf-perf-no-secty-arm64.yml
+++ b/releases/pre-release/taf/docker-compose-taf-perf-no-secty-arm64.yml
@@ -267,6 +267,7 @@ services:
       edgex-network: {}
     ports:
     - 127.0.0.1:49990:49990/tcp
+    read_only: true
     security_opt:
     - no-new-privileges:true
     user: 2002:2001

--- a/releases/pre-release/taf/docker-compose-taf-perf-no-secty.yml
+++ b/releases/pre-release/taf/docker-compose-taf-perf-no-secty.yml
@@ -267,6 +267,7 @@ services:
       edgex-network: {}
     ports:
     - 127.0.0.1:49990:49990/tcp
+    read_only: true
     security_opt:
     - no-new-privileges:true
     user: 2002:2001

--- a/releases/pre-release/taf/docker-compose-taf-perf.yml
+++ b/releases/pre-release/taf/docker-compose-taf-perf.yml
@@ -394,6 +394,7 @@ services:
       edgex-network: {}
     ports:
     - 127.0.0.1:49990:49990/tcp
+    read_only: true
     security_opt:
     - no-new-privileges:true
     user: 2002:2001

--- a/releases/pre-release/taf/docker-compose-taf.yml
+++ b/releases/pre-release/taf/docker-compose-taf.yml
@@ -640,6 +640,7 @@ services:
       edgex-network: {}
     ports:
     - 127.0.0.1:49990:49990/tcp
+    read_only: true
     security_opt:
     - no-new-privileges:true
     user: 2002:2001


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-examples/blob/master/.github/CONTRIBUTING.md.

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->
device-virtual docker container is using a R/W filesystem.

## Issue Number: #32 


## What is the new behavior?
device-virtual will have read-only permission.

Close #32
Resolve edgexfoundry/device-virtual-go#168

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No
