### PR TITLE
refactor: Specify user explicitly for all services

### DIFF
--- a/compose-builder/add-security.yml
+++ b/compose-builder/add-security.yml
@@ -175,7 +175,7 @@ services:
 
   kong:
     image: kong:${KONG_VERSION}
-    #user: "kong:kong" # Note Kong already running as kong user but doesn't expose kong user, so this fails
+    user: "kong:nogroup" # Note Kong already running as kong user but doesn't define a group
     container_name: kong
     hostname: kong
     read_only: true

--- a/compose-builder/add-security.yml
+++ b/compose-builder/add-security.yml
@@ -30,6 +30,7 @@ volumes:
 services:
   security-bootstrapper:
     image: ${CORE_EDGEX_REPOSITORY}/docker-security-bootstrapper-go${ARCH}:${CORE_EDGEX_VERSION}${DEV}
+    user: "root:root" # Must run as root
     container_name: edgex-security-bootstrapper
     hostname: edgex-security-bootstrapper
     networks:
@@ -86,6 +87,7 @@ services:
 
   vault:
     image: vault:${VAULT_VERSION}
+    user: "root:root" # Note that Vault is run under the 'vault' user, but entry point scripts need to first run as root
     container_name: edgex-vault
     hostname: edgex-vault
     networks:
@@ -113,6 +115,7 @@ services:
 
   secretstore-setup:
     image: ${CORE_EDGEX_REPOSITORY}/docker-security-secretstore-setup-go${ARCH}:${CORE_EDGEX_VERSION}${DEV}
+    user: "root:root" # must run as root
     container_name: edgex-secretstore-setup
     hostname: edgex-secretstore-setup
     env_file:
@@ -140,6 +143,7 @@ services:
 # containers for reverse proxy
   kong-db:
     image: postgres:${POSTGRES_VERSION}
+    user: "root:root" # Note that postgres is run under the 'postgres' user, but entry point scripts need to first run as root
     container_name: kong-db
     hostname: kong-db
     read_only: true
@@ -171,6 +175,7 @@ services:
 
   kong:
     image: kong:${KONG_VERSION}
+    #user: "kong:kong" # Note Kong already running as kong user but doesn't expose kong user, so this fails
     container_name: kong
     hostname: kong
     read_only: true
@@ -210,6 +215,7 @@ services:
 
   proxy-setup:
     image: ${CORE_EDGEX_REPOSITORY}/docker-security-proxy-setup-go${ARCH}:${CORE_EDGEX_VERSION}${DEV}
+    user: "${EDGEX_USER}:${EDGEX_GROUP}"
     container_name: edgex-proxy-setup
     hostname: edgex-proxy-setup
     entrypoint: ["/edgex-init/proxy_setup_wait_install.sh"]
@@ -237,7 +243,6 @@ services:
       - kong
     security_opt: 
       - no-new-privileges:true
-    user: "${EDGEX_USER}:${EDGEX_GROUP}"
 
 # end of containers for reverse proxy
 

--- a/compose-builder/docker-compose-base.yml
+++ b/compose-builder/docker-compose-base.yml
@@ -30,6 +30,7 @@ volumes:
 services:
   consul:
     image: consul:${CONSUL_VERSION}
+    user: "root:root" # Note that Consul is run under the 'consul' user, but entry point scripts need to first run as root
     ports:
       - "127.0.0.1:8500:8500"
     container_name: edgex-core-consul
@@ -45,6 +46,7 @@ services:
 
   database:
     image: redis:${REDIS_VERSION}
+    user: "root:root" # Note that Redis is run under the 'redis' user, but entry point scripts need to first run as root
     ports:
       - "127.0.0.1:6379:6379"
     container_name: edgex-redis
@@ -89,6 +91,7 @@ services:
 
   notifications:
     image: ${CORE_EDGEX_REPOSITORY}/docker-support-notifications-go${ARCH}:${CORE_EDGEX_VERSION}${DEV}
+    user: "${EDGEX_USER}:${EDGEX_GROUP}"
     ports:
       - "127.0.0.1:48060:48060"
     container_name: edgex-support-notifications
@@ -105,10 +108,10 @@ services:
       - database
     security_opt: 
       - no-new-privileges:true
-    user: "${EDGEX_USER}:${EDGEX_GROUP}"
 
   metadata:
     image: ${CORE_EDGEX_REPOSITORY}/docker-core-metadata-go${ARCH}:${CORE_EDGEX_VERSION}${DEV}
+    user: "${EDGEX_USER}:${EDGEX_GROUP}"
     ports:
       - "127.0.0.1:48081:48081"
     container_name: edgex-core-metadata
@@ -127,10 +130,10 @@ services:
       - notifications
     security_opt: 
       - no-new-privileges:true
-    user: "${EDGEX_USER}:${EDGEX_GROUP}"
 
   data:
     image: ${CORE_EDGEX_REPOSITORY}/docker-core-data-go${ARCH}:${CORE_EDGEX_VERSION}${DEV}
+    user: "${EDGEX_USER}:${EDGEX_GROUP}"
     ports:
       - "127.0.0.1:48080:48080"
       - "127.0.0.1:5563:5563"
@@ -149,10 +152,10 @@ services:
       - metadata
     security_opt: 
       - no-new-privileges:true
-    user: "${EDGEX_USER}:${EDGEX_GROUP}"
 
   command:
     image: ${CORE_EDGEX_REPOSITORY}/docker-core-command-go${ARCH}:${CORE_EDGEX_VERSION}${DEV}
+    user: "${EDGEX_USER}:${EDGEX_GROUP}"
     ports:
       - "127.0.0.1:48082:48082"
     container_name: edgex-core-command
@@ -170,10 +173,10 @@ services:
       - metadata
     security_opt: 
       - no-new-privileges:true
-    user: "${EDGEX_USER}:${EDGEX_GROUP}"
 
   scheduler:
     image: ${CORE_EDGEX_REPOSITORY}/docker-support-scheduler-go${ARCH}:${CORE_EDGEX_VERSION}${DEV}
+    user: "${EDGEX_USER}:${EDGEX_GROUP}"
     ports:
       - "127.0.0.1:48085:48085"
     container_name: edgex-support-scheduler
@@ -192,10 +195,10 @@ services:
       - database
     security_opt: 
       - no-new-privileges:true
-    user: "${EDGEX_USER}:${EDGEX_GROUP}"
 
   app-service-rules:
     image: ${APP_SVC_REPOSITORY}/docker-app-service-configurable${ARCH}:${APP_SERVICE_VERSION}${APP_SVC_DEV}
+    user: "${EDGEX_USER}:${EDGEX_GROUP}"
     ports:
       - "127.0.0.1:48100:48100"
     container_name: edgex-app-service-configurable-rules
@@ -216,7 +219,6 @@ services:
       - data
     security_opt: 
       - no-new-privileges:true
-    user: "${EDGEX_USER}:${EDGEX_GROUP}"
 
   rulesengine:
     image: emqx/kuiper:${KUIPER_VERSION}

--- a/releases/pre-release/docker-compose-pre-release-arm64.yml
+++ b/releases/pre-release/docker-compose-pre-release-arm64.yml
@@ -166,6 +166,7 @@ services:
     read_only: true
     security_opt:
     - no-new-privileges:true
+    user: root:root
     volumes:
     - consul-config:/consul/config:z
     - consul-data:/consul/data:z
@@ -292,6 +293,7 @@ services:
     - no-new-privileges:true
     tmpfs:
     - /run
+    user: root:root
     volumes:
     - db-data:/data:z
     - edgex-init:/edgex-init:ro,z
@@ -461,6 +463,7 @@ services:
     - /var/run
     - /tmp
     - /run
+    user: root:root
     volumes:
     - edgex-init:/edgex-init:ro,z
     - postgres-config:/tmp/postgres-config:z
@@ -769,6 +772,7 @@ services:
     tmpfs:
     - /run
     - /vault
+    user: root:root
     volumes:
     - edgex-init:/edgex-init:ro,z
     - /tmp/edgex/secrets:/tmp/edgex/secrets:z
@@ -803,6 +807,7 @@ services:
     read_only: true
     security_opt:
     - no-new-privileges:true
+    user: root:root
     volumes:
     - edgex-init:/edgex-init:z
   system:
@@ -883,6 +888,7 @@ services:
     - 127.0.0.1:8200:8200/tcp
     tmpfs:
     - /vault/config
+    user: root:root
     volumes:
     - edgex-init:/edgex-init:ro,z
     - vault-file:/vault/file:z

--- a/releases/pre-release/docker-compose-pre-release-arm64.yml
+++ b/releases/pre-release/docker-compose-pre-release-arm64.yml
@@ -414,6 +414,7 @@ services:
     - /run
     - /tmp
     tty: true
+    user: kong:nogroup
     volumes:
     - edgex-init:/edgex-init:ro,z
     - postgres-config:/tmp/postgres-config:z

--- a/releases/pre-release/docker-compose-pre-release-no-secty-arm64.yml
+++ b/releases/pre-release/docker-compose-pre-release-no-secty-arm64.yml
@@ -106,6 +106,7 @@ services:
     read_only: true
     security_opt:
     - no-new-privileges:true
+    user: root:root
     volumes:
     - consul-config:/consul/config:z
     - consul-data:/consul/data:z
@@ -168,6 +169,7 @@ services:
     read_only: true
     security_opt:
     - no-new-privileges:true
+    user: root:root
     volumes:
     - db-data:/data:z
   device-rest:

--- a/releases/pre-release/docker-compose-pre-release-no-secty.yml
+++ b/releases/pre-release/docker-compose-pre-release-no-secty.yml
@@ -106,6 +106,7 @@ services:
     read_only: true
     security_opt:
     - no-new-privileges:true
+    user: root:root
     volumes:
     - consul-config:/consul/config:z
     - consul-data:/consul/data:z
@@ -168,6 +169,7 @@ services:
     read_only: true
     security_opt:
     - no-new-privileges:true
+    user: root:root
     volumes:
     - db-data:/data:z
   device-rest:

--- a/releases/pre-release/docker-compose-pre-release.yml
+++ b/releases/pre-release/docker-compose-pre-release.yml
@@ -166,6 +166,7 @@ services:
     read_only: true
     security_opt:
     - no-new-privileges:true
+    user: root:root
     volumes:
     - consul-config:/consul/config:z
     - consul-data:/consul/data:z
@@ -292,6 +293,7 @@ services:
     - no-new-privileges:true
     tmpfs:
     - /run
+    user: root:root
     volumes:
     - db-data:/data:z
     - edgex-init:/edgex-init:ro,z
@@ -461,6 +463,7 @@ services:
     - /var/run
     - /tmp
     - /run
+    user: root:root
     volumes:
     - edgex-init:/edgex-init:ro,z
     - postgres-config:/tmp/postgres-config:z
@@ -769,6 +772,7 @@ services:
     tmpfs:
     - /run
     - /vault
+    user: root:root
     volumes:
     - edgex-init:/edgex-init:ro,z
     - /tmp/edgex/secrets:/tmp/edgex/secrets:z
@@ -803,6 +807,7 @@ services:
     read_only: true
     security_opt:
     - no-new-privileges:true
+    user: root:root
     volumes:
     - edgex-init:/edgex-init:z
   system:
@@ -883,6 +888,7 @@ services:
     - 127.0.0.1:8200:8200/tcp
     tmpfs:
     - /vault/config
+    user: root:root
     volumes:
     - edgex-init:/edgex-init:ro,z
     - vault-file:/vault/file:z

--- a/releases/pre-release/docker-compose-pre-release.yml
+++ b/releases/pre-release/docker-compose-pre-release.yml
@@ -414,6 +414,7 @@ services:
     - /run
     - /tmp
     tty: true
+    user: kong:nogroup
     volumes:
     - edgex-init:/edgex-init:ro,z
     - postgres-config:/tmp/postgres-config:z

--- a/releases/pre-release/taf/docker-compose-taf-arm64.yml
+++ b/releases/pre-release/taf/docker-compose-taf-arm64.yml
@@ -705,6 +705,7 @@ services:
     - /run
     - /tmp
     tty: true
+    user: kong:nogroup
     volumes:
     - edgex-init:/edgex-init:ro,z
     - postgres-config:/tmp/postgres-config:z

--- a/releases/pre-release/taf/docker-compose-taf-arm64.yml
+++ b/releases/pre-release/taf/docker-compose-taf-arm64.yml
@@ -419,6 +419,7 @@ services:
     read_only: true
     security_opt:
     - no-new-privileges:true
+    user: root:root
     volumes:
     - consul-config:/consul/config:z
     - consul-data:/consul/data:z
@@ -545,6 +546,7 @@ services:
     - no-new-privileges:true
     tmpfs:
     - /run
+    user: root:root
     volumes:
     - db-data:/data:z
     - edgex-init:/edgex-init:ro,z
@@ -752,6 +754,7 @@ services:
     - /var/run
     - /tmp
     - /run
+    user: root:root
     volumes:
     - edgex-init:/edgex-init:ro,z
     - postgres-config:/tmp/postgres-config:z
@@ -1124,6 +1127,7 @@ services:
     tmpfs:
     - /run
     - /vault
+    user: root:root
     volumes:
     - edgex-init:/edgex-init:ro,z
     - /tmp/edgex/secrets:/tmp/edgex/secrets:z
@@ -1158,6 +1162,7 @@ services:
     read_only: true
     security_opt:
     - no-new-privileges:true
+    user: root:root
     volumes:
     - edgex-init:/edgex-init:z
   system:
@@ -1238,6 +1243,7 @@ services:
     - 127.0.0.1:8200:8200/tcp
     tmpfs:
     - /vault/config
+    user: root:root
     volumes:
     - edgex-init:/edgex-init:ro,z
     - vault-file:/vault/file:z

--- a/releases/pre-release/taf/docker-compose-taf-no-secty-arm64.yml
+++ b/releases/pre-release/taf/docker-compose-taf-no-secty-arm64.yml
@@ -216,6 +216,7 @@ services:
     read_only: true
     security_opt:
     - no-new-privileges:true
+    user: root:root
     volumes:
     - consul-config:/consul/config:z
     - consul-data:/consul/data:z
@@ -278,6 +279,7 @@ services:
     read_only: true
     security_opt:
     - no-new-privileges:true
+    user: root:root
     volumes:
     - db-data:/data:z
   device-modbus:

--- a/releases/pre-release/taf/docker-compose-taf-no-secty.yml
+++ b/releases/pre-release/taf/docker-compose-taf-no-secty.yml
@@ -216,6 +216,7 @@ services:
     read_only: true
     security_opt:
     - no-new-privileges:true
+    user: root:root
     volumes:
     - consul-config:/consul/config:z
     - consul-data:/consul/data:z
@@ -278,6 +279,7 @@ services:
     read_only: true
     security_opt:
     - no-new-privileges:true
+    user: root:root
     volumes:
     - db-data:/data:z
   device-modbus:

--- a/releases/pre-release/taf/docker-compose-taf-perf-arm64.yml
+++ b/releases/pre-release/taf/docker-compose-taf-perf-arm64.yml
@@ -204,6 +204,7 @@ services:
     read_only: true
     security_opt:
     - no-new-privileges:true
+    user: root:root
     volumes:
     - consul-config:/consul/config:z
     - consul-data:/consul/data:z
@@ -330,6 +331,7 @@ services:
     - no-new-privileges:true
     tmpfs:
     - /run
+    user: root:root
     volumes:
     - db-data:/data:z
     - edgex-init:/edgex-init:ro,z
@@ -499,6 +501,7 @@ services:
     - /var/run
     - /tmp
     - /run
+    user: root:root
     volumes:
     - edgex-init:/edgex-init:ro,z
     - postgres-config:/tmp/postgres-config:z
@@ -819,6 +822,7 @@ services:
     tmpfs:
     - /run
     - /vault
+    user: root:root
     volumes:
     - edgex-init:/edgex-init:ro,z
     - /tmp/edgex/secrets:/tmp/edgex/secrets:z
@@ -853,6 +857,7 @@ services:
     read_only: true
     security_opt:
     - no-new-privileges:true
+    user: root:root
     volumes:
     - edgex-init:/edgex-init:z
   system:
@@ -933,6 +938,7 @@ services:
     - 127.0.0.1:8200:8200/tcp
     tmpfs:
     - /vault/config
+    user: root:root
     volumes:
     - edgex-init:/edgex-init:ro,z
     - vault-file:/vault/file:z

--- a/releases/pre-release/taf/docker-compose-taf-perf-arm64.yml
+++ b/releases/pre-release/taf/docker-compose-taf-perf-arm64.yml
@@ -452,6 +452,7 @@ services:
     - /run
     - /tmp
     tty: true
+    user: kong:nogroup
     volumes:
     - edgex-init:/edgex-init:ro,z
     - postgres-config:/tmp/postgres-config:z

--- a/releases/pre-release/taf/docker-compose-taf-perf-no-secty-arm64.yml
+++ b/releases/pre-release/taf/docker-compose-taf-perf-no-secty-arm64.yml
@@ -144,6 +144,7 @@ services:
     read_only: true
     security_opt:
     - no-new-privileges:true
+    user: root:root
     volumes:
     - consul-config:/consul/config:z
     - consul-data:/consul/data:z
@@ -206,6 +207,7 @@ services:
     read_only: true
     security_opt:
     - no-new-privileges:true
+    user: root:root
     volumes:
     - db-data:/data:z
   device-rest:

--- a/releases/pre-release/taf/docker-compose-taf-perf-no-secty.yml
+++ b/releases/pre-release/taf/docker-compose-taf-perf-no-secty.yml
@@ -144,6 +144,7 @@ services:
     read_only: true
     security_opt:
     - no-new-privileges:true
+    user: root:root
     volumes:
     - consul-config:/consul/config:z
     - consul-data:/consul/data:z
@@ -206,6 +207,7 @@ services:
     read_only: true
     security_opt:
     - no-new-privileges:true
+    user: root:root
     volumes:
     - db-data:/data:z
   device-rest:

--- a/releases/pre-release/taf/docker-compose-taf-perf.yml
+++ b/releases/pre-release/taf/docker-compose-taf-perf.yml
@@ -204,6 +204,7 @@ services:
     read_only: true
     security_opt:
     - no-new-privileges:true
+    user: root:root
     volumes:
     - consul-config:/consul/config:z
     - consul-data:/consul/data:z
@@ -330,6 +331,7 @@ services:
     - no-new-privileges:true
     tmpfs:
     - /run
+    user: root:root
     volumes:
     - db-data:/data:z
     - edgex-init:/edgex-init:ro,z
@@ -499,6 +501,7 @@ services:
     - /var/run
     - /tmp
     - /run
+    user: root:root
     volumes:
     - edgex-init:/edgex-init:ro,z
     - postgres-config:/tmp/postgres-config:z
@@ -819,6 +822,7 @@ services:
     tmpfs:
     - /run
     - /vault
+    user: root:root
     volumes:
     - edgex-init:/edgex-init:ro,z
     - /tmp/edgex/secrets:/tmp/edgex/secrets:z
@@ -853,6 +857,7 @@ services:
     read_only: true
     security_opt:
     - no-new-privileges:true
+    user: root:root
     volumes:
     - edgex-init:/edgex-init:z
   system:
@@ -933,6 +938,7 @@ services:
     - 127.0.0.1:8200:8200/tcp
     tmpfs:
     - /vault/config
+    user: root:root
     volumes:
     - edgex-init:/edgex-init:ro,z
     - vault-file:/vault/file:z

--- a/releases/pre-release/taf/docker-compose-taf-perf.yml
+++ b/releases/pre-release/taf/docker-compose-taf-perf.yml
@@ -452,6 +452,7 @@ services:
     - /run
     - /tmp
     tty: true
+    user: kong:nogroup
     volumes:
     - edgex-init:/edgex-init:ro,z
     - postgres-config:/tmp/postgres-config:z

--- a/releases/pre-release/taf/docker-compose-taf.yml
+++ b/releases/pre-release/taf/docker-compose-taf.yml
@@ -705,6 +705,7 @@ services:
     - /run
     - /tmp
     tty: true
+    user: kong:nogroup
     volumes:
     - edgex-init:/edgex-init:ro,z
     - postgres-config:/tmp/postgres-config:z

--- a/releases/pre-release/taf/docker-compose-taf.yml
+++ b/releases/pre-release/taf/docker-compose-taf.yml
@@ -419,6 +419,7 @@ services:
     read_only: true
     security_opt:
     - no-new-privileges:true
+    user: root:root
     volumes:
     - consul-config:/consul/config:z
     - consul-data:/consul/data:z
@@ -545,6 +546,7 @@ services:
     - no-new-privileges:true
     tmpfs:
     - /run
+    user: root:root
     volumes:
     - db-data:/data:z
     - edgex-init:/edgex-init:ro,z
@@ -752,6 +754,7 @@ services:
     - /var/run
     - /tmp
     - /run
+    user: root:root
     volumes:
     - edgex-init:/edgex-init:ro,z
     - postgres-config:/tmp/postgres-config:z
@@ -1124,6 +1127,7 @@ services:
     tmpfs:
     - /run
     - /vault
+    user: root:root
     volumes:
     - edgex-init:/edgex-init:ro,z
     - /tmp/edgex/secrets:/tmp/edgex/secrets:z
@@ -1158,6 +1162,7 @@ services:
     read_only: true
     security_opt:
     - no-new-privileges:true
+    user: root:root
     volumes:
     - edgex-init:/edgex-init:z
   system:
@@ -1238,6 +1243,7 @@ services:
     - 127.0.0.1:8200:8200/tcp
     tmpfs:
     - /vault/config
+    user: root:root
     volumes:
     - edgex-init:/edgex-init:ro,z
     - vault-file:/vault/file:z


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-examples/blob/master/.github/CONTRIBUTING.md.

## What is the current behavior?
Not all services have the user specified explicitly.
The CIS/DBS tool expects that when running as root that be explicit.

## Issue Number: #23


## What is the new behavior?
All services, except Kong, have the user specified explicitly.
Kong runs as `kong` user, but doesn't expose it so it can be used in the compose file.


## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information