### PR TITLE
feat(security): Update consul's volume on secrets folder to be writable

### DIFF
--- a/compose-builder/add-security.yml
+++ b/compose-builder/add-security.yml
@@ -82,7 +82,6 @@ services:
       - edgex-init:/edgex-init:ro,z
       # make secrets directories writable as Consul tokens are saved underneath this base directory
       - /tmp/edgex/secrets:/tmp/edgex/secrets:z
-      - /tmp/edgex/secrets/edgex-consul:/tmp/edgex/secrets/edgex-consul:ro,z
       # using regular volume to avoid lose of token due to host system reboot
       # and it is only shared between consul and proxy-setup
       - consul-acl-token:/tmp/edgex/secrets/consul-acl-token:z

--- a/compose-builder/add-security.yml
+++ b/compose-builder/add-security.yml
@@ -73,10 +73,15 @@ services:
       - common-security.env
       - common-sec-stage-gate.env
     environment:
+      # uncomment and modify the following line to add additional registry ACL roles on the fly
+      # the list is comma-separated service keys for these services
+      #ADD_REGISTRY_ACL_ROLES: edgex-app-service-configurable-rules, device-virtual
       STAGEGATE_REGISTRY_ACL_SENTINELFILEPATH: /consul/config/consul_acl_done
       STAGEGATE_REGISTRY_ACL_BOOTSTRAPTOKENPATH: /tmp/edgex/secrets/consul-acl-token/bootstrap_token.json
     volumes:
       - edgex-init:/edgex-init:ro,z
+      # make secrets directories writable as Consul tokens are saved underneath this base directory
+      - /tmp/edgex/secrets:/tmp/edgex/secrets:z
       - /tmp/edgex/secrets/edgex-consul:/tmp/edgex/secrets/edgex-consul:ro,z
       # using regular volume to avoid lose of token due to host system reboot
       # and it is only shared between consul and proxy-setup

--- a/releases/pre-release/docker-compose-pre-release-arm64.yml
+++ b/releases/pre-release/docker-compose-pre-release-arm64.yml
@@ -171,8 +171,8 @@ services:
     - consul-config:/consul/config:z
     - consul-data:/consul/data:z
     - edgex-init:/edgex-init:ro,z
+    - /tmp/edgex/secrets:/tmp/edgex/secrets:z
     - consul-acl-token:/tmp/edgex/secrets/consul-acl-token:z
-    - /tmp/edgex/secrets/edgex-consul:/tmp/edgex/secrets/edgex-consul:ro,z
   data:
     command: /core-data -cp=consul.http://edgex-core-consul:8500 --registry --confdir=/res
     container_name: edgex-core-data

--- a/releases/pre-release/docker-compose-pre-release.yml
+++ b/releases/pre-release/docker-compose-pre-release.yml
@@ -171,8 +171,8 @@ services:
     - consul-config:/consul/config:z
     - consul-data:/consul/data:z
     - edgex-init:/edgex-init:ro,z
+    - /tmp/edgex/secrets:/tmp/edgex/secrets:z
     - consul-acl-token:/tmp/edgex/secrets/consul-acl-token:z
-    - /tmp/edgex/secrets/edgex-consul:/tmp/edgex/secrets/edgex-consul:ro,z
   data:
     command: /core-data -cp=consul.http://edgex-core-consul:8500 --registry --confdir=/res
     container_name: edgex-core-data

--- a/releases/pre-release/taf/docker-compose-taf-arm64.yml
+++ b/releases/pre-release/taf/docker-compose-taf-arm64.yml
@@ -424,8 +424,8 @@ services:
     - consul-config:/consul/config:z
     - consul-data:/consul/data:z
     - edgex-init:/edgex-init:ro,z
+    - /tmp/edgex/secrets:/tmp/edgex/secrets:z
     - consul-acl-token:/tmp/edgex/secrets/consul-acl-token:z
-    - /tmp/edgex/secrets/edgex-consul:/tmp/edgex/secrets/edgex-consul:ro,z
   data:
     command: /core-data -cp=consul.http://edgex-core-consul:8500 --registry --confdir=/res
     container_name: edgex-core-data

--- a/releases/pre-release/taf/docker-compose-taf-perf-arm64.yml
+++ b/releases/pre-release/taf/docker-compose-taf-perf-arm64.yml
@@ -209,8 +209,8 @@ services:
     - consul-config:/consul/config:z
     - consul-data:/consul/data:z
     - edgex-init:/edgex-init:ro,z
+    - /tmp/edgex/secrets:/tmp/edgex/secrets:z
     - consul-acl-token:/tmp/edgex/secrets/consul-acl-token:z
-    - /tmp/edgex/secrets/edgex-consul:/tmp/edgex/secrets/edgex-consul:ro,z
   data:
     command: /core-data -cp=consul.http://edgex-core-consul:8500 --registry --confdir=/res
     container_name: edgex-core-data

--- a/releases/pre-release/taf/docker-compose-taf-perf.yml
+++ b/releases/pre-release/taf/docker-compose-taf-perf.yml
@@ -209,8 +209,8 @@ services:
     - consul-config:/consul/config:z
     - consul-data:/consul/data:z
     - edgex-init:/edgex-init:ro,z
+    - /tmp/edgex/secrets:/tmp/edgex/secrets:z
     - consul-acl-token:/tmp/edgex/secrets/consul-acl-token:z
-    - /tmp/edgex/secrets/edgex-consul:/tmp/edgex/secrets/edgex-consul:ro,z
   data:
     command: /core-data -cp=consul.http://edgex-core-consul:8500 --registry --confdir=/res
     container_name: edgex-core-data

--- a/releases/pre-release/taf/docker-compose-taf.yml
+++ b/releases/pre-release/taf/docker-compose-taf.yml
@@ -424,8 +424,8 @@ services:
     - consul-config:/consul/config:z
     - consul-data:/consul/data:z
     - edgex-init:/edgex-init:ro,z
+    - /tmp/edgex/secrets:/tmp/edgex/secrets:z
     - consul-acl-token:/tmp/edgex/secrets/consul-acl-token:z
-    - /tmp/edgex/secrets/edgex-consul:/tmp/edgex/secrets/edgex-consul:ro,z
   data:
     command: /core-data -cp=consul.http://edgex-core-consul:8500 --registry --confdir=/res
     container_name: edgex-core-data


### PR DESCRIPTION
- mount /tmp/edgex/secrets/ to be writable volume

Closes: #40

Signed-off-by: Jim Wang <yutsung.jim.wang@intel.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-examples/blob/master/.github/CONTRIBUTING.md.

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->
Currently, the /tmp/edgex/secrets/ is not mounted as volume and thus it is read-only as the container itself is read-only system.

## Issue Number: #40 


## What is the new behavior?
Mount the volume `/tmp/edgex/secrets` folder to be writable.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x ] No

## New Imports
Are there any new imports or modules? If so, what are they used for and why?

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information
This PR should be merged together with the edgex-go PR  https://github.com/edgexfoundry/edgex-go/pull/3324 so that the token generation process can work properly.
