### PR TITLE
feat(security): integrating consul token for edgex-sys-mgmt and app-services

### DIFF
--- a/compose-builder/Makefile
+++ b/compose-builder/Makefile
@@ -104,7 +104,7 @@ ifeq (asc-http, $(filter asc-http,$(ARGS)))
 		else
 			TOKEN_LIST:=$(TOKEN_LIST),app-http-export
 		endif
-		# when there does NOT ask for no secure mode (no-secty) explicitly,
+		# when no security mode (no-secty) not explicitly specified,
 		# then we also need to add the secure version on top of base yml by default.
 		COMPOSE_FILES:=$(COMPOSE_FILES) -f add-asc-http-export-secure.yml
 	endif
@@ -118,7 +118,7 @@ ifeq (asc-mqtt, $(filter asc-mqtt,$(ARGS)))
 		else
 			TOKEN_LIST:=$(TOKEN_LIST),app-mqtt-export
 		endif
-		# when there does NOT ask for no secure mode (no-secty) explicitly,
+		# when no security mode (no-secty) not explicitly specified,
 		# then we also need to add the secure version on top of base yml by default.
 		COMPOSE_FILES:=$(COMPOSE_FILES) -f add-asc-mqtt-export-secure.yml
 	endif
@@ -154,11 +154,12 @@ endif
 
 # Build compose for TAF secure testing (ignore all other compose file options)
 ifeq (taf-secty, $(filter taf-secty,$(ARGS)))
-	TOKEN_LIST:=app-http-export,app-mqtt-export
+	TOKEN_LIST:=app-http-export,app-mqtt-export,app-functional-tests
 	COMPOSE_FILES:= \
 		-f docker-compose-base.yml \
 		-f add-security.yml \
 		-f add-taf-app-services.yml \
+		-f add-taf-app-services-secure.yml \
 		-f add-asc-http-export.yml \
 		-f add-asc-http-export-secure.yml \
 		-f add-asc-mqtt-export.yml \
@@ -191,6 +192,7 @@ else
     			-f docker-compose-base.yml \
     			-f add-security.yml \
     			-f add-asc-mqtt-export.yml \
+    			-f add-asc-mqtt-export-secure.yml \
     			-f add-device-virtual.yml \
     			-f add-device-rest.yml \
     			-f add-mqtt-broker.yml

--- a/compose-builder/Makefile
+++ b/compose-builder/Makefile
@@ -188,6 +188,7 @@ else
     else
     	# Build compose for TAF secure performance testing (ignore all other compose file options)
     	ifeq (taf-perf, $(filter taf-perf,$(ARGS)))
+			TOKEN_LIST:=app-http-export,app-mqtt-export,app-functional-tests
     		COMPOSE_FILES:= \
     			-f docker-compose-base.yml \
     			-f add-security.yml \

--- a/compose-builder/Makefile
+++ b/compose-builder/Makefile
@@ -103,9 +103,9 @@ ifeq (asc-http, $(filter asc-http,$(ARGS)))
 endif
 ifeq (asc-http-s, $(filter asc-http-s,$(ARGS)))
     ifeq ($(TOKEN_LIST),"")
-      TOKEN_LIST:=app-service-http-export-secrets
+      TOKEN_LIST:=app-http-export-secrets
     else
-      TOKEN_LIST:=$(TOKEN_LIST),app-service-http-export-secrets
+      TOKEN_LIST:=$(TOKEN_LIST),app-http-export-secrets
     endif
     COMPOSE_FILES:=$(COMPOSE_FILES) -f add-asc-http-export-secure.yml
 endif
@@ -114,9 +114,9 @@ ifeq (asc-mqtt, $(filter asc-mqtt,$(ARGS)))
 endif
 ifeq (asc-mqtt-s, $(filter asc-mqtt-s,$(ARGS)))
     ifeq ($(TOKEN_LIST),"")
-      TOKEN_LIST:=app-service-mqtt-export-secrets
+      TOKEN_LIST:=app-mqtt-export-secrets
     else
-      TOKEN_LIST:=$(TOKEN_LIST),app-service-mqtt-export-secrets
+      TOKEN_LIST:=$(TOKEN_LIST),app-mqtt-export-secrets
     endif
     COMPOSE_FILES:=$(COMPOSE_FILES) -f add-asc-mqtt-export-secure.yml
 endif
@@ -151,7 +151,7 @@ endif
 
 # Build compose for TAF secure testing (ignore all other compose file options)
 ifeq (taf-secty, $(filter taf-secty,$(ARGS)))
-	TOKEN_LIST:=app-service-http-export-secrets,app-service-mqtt-export-secrets
+	TOKEN_LIST:=app-http-export-secrets,app-mqtt-export-secrets
 	COMPOSE_FILES:= \
 		-f docker-compose-base.yml \
 		-f add-security.yml \

--- a/compose-builder/Makefile
+++ b/compose-builder/Makefile
@@ -33,7 +33,7 @@ define OPTIONS
  - mqtt-bus mqtt-broker -
  - taf-secty taf-no-secty taf-perf taf-perf-no-secty -
  - ds-bacnet ds-camera ds-grove ds-modbus ds-mqtt ds-random ds-rest ds-snmp ds-virtual -
- - asc-http asc-http-s asc-mqtt asc-mqtt-s -
+ - asc-http asc-mqtt -
  - modbus-sim ui ui-only -
 endef
 export OPTIONS
@@ -88,9 +88,6 @@ endif
 ifeq (ds-virtual, $(filter ds-virtual,$(ARGS)))
 	COMPOSE_FILES:=$(COMPOSE_FILES) -f add-device-virtual.yml
 endif
-ifeq (asc-http, $(filter asc-http,$(ARGS)))
-	COMPOSE_FILES:=$(COMPOSE_FILES) -f add-asc-http-export.yml
-endif
 
 # Add ModBus Simulator
 ifeq (modbus-sim, $(filter modbus-sim,$(ARGS)))
@@ -99,26 +96,32 @@ endif
 
 # Add Application Services
 ifeq (asc-http, $(filter asc-http,$(ARGS)))
+	# always add the base
 	COMPOSE_FILES:=$(COMPOSE_FILES) -f add-asc-http-export.yml
-endif
-ifeq (asc-http-s, $(filter asc-http-s,$(ARGS)))
-    ifeq ($(TOKEN_LIST),"")
-      TOKEN_LIST:=app-http-export-secrets
-    else
-      TOKEN_LIST:=$(TOKEN_LIST),app-http-export-secrets
-    endif
-    COMPOSE_FILES:=$(COMPOSE_FILES) -f add-asc-http-export-secure.yml
+	ifneq (no-secty, $(filter no-secty,$(ARGS)))
+		ifeq ($(TOKEN_LIST),"")
+			TOKEN_LIST:=app-http-export
+		else
+			TOKEN_LIST:=$(TOKEN_LIST),app-http-export
+		endif
+		# when there does NOT ask for no secure mode (no-secty) explicitly,
+		# then we also need to add the secure version on top of base yml by default.
+		COMPOSE_FILES:=$(COMPOSE_FILES) -f add-asc-http-export-secure.yml
+	endif
 endif
 ifeq (asc-mqtt, $(filter asc-mqtt,$(ARGS)))
+	# always add the base
 	COMPOSE_FILES:=$(COMPOSE_FILES) -f add-asc-mqtt-export.yml
-endif
-ifeq (asc-mqtt-s, $(filter asc-mqtt-s,$(ARGS)))
-    ifeq ($(TOKEN_LIST),"")
-      TOKEN_LIST:=app-mqtt-export-secrets
-    else
-      TOKEN_LIST:=$(TOKEN_LIST),app-mqtt-export-secrets
-    endif
-    COMPOSE_FILES:=$(COMPOSE_FILES) -f add-asc-mqtt-export-secure.yml
+	ifneq (no-secty, $(filter no-secty,$(ARGS)))
+		ifeq ($(TOKEN_LIST),"")
+			TOKEN_LIST:=app-mqtt-export
+		else
+			TOKEN_LIST:=$(TOKEN_LIST),app-mqtt-export
+		endif
+		# when there does NOT ask for no secure mode (no-secty) explicitly,
+		# then we also need to add the secure version on top of base yml by default.
+		COMPOSE_FILES:=$(COMPOSE_FILES) -f add-asc-mqtt-export-secure.yml
+	endif
 endif
 
 # Add a MQTT Broker
@@ -151,15 +154,15 @@ endif
 
 # Build compose for TAF secure testing (ignore all other compose file options)
 ifeq (taf-secty, $(filter taf-secty,$(ARGS)))
-	TOKEN_LIST:=app-http-export-secrets,app-mqtt-export-secrets
+	TOKEN_LIST:=app-http-export,app-mqtt-export
 	COMPOSE_FILES:= \
 		-f docker-compose-base.yml \
 		-f add-security.yml \
 		-f add-taf-app-services.yml \
-		-f add-asc-http-export-secure.yml \
 		-f add-asc-http-export.yml \
-		-f add-asc-mqtt-export-secure.yml \
+		-f add-asc-http-export-secure.yml \
 		-f add-asc-mqtt-export.yml \
+		-f add-asc-mqtt-export-secure.yml \
 		-f add-device-virtual.yml \
 		-f add-device-rest.yml \
 		-f add-device-modbus.yml \

--- a/compose-builder/Makefile
+++ b/compose-builder/Makefile
@@ -154,7 +154,7 @@ endif
 
 # Build compose for TAF secure testing (ignore all other compose file options)
 ifeq (taf-secty, $(filter taf-secty,$(ARGS)))
-	TOKEN_LIST:=app-http-export,app-mqtt-export,app-functional-tests
+	TOKEN_LIST:=app-http-export,app-mqtt-export,app-functional-tests,scalability-test-mqtt-export
 	COMPOSE_FILES:= \
 		-f docker-compose-base.yml \
 		-f add-security.yml \
@@ -188,7 +188,7 @@ else
     else
     	# Build compose for TAF secure performance testing (ignore all other compose file options)
     	ifeq (taf-perf, $(filter taf-perf,$(ARGS)))
-			TOKEN_LIST:=app-http-export,app-mqtt-export,app-functional-tests
+			TOKEN_LIST:=app-http-export,app-mqtt-export,app-functional-tests,scalability-test-mqtt-export
     		COMPOSE_FILES:= \
     			-f docker-compose-base.yml \
     			-f add-security.yml \

--- a/compose-builder/README.md
+++ b/compose-builder/README.md
@@ -77,6 +77,8 @@ This folder contains the following compose files:
     MQTT MesssageBus **extending** compose file. Adds additional configuration of services so that the `MQTT` implementation of the Edgex Message Bus is used. **Must be used in conjunction with add-mqtt-broker.yml**
 - **add-taf-app-services.yml**
     TAF App Services **extending** compose file. Adds additional App Service for the TAF testing compose files.
+- **add-taf-app-services-secure.yml**
+    TAF App Services **extending** `add-taf-app-services` compose file, and services are enabled with secret store by default.
 - **add-taf-device-services-mods.yml**
     TAF Device Services **extending** compose file. Modifies setting of Device Virtual and Device Modbus for the TAF testing compose files. **Must be used in conjunction with add-device-modbus.yml and add-device-virtual.yml**
 - **add-ui.yml**

--- a/compose-builder/README.md
+++ b/compose-builder/README.md
@@ -61,10 +61,14 @@ This folder contains the following compose files:
     Device Service **extending** compose file, which adds the **Device Virtual**  service.
 - **add-asc-http-export.yml**
     Application Service Configurable **extending** compose file, which adds the **App Service Http Export**  service.
-    Service is enabled with secret store by default.
+- **add-asc-http-export-secure.yml**
+    Application Service Configurable **extending** `add-asc-http-export` compose file, and the service is
+    enabled with secret store by default.
 - **add-asc-mqtt-export.yml**
     Application Service Configurable **extending** compose file, which adds the **App Service MQTT Export**  service.
-    Service is enabled with secret store by default.
+- **add-asc-mqtt-export-secure.yml**
+    Application Service Configurable **extending** `add-asc-mqtt-export` compose file, and the service is
+    enabled with secret store by default.
 - **add-modbus-simulator.yml**
     ModBus Simulator **extending** compose file. Adds the MQTT ModBus Simulator service. Must be used in conjunction with  **add-device-modbus.yml**
 - **add-mqtt-broker.yml**

--- a/compose-builder/README.md
+++ b/compose-builder/README.md
@@ -61,12 +61,10 @@ This folder contains the following compose files:
     Device Service **extending** compose file, which adds the **Device Virtual**  service.
 - **add-asc-http-export.yml**
     Application Service Configurable **extending** compose file, which adds the **App Service Http Export**  service.
-- **add-asc-http-export-secure.yml**
-    Application Service Configurable **extending** compose file, which adds the **App Service Http Export Secrets** service. Service is enable for secure secrets.
+    Service is enabled with secret store by default.
 - **add-asc-mqtt-export.yml**
     Application Service Configurable **extending** compose file, which adds the **App Service MQTT Export**  service.
-- **add-asc-mqtt-export-secure.yml**
-    Application Service Configurable **extending** compose file, which adds the **App Service MQTT Export Secrets** service. Service is enable for secure secrets.
+    Service is enabled with secret store by default.
 - **add-modbus-simulator.yml**
     ModBus Simulator **extending** compose file. Adds the MQTT ModBus Simulator service. Must be used in conjunction with  **add-device-modbus.yml**
 - **add-mqtt-broker.yml**
@@ -162,9 +160,7 @@ Options:
     ds-virtual:  Runs with device-virtual included
     modbus-sim:  Runs with ModBus simulator included
     asc-http:    Runs with App Service HTTP Export included
-    asc-http-s:  Runs with App Service HTTP Export Secrets included
     asc-mqtt:    Runs with App Service MQTT Export included
-    asc-mqtt-s:  Runs with App Service MQTT Export Secrets included
     mqtt-broker: Runs with a MQTT Broker service included 
     mqtt-bus:    Runs with services configure for MQTT Message Bus 
     ui:          Runs with the UI service included
@@ -205,9 +201,7 @@ Options:
     ds-virtual:  Pull includes device-virtual
     modbus-sim:  Pull includes ModBus simulator
     asc-http:    Pull includes App Service HTTP Export
-    asc-http-s:  Pull includes App Service HTTP Export Secrets
     asc-mqtt:    Pull includes App Service MQTT Export
-    asc-mqtt-s:  Pull includes App Service MQTT Export Secrets
     mqtt-broker: Pull includes MQTT Broker service
     mqtt-bus:    Pull includes additional service for MQTT Message Bus
     ui:          Pulls includes the EdgeX UI service.
@@ -239,9 +233,7 @@ Options:
     ds-virtual:  Generates compose file with device-virtual included
     modbus-sim:  Generates compose file with ModBus simulator included
     asc-http:    Generates compose file with App Service HTTP Export included
-    asc-http-s:  Generates compose file with App Service HTTP Export Secrets included
     asc-mqtt:    Generates compose file with App Service MQTT Export included
-    asc-mqtt-s:  Generates compose file with App Service MQTT Export Secrets included
     mqtt-broker: Generates compose file with a MQTT Broker service included 
     mqtt-bus:    Generates compose file with services configure for MQTT Message Bus 
                  The MQTT Broker service is also included. 
@@ -315,9 +307,7 @@ Options:
     ds-virtual:  Generates compose file with device-virtual included
     modbus-sim:  Generates compose file with ModBus simulator included
     asc-http:    Generates compose file with App Service HTTP Export included
-    asc-http-s:  Generates compose file with App Service HTTP Export Secrets included
     asc-mqtt:    Generates compose file with App Service MQTT Export included
-    asc-mqtt-s:  Generates compose file with App Service MQTT Export Secrets included
     mqtt-broker: Generates compose file with a MQTT Broker service included 
     mqtt-bus:    Generates compose file with services configure for MQTT Message Bus 
                  The MQTT Broker service is also included.

--- a/compose-builder/add-asc-http-export-secure.yml
+++ b/compose-builder/add-asc-http-export-secure.yml
@@ -26,8 +26,8 @@ services:
     command: "/app-service-configurable ${DEFAULT_EDGEX_RUN_CMD_PARMS}"
     ports:
       - 127.0.0.1:48102:48102/tcp
-    container_name: app-service-http-export-secrets
-    hostname: app-service-http-export-secrets
+    container_name: app-http-export-secrets
+    hostname: app-http-export-secrets
     env_file:
       - common.env
       - common-security.env
@@ -35,16 +35,16 @@ services:
       - asc-common.env
       - asc-http-export.env
     environment:
-      SERVICE_HOST: app-service-http-export-secrets
+      SERVICE_HOST: app-http-export-secrets
       SERVICE_PORT: 48102
-      SECRETSTORE_PATH: /v1/secret/edgex/app-service-http-export-secrets/
-      SECRETSTORE_TOKENFILE: /tmp/edgex/secrets/app-service-http-export-secrets/secrets-token.json
+      SECRETSTORE_PATH: /v1/secret/edgex/app-http-export-secrets/
+      SECRETSTORE_TOKENFILE: /tmp/edgex/secrets/app-http-export-secrets/secrets-token.json
       WRITABLE_PIPELINE_FUNCTIONS_HTTPEXPORT_PARAMETERS_HEADERNAME: ""
       WRITABLE_PIPELINE_FUNCTIONS_HTTPEXPORT_PARAMETERS_SECRETNAME: ""
       WRITABLE_PIPELINE_FUNCTIONS_HTTPEXPORT_PARAMETERS_SECRETPATH: ""
     volumes:
       - edgex-init:/edgex-init:ro,z
-      - /tmp/edgex/secrets/app-service-http-export-secrets:/tmp/edgex/secrets/app-service-http-export-secrets:ro,z
+      - /tmp/edgex/secrets/app-http-export-secrets:/tmp/edgex/secrets/app-http-export-secrets:ro,z
     depends_on:
       - security-bootstrapper
       - consul
@@ -55,3 +55,7 @@ services:
     security_opt:
       - no-new-privileges:true
     user: "${EDGEX_USER}:${EDGEX_GROUP}"
+
+  consul:
+    environment:
+      ADD_REGISTRY_ACL_ROLES: ${TOKEN_LIST}

--- a/compose-builder/add-asc-http-export-secure.yml
+++ b/compose-builder/add-asc-http-export-secure.yml
@@ -20,6 +20,10 @@ services:
     environment:
       ADD_SECRETSTORE_TOKENS: ${TOKEN_LIST}
 
+  consul:
+    environment:
+      ADD_REGISTRY_ACL_ROLES: ${TOKEN_LIST}
+
   app-service-http-export-secrets:
     image: ${APP_SVC_REPOSITORY}/docker-app-service-configurable${ARCH}:${APP_SERVICE_VERSION}${APP_SVC_DEV}
     entrypoint: ["/edgex-init/ready_to_run_wait_install.sh"]
@@ -55,7 +59,3 @@ services:
     security_opt:
       - no-new-privileges:true
     user: "${EDGEX_USER}:${EDGEX_GROUP}"
-
-  consul:
-    environment:
-      ADD_REGISTRY_ACL_ROLES: ${TOKEN_LIST}

--- a/compose-builder/add-asc-http-export-secure.yml
+++ b/compose-builder/add-asc-http-export-secure.yml
@@ -24,38 +24,14 @@ services:
     environment:
       ADD_REGISTRY_ACL_ROLES: ${TOKEN_LIST}
 
-  app-service-http-export-secrets:
-    image: ${APP_SVC_REPOSITORY}/docker-app-service-configurable${ARCH}:${APP_SERVICE_VERSION}${APP_SVC_DEV}
+  app-service-http-export:
     entrypoint: ["/edgex-init/ready_to_run_wait_install.sh"]
     command: "/app-service-configurable ${DEFAULT_EDGEX_RUN_CMD_PARMS}"
-    ports:
-      - 127.0.0.1:48102:48102/tcp
-    container_name: app-http-export-secrets
-    hostname: app-http-export-secrets
     env_file:
-      - common.env
       - common-security.env
       - common-sec-stage-gate.env
-      - asc-common.env
-      - asc-http-export.env
-    environment:
-      SERVICE_HOST: app-http-export-secrets
-      SERVICE_PORT: 48102
-      SECRETSTORE_PATH: /v1/secret/edgex/app-http-export-secrets/
-      SECRETSTORE_TOKENFILE: /tmp/edgex/secrets/app-http-export-secrets/secrets-token.json
-      WRITABLE_PIPELINE_FUNCTIONS_HTTPEXPORT_PARAMETERS_HEADERNAME: ""
-      WRITABLE_PIPELINE_FUNCTIONS_HTTPEXPORT_PARAMETERS_SECRETNAME: ""
-      WRITABLE_PIPELINE_FUNCTIONS_HTTPEXPORT_PARAMETERS_SECRETPATH: ""
     volumes:
       - edgex-init:/edgex-init:ro,z
-      - /tmp/edgex/secrets/app-http-export-secrets:/tmp/edgex/secrets/app-http-export-secrets:ro,z
+      - /tmp/edgex/secrets/app-http-export:/tmp/edgex/secrets/app-http-export:ro,z
     depends_on:
       - security-bootstrapper
-      - consul
-      - data
-    read_only: true
-    networks:
-      - edgex-network
-    security_opt:
-      - no-new-privileges:true
-    user: "${EDGEX_USER}:${EDGEX_GROUP}"

--- a/compose-builder/add-asc-http-export.yml
+++ b/compose-builder/add-asc-http-export.yml
@@ -20,14 +20,14 @@ services:
     image: ${APP_SVC_REPOSITORY}/docker-app-service-configurable${ARCH}:${APP_SERVICE_VERSION}${APP_SVC_DEV}
     ports:
       - 127.0.0.1:48101:48101/tcp
-    container_name: app-service-http-export
-    hostname: app-service-http-export
+    container_name: app-http-export
+    hostname: app-http-export
     env_file:
       - common.env
       - asc-common.env
       - asc-http-export.env
     environment:
-      SERVICE_HOST: app-service-http-export
+      SERVICE_HOST: app-http-export
       SERVICE_PORT: 48101
     depends_on:
       - consul

--- a/compose-builder/add-asc-mqtt-export-secure.yml
+++ b/compose-builder/add-asc-mqtt-export-secure.yml
@@ -20,6 +20,10 @@ services:
     environment:
       ADD_SECRETSTORE_TOKENS: ${TOKEN_LIST}
 
+  consul:
+    environment:
+      ADD_REGISTRY_ACL_ROLES: ${TOKEN_LIST}
+
   appservice-mqtt-export-secrets:
     image: ${APP_SVC_REPOSITORY}/docker-app-service-configurable${ARCH}:${APP_SERVICE_VERSION}${APP_SVC_DEV}
     entrypoint: ["/edgex-init/ready_to_run_wait_install.sh"]
@@ -55,7 +59,3 @@ services:
     security_opt:
       - no-new-privileges:true
     user: "${EDGEX_USER}:${EDGEX_GROUP}"
-
-  consul:
-    environment:
-      ADD_REGISTRY_ACL_ROLES: ${TOKEN_LIST}

--- a/compose-builder/add-asc-mqtt-export-secure.yml
+++ b/compose-builder/add-asc-mqtt-export-secure.yml
@@ -26,8 +26,8 @@ services:
     command: "/app-service-configurable ${DEFAULT_EDGEX_RUN_CMD_PARMS}"
     ports:
       - 127.0.0.1:48104:48104/tcp
-    container_name: app-service-mqtt-export-secrets
-    hostname: app-service-mqtt-export-secrets
+    container_name: app-mqtt-export-secrets
+    hostname: app-mqtt-export-secrets
     env_file:
       - common.env
       - common-security.env
@@ -35,10 +35,10 @@ services:
       - asc-common.env
       - asc-mqtt-export.env
     environment:
-      SERVICE_HOST: app-service-mqtt-export-secrets
+      SERVICE_HOST: app-mqtt-export-secrets
       SERVICE_PORT: 48104
-      SECRETSTORE_PATH: /v1/secret/edgex/app-service-mqtt-export-secrets/
-      SECRETSTORE_TOKENFILE: /tmp/edgex/secrets/app-service-mqtt-export-secrets/secrets-token.json
+      SECRETSTORE_PATH: /v1/secret/edgex/app-mqtt-export-secrets/
+      SECRETSTORE_TOKENFILE: /tmp/edgex/secrets/app-mqtt-export-secrets/secrets-token.json
       WRITABLE_PIPELINE_FUNCTIONS_MQTTEXPORT_PARAMETERS_AUTHMODE : usernamepassword
       WRITABLE_INSECURESECRETS_MQTT_SECRETS_USERNAME: USERNAME_PLACEH_OLDER
       WRITABLE_INSECURESECRETS_MQTT_SECRETS_PASSWORD: PASSWORD_PLACE_HOLDER
@@ -51,7 +51,11 @@ services:
       - edgex-network
     volumes:
       - edgex-init:/edgex-init:ro,z
-      - /tmp/edgex/secrets/app-service-mqtt-export-secrets:/tmp/edgex/secrets/app-service-mqtt-export-secrets:ro,z
+      - /tmp/edgex/secrets/app-mqtt-export-secrets:/tmp/edgex/secrets/app-mqtt-export-secrets:ro,z
     security_opt:
       - no-new-privileges:true
     user: "${EDGEX_USER}:${EDGEX_GROUP}"
+
+  consul:
+    environment:
+      ADD_REGISTRY_ACL_ROLES: ${TOKEN_LIST}

--- a/compose-builder/add-asc-mqtt-export-secure.yml
+++ b/compose-builder/add-asc-mqtt-export-secure.yml
@@ -24,38 +24,18 @@ services:
     environment:
       ADD_REGISTRY_ACL_ROLES: ${TOKEN_LIST}
 
-  appservice-mqtt-export-secrets:
-    image: ${APP_SVC_REPOSITORY}/docker-app-service-configurable${ARCH}:${APP_SERVICE_VERSION}${APP_SVC_DEV}
+  appservice-mqtt-export:
     entrypoint: ["/edgex-init/ready_to_run_wait_install.sh"]
     command: "/app-service-configurable ${DEFAULT_EDGEX_RUN_CMD_PARMS}"
-    ports:
-      - 127.0.0.1:48104:48104/tcp
-    container_name: app-mqtt-export-secrets
-    hostname: app-mqtt-export-secrets
     env_file:
-      - common.env
       - common-security.env
       - common-sec-stage-gate.env
-      - asc-common.env
-      - asc-mqtt-export.env
     environment:
-      SERVICE_HOST: app-mqtt-export-secrets
-      SERVICE_PORT: 48104
-      SECRETSTORE_PATH: /v1/secret/edgex/app-mqtt-export-secrets/
-      SECRETSTORE_TOKENFILE: /tmp/edgex/secrets/app-mqtt-export-secrets/secrets-token.json
       WRITABLE_PIPELINE_FUNCTIONS_MQTTEXPORT_PARAMETERS_AUTHMODE : usernamepassword
       WRITABLE_INSECURESECRETS_MQTT_SECRETS_USERNAME: USERNAME_PLACEH_OLDER
       WRITABLE_INSECURESECRETS_MQTT_SECRETS_PASSWORD: PASSWORD_PLACE_HOLDER
     depends_on:
       - security-bootstrapper
-      - consul
-      - data
-    read_only: true
-    networks:
-      - edgex-network
     volumes:
       - edgex-init:/edgex-init:ro,z
       - /tmp/edgex/secrets/app-mqtt-export-secrets:/tmp/edgex/secrets/app-mqtt-export-secrets:ro,z
-    security_opt:
-      - no-new-privileges:true
-    user: "${EDGEX_USER}:${EDGEX_GROUP}"

--- a/compose-builder/add-asc-mqtt-export-secure.yml
+++ b/compose-builder/add-asc-mqtt-export-secure.yml
@@ -24,7 +24,7 @@ services:
     environment:
       ADD_REGISTRY_ACL_ROLES: ${TOKEN_LIST}
 
-  appservice-mqtt-export:
+  app-service-mqtt-export:
     entrypoint: ["/edgex-init/ready_to_run_wait_install.sh"]
     command: "/app-service-configurable ${DEFAULT_EDGEX_RUN_CMD_PARMS}"
     env_file:

--- a/compose-builder/add-asc-mqtt-export.yml
+++ b/compose-builder/add-asc-mqtt-export.yml
@@ -20,14 +20,14 @@ services:
     image: ${APP_SVC_REPOSITORY}/docker-app-service-configurable${ARCH}:${APP_SERVICE_VERSION}${APP_SVC_DEV}
     ports:
       - 127.0.0.1:48103:48103/tcp
-    container_name: app-service-mqtt-export
-    hostname: app-service-mqtt-export
+    container_name: app-mqtt-export
+    hostname: app-mqtt-export
     env_file:
       - common.env
       - asc-common.env
       - asc-mqtt-export.env
     environment:
-      SERVICE_HOST: app-service-mqtt-export
+      SERVICE_HOST: app-mqtt-export
       SERVICE_PORT: 48103
     depends_on:
       - consul

--- a/compose-builder/add-security.yml
+++ b/compose-builder/add-security.yml
@@ -66,6 +66,37 @@ services:
       - security-bootstrapper
       - secretstore-setup
 
+  secretstore-setup:
+    image: ${CORE_EDGEX_REPOSITORY}/docker-security-secretstore-setup-go${ARCH}:${CORE_EDGEX_VERSION}${DEV}
+    user: "root:root" # must run as root
+    container_name: edgex-secretstore-setup
+    hostname: edgex-secretstore-setup
+    env_file:
+      - common-security.env
+      - common-sec-stage-gate.env
+    environment:
+      EDGEX_USER: ${EDGEX_USER}
+      EDGEX_GROUP: ${EDGEX_GROUP}
+      # Uncomment and modify the following "ADD_SECRETSTORE_TOKENS" to add the additional secret store tokens on the fly
+      # the secret store token is required if you have added registry acl roles from env "ADD_REGISTRY_ACL_ROLES"
+      # in service "consul".
+      #ADD_SECRETSTORE_TOKENS: app-sample,app-rules-engine-redis, app-rules-engine-mqtt, app-push-to-core
+    read_only: true
+    networks:
+      - edgex-network
+    tmpfs:
+      - /run
+      - /vault
+    volumes:
+      - edgex-init:/edgex-init:ro,z
+      - vault-config:/vault/config:z
+      - /tmp/edgex/secrets:/tmp/edgex/secrets:z
+    depends_on:
+      - security-bootstrapper
+      - vault
+    security_opt:
+      - no-new-privileges:true
+
   consul:
     entrypoint: ["/edgex-init/consul_wait_install.sh"]
     env_file:
@@ -73,9 +104,9 @@ services:
       - common-security.env
       - common-sec-stage-gate.env
     environment:
-      # uncomment and modify the following line to add additional registry ACL roles on the fly
+      # uncomment and modify the following "ADD_REGISTRY_ACL_ROLES" to add additional registry ACL roles on the fly
       # the list is comma-separated service keys for these services
-      #ADD_REGISTRY_ACL_ROLES: appservice-sample,appservice-rules-engine-redis, appservice-rules-engine-mqtt, appservice-push-to-core
+      #ADD_REGISTRY_ACL_ROLES: app-sample,app-rules-engine-redis, app-rules-engine-mqtt, app-push-to-core
       STAGEGATE_REGISTRY_ACL_SENTINELFILEPATH: /consul/config/consul_acl_done
       STAGEGATE_REGISTRY_ACL_BOOTSTRAPTOKENPATH: /tmp/edgex/secrets/consul-acl-token/bootstrap_token.json
     volumes:
@@ -116,33 +147,6 @@ services:
       - vault-logs:/vault/logs:z
     depends_on:
       - security-bootstrapper
-
-  secretstore-setup:
-    image: ${CORE_EDGEX_REPOSITORY}/docker-security-secretstore-setup-go${ARCH}:${CORE_EDGEX_VERSION}${DEV}
-    user: "root:root" # must run as root
-    container_name: edgex-secretstore-setup
-    hostname: edgex-secretstore-setup
-    env_file:
-      - common-security.env
-      - common-sec-stage-gate.env
-    environment:
-      EDGEX_USER: ${EDGEX_USER}
-      EDGEX_GROUP: ${EDGEX_GROUP}
-    read_only: true
-    networks:
-      - edgex-network
-    tmpfs:
-      - /run
-      - /vault
-    volumes:
-      - edgex-init:/edgex-init:ro,z
-      - vault-config:/vault/config:z
-      - /tmp/edgex/secrets:/tmp/edgex/secrets:z
-    depends_on:
-      - security-bootstrapper
-      - vault
-    security_opt: 
-      - no-new-privileges:true
 
 # containers for reverse proxy
   kong-db:

--- a/compose-builder/add-security.yml
+++ b/compose-builder/add-security.yml
@@ -111,7 +111,6 @@ services:
       STAGEGATE_REGISTRY_ACL_BOOTSTRAPTOKENPATH: /tmp/edgex/secrets/consul-acl-token/bootstrap_token.json
     volumes:
       - edgex-init:/edgex-init:ro,z
-      - /tmp/edgex/secrets:/tmp/edgex/secrets:z
       - /tmp/edgex/secrets/edgex-consul:/tmp/edgex/secrets/edgex-consul:ro,z
       # using regular volume to avoid lose of token due to host system reboot
       # and it is only shared between consul and proxy-setup

--- a/compose-builder/add-security.yml
+++ b/compose-builder/add-security.yml
@@ -73,15 +73,15 @@ services:
       - common-security.env
       - common-sec-stage-gate.env
     environment:
-      # modify the following line to add additional registry ACL roles on the fly
+      # uncomment and modify the following line to add additional registry ACL roles on the fly
       # the list is comma-separated service keys for these services
-      ADD_REGISTRY_ACL_ROLES: edgex-sys-mgmt-agent, appservice-rules-engine
+      #ADD_REGISTRY_ACL_ROLES: appservice-sample,appservice-rules-engine-redis, appservice-rules-engine-mqtt, appservice-push-to-core
       STAGEGATE_REGISTRY_ACL_SENTINELFILEPATH: /consul/config/consul_acl_done
       STAGEGATE_REGISTRY_ACL_BOOTSTRAPTOKENPATH: /tmp/edgex/secrets/consul-acl-token/bootstrap_token.json
     volumes:
       - edgex-init:/edgex-init:ro,z
-      # make secrets directories writable as Consul tokens are saved underneath this base directory
       - /tmp/edgex/secrets:/tmp/edgex/secrets:z
+      - /tmp/edgex/secrets/edgex-consul:/tmp/edgex/secrets/edgex-consul:ro,z
       # using regular volume to avoid lose of token due to host system reboot
       # and it is only shared between consul and proxy-setup
       - consul-acl-token:/tmp/edgex/secrets/consul-acl-token:z
@@ -330,23 +330,19 @@ services:
       - secretstore-setup
       - database
 
-  # this is to make sure this service is started after security-bootstrapper process is done
-  # because it needs to await Consul token to be available
+  # this is to make sure the service is started after security-bootstrapper process is done
+  # because it needs to await Consul roles to be created
   app-service-rules:
     entrypoint: ["/edgex-init/ready_to_run_wait_install.sh"]
     command: "/app-service-configurable ${DEFAULT_EDGEX_RUN_CMD_PARMS}"
     env_file:
+      - common-security.env
       - common-sec-stage-gate.env
     environment:
-      # for this one doesn't need the secretstore
-      EDGEX_SECURITY_SECRET_STORE: "false"
-      # service key name is always lower cases
-      SERVICE_CONFIGACCESSTOKENFILE: /tmp/edgex/secrets/appservice-rules-engine/consul-token
-      REGISTRY_ACCESSTOKENFILE: /tmp/edgex/secrets/appservice-rules-engine/consul-token
+      SECRETSTORE_TOKENFILE: /tmp/edgex/secrets/app-rules-engine/secrets-token.json
     volumes:
       - edgex-init:/edgex-init:ro,z
-      # where the consul token is stored
-      - /tmp/edgex/secrets/appservice-rules-engine:/tmp/edgex/secrets/appservice-rules-engine:ro,z
+      - /tmp/edgex/secrets/app-rules-engine:/tmp/edgex/secrets/app-rules-engine:ro,z
     depends_on:
       - security-bootstrapper
 
@@ -354,13 +350,12 @@ services:
     entrypoint: ["/edgex-init/ready_to_run_wait_install.sh"]
     command: "/sys-mgmt-agent ${DEFAULT_EDGEX_RUN_CMD_PARMS}"
     env_file:
+      - common-security.env
       - common-sec-stage-gate.env
     environment:
-      # for this one doesn't need the secretstore
-      EDGEX_SECURITY_SECRET_STORE: "false"
+      SECRETSTORE_TOKENFILE: /tmp/edgex/secrets/edgex-sys-mgmt-agent/secrets-token.json
     volumes:
       - edgex-init:/edgex-init:ro,z
-      # where the consul token is stored
       - /tmp/edgex/secrets/edgex-sys-mgmt-agent:/tmp/edgex/secrets/edgex-sys-mgmt-agent:ro,z
     depends_on:
       - security-bootstrapper

--- a/compose-builder/add-security.yml
+++ b/compose-builder/add-security.yml
@@ -73,9 +73,9 @@ services:
       - common-security.env
       - common-sec-stage-gate.env
     environment:
-      # uncomment and modify the following line to add additional registry ACL roles on the fly
+      # modify the following line to add additional registry ACL roles on the fly
       # the list is comma-separated service keys for these services
-      #ADD_REGISTRY_ACL_ROLES: edgex-app-service-configurable-rules, device-virtual
+      ADD_REGISTRY_ACL_ROLES: edgex-sys-mgmt-agent, appservice-rules-engine
       STAGEGATE_REGISTRY_ACL_SENTINELFILEPATH: /consul/config/consul_acl_done
       STAGEGATE_REGISTRY_ACL_BOOTSTRAPTOKENPATH: /tmp/edgex/secrets/consul-acl-token/bootstrap_token.json
     volumes:
@@ -329,3 +329,38 @@ services:
       - security-bootstrapper
       - secretstore-setup
       - database
+
+  # this is to make sure this service is started after security-bootstrapper process is done
+  # because it needs to await Consul token to be available
+  app-service-rules:
+    entrypoint: ["/edgex-init/ready_to_run_wait_install.sh"]
+    command: "/app-service-configurable ${DEFAULT_EDGEX_RUN_CMD_PARMS}"
+    env_file:
+      - common-sec-stage-gate.env
+    environment:
+      # for this one doesn't need the secretstore
+      EDGEX_SECURITY_SECRET_STORE: "false"
+      # service key name is always lower cases
+      SERVICE_CONFIGACCESSTOKENFILE: /tmp/edgex/secrets/appservice-rules-engine/consul-token
+      REGISTRY_ACCESSTOKENFILE: /tmp/edgex/secrets/appservice-rules-engine/consul-token
+    volumes:
+      - edgex-init:/edgex-init:ro,z
+      # where the consul token is stored
+      - /tmp/edgex/secrets/appservice-rules-engine:/tmp/edgex/secrets/appservice-rules-engine:ro,z
+    depends_on:
+      - security-bootstrapper
+
+  system:
+    entrypoint: ["/edgex-init/ready_to_run_wait_install.sh"]
+    command: "/sys-mgmt-agent ${DEFAULT_EDGEX_RUN_CMD_PARMS}"
+    env_file:
+      - common-sec-stage-gate.env
+    environment:
+      # for this one doesn't need the secretstore
+      EDGEX_SECURITY_SECRET_STORE: "false"
+    volumes:
+      - edgex-init:/edgex-init:ro,z
+      # where the consul token is stored
+      - /tmp/edgex/secrets/edgex-sys-mgmt-agent:/tmp/edgex/secrets/edgex-sys-mgmt-agent:ro,z
+    depends_on:
+      - security-bootstrapper

--- a/compose-builder/add-taf-app-services-secure.yml
+++ b/compose-builder/add-taf-app-services-secure.yml
@@ -39,8 +39,6 @@ services:
   scalability-test-mqtt-export:
     entrypoint: ["/edgex-init/ready_to_run_wait_install.sh"]
     command: "/app-service-configurable ${DEFAULT_EDGEX_RUN_CMD_PARMS}"
-    environment:
-      EDGEX_SERVICE_KEY: scalability-test-mqtt-export
     env_file:
       - common-security.env
       - common-sec-stage-gate.env

--- a/compose-builder/add-taf-app-services-secure.yml
+++ b/compose-builder/add-taf-app-services-secure.yml
@@ -39,12 +39,13 @@ services:
   scalability-test-mqtt-export:
     entrypoint: ["/edgex-init/ready_to_run_wait_install.sh"]
     command: "/app-service-configurable ${DEFAULT_EDGEX_RUN_CMD_PARMS}"
+    environment:
+      EDGEX_SERVICE_KEY: scalability-test-mqtt-export
     env_file:
       - common-security.env
       - common-sec-stage-gate.env
     volumes:
       - edgex-init:/edgex-init:ro,z
-      # using the same secret store token as the one from app-mqtt-export
-      - /tmp/edgex/secrets/app-mqtt-export:/tmp/edgex/secrets/app-mqtt-export:ro,z
+      - /tmp/edgex/secrets/scalability-test-mqtt-export:/tmp/edgex/secrets/scalability-test-mqtt-export:ro,z
     depends_on:
       - security-bootstrapper

--- a/compose-builder/add-taf-app-services-secure.yml
+++ b/compose-builder/add-taf-app-services-secure.yml
@@ -24,18 +24,27 @@ services:
     environment:
       ADD_REGISTRY_ACL_ROLES: ${TOKEN_LIST}
 
-  app-service-mqtt-export:
+  app-service-functional-tests:
     entrypoint: ["/edgex-init/ready_to_run_wait_install.sh"]
     command: "/app-service-configurable ${DEFAULT_EDGEX_RUN_CMD_PARMS}"
     env_file:
       - common-security.env
       - common-sec-stage-gate.env
-    environment:
-      WRITABLE_PIPELINE_FUNCTIONS_MQTTEXPORT_PARAMETERS_AUTHMODE : usernamepassword
-      WRITABLE_INSECURESECRETS_MQTT_SECRETS_USERNAME: USERNAME_PLACEH_OLDER
-      WRITABLE_INSECURESECRETS_MQTT_SECRETS_PASSWORD: PASSWORD_PLACE_HOLDER
-    depends_on:
-      - security-bootstrapper
     volumes:
       - edgex-init:/edgex-init:ro,z
+      - /tmp/edgex/secrets/app-functional-tests:/tmp/edgex/secrets/app-functional-tests:ro,z
+    depends_on:
+      - security-bootstrapper
+
+  scalability-test-mqtt-export:
+    entrypoint: ["/edgex-init/ready_to_run_wait_install.sh"]
+    command: "/app-service-configurable ${DEFAULT_EDGEX_RUN_CMD_PARMS}"
+    env_file:
+      - common-security.env
+      - common-sec-stage-gate.env
+    volumes:
+      - edgex-init:/edgex-init:ro,z
+      # using the same secret store token as the one from app-mqtt-export
       - /tmp/edgex/secrets/app-mqtt-export:/tmp/edgex/secrets/app-mqtt-export:ro,z
+    depends_on:
+      - security-bootstrapper

--- a/compose-builder/add-taf-app-services.yml
+++ b/compose-builder/add-taf-app-services.yml
@@ -50,7 +50,8 @@ services:
       - asc-common.env
       - asc-mqtt-export.env
     environment:
-      SERVICE_HOST: app-mqtt-export
+      EDGEX_SERVICE_KEY: scalability-test-mqtt-export
+      SERVICE_HOST: scalability-test-mqtt-export
       SERVICE_PORT: 48106
       WRITABLE_PIPELINE_EXECUTIONORDER: "TransformToJSON, MQTTSecretSend"
       WRITABLE_LOGLEVEL: DEBUG

--- a/compose-builder/add-taf-app-services.yml
+++ b/compose-builder/add-taf-app-services.yml
@@ -20,14 +20,14 @@ services:
     image: ${APP_SVC_REPOSITORY}/docker-app-service-configurable${ARCH}:${APP_SERVICE_VERSION}${APP_SVC_DEV}
     ports:
       - 48105:48105/tcp
-    container_name: app-service-functional-tests
-    hostname: app-service-functional-tests
+    container_name: app-functional-tests
+    hostname: app-functional-tests
     env_file:
       - common.env
       - asc-common.env
     environment:
       EDGEX_PROFILE: functional-tests
-      SERVICE_HOST: app-service-functional-tests
+      SERVICE_HOST: app-functional-tests
       SERVICE_PORT: 48105
     depends_on:
       - consul
@@ -50,7 +50,7 @@ services:
       - asc-common.env
       - asc-mqtt-export.env
     environment:
-      SERVICE_HOST: app-service-mqtt-export
+      SERVICE_HOST: app-mqtt-export
       SERVICE_PORT: 48106
       WRITABLE_PIPELINE_EXECUTIONORDER: "TransformToJSON, MQTTSecretSend"
       WRITABLE_LOGLEVEL: DEBUG

--- a/docker-compose-pre-release-arm64.yml
+++ b/docker-compose-pre-release-arm64.yml
@@ -29,11 +29,18 @@ networks:
     driver: bridge
 services:
   app-service-rules:
+    command: /app-service-configurable -cp=consul.http://edgex-core-consul:8500 --registry
+      --confdir=/res
     container_name: edgex-app-service-configurable-rules
     depends_on:
     - consul
     - data
+    - security-bootstrapper
+    entrypoint:
+    - /edgex-init/ready_to_run_wait_install.sh
     environment:
+      API_GATEWAY_HOST: kong
+      API_GATEWAY_STATUS_PORT: '8001'
       CLIENTS_COMMAND_HOST: edgex-core-command
       CLIENTS_COREDATA_HOST: edgex-core-data
       CLIENTS_DATA_HOST: edgex-core-data
@@ -47,10 +54,30 @@ services:
       CLIENTS_SCHEDULER_HOST: edgex-support-scheduler
       DATABASES_PRIMARY_HOST: edgex-redis
       EDGEX_PROFILE: rules-engine
-      EDGEX_SECURITY_SECRET_STORE: "false"
+      EDGEX_SECURITY_SECRET_STORE: "true"
+      ENABLE_REGISTRY_ACL: "true"
+      PROXY_SETUP_HOST: edgex-proxy-setup
       REGISTRY_HOST: edgex-core-consul
+      SECRETSTORE_HOST: edgex-vault
+      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_TOKENFILE: /tmp/edgex/secrets/app-rules-engine/secrets-token.json
       SERVICE_HOST: edgex-app-service-configurable-rules
       SERVICE_PORT: 48100
+      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_DATABASE_HOST: edgex-redis
+      STAGEGATE_DATABASE_PORT: '6379'
+      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_KONGDB_HOST: kong-db
+      STAGEGATE_KONGDB_PORT: '5432'
+      STAGEGATE_KONGDB_READYPORT: '54325'
+      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_REGISTRY_HOST: edgex-core-consul
+      STAGEGATE_REGISTRY_PORT: '8500'
+      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_SECRETSTORESETUP_HOST: edgex-secretstore-setup
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_WAITFOR_TIMEOUT: 60s
       TRIGGER_EDGEXMESSAGEBUS_SUBSCRIBEHOST_HOST: edgex-core-data
       TRIGGER_PUBLISHTOPIC: events
     hostname: edgex-app-service-configurable-rules
@@ -63,6 +90,9 @@ services:
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
+    volumes:
+    - edgex-init:/edgex-init:ro,z
+    - /tmp/edgex/secrets/app-rules-engine:/tmp/edgex/secrets/app-rules-engine:ro,z
   command:
     command: /core-command -cp=consul.http://edgex-core-consul:8500 --registry --confdir=/res
     container_name: edgex-core-command
@@ -171,8 +201,8 @@ services:
     - consul-config:/consul/config:z
     - consul-data:/consul/data:z
     - edgex-init:/edgex-init:ro,z
-    - /tmp/edgex/secrets:/tmp/edgex/secrets:z
     - consul-acl-token:/tmp/edgex/secrets/consul-acl-token:z
+    - /tmp/edgex/secrets/edgex-consul:/tmp/edgex/secrets/edgex-consul:ro,z
   data:
     command: /core-data -cp=consul.http://edgex-core-consul:8500 --registry --confdir=/res
     container_name: edgex-core-data
@@ -812,6 +842,7 @@ services:
     volumes:
     - edgex-init:/edgex-init:z
   system:
+    command: /sys-mgmt-agent -cp=consul.http://edgex-core-consul:8500 --registry --confdir=/res
     container_name: edgex-sys-mgmt-agent
     depends_on:
     - command
@@ -820,7 +851,12 @@ services:
     - metadata
     - notifications
     - scheduler
+    - security-bootstrapper
+    entrypoint:
+    - /edgex-init/ready_to_run_wait_install.sh
     environment:
+      API_GATEWAY_HOST: kong
+      API_GATEWAY_STATUS_PORT: '8001'
       CLIENTS_COMMAND_HOST: edgex-core-command
       CLIENTS_COREDATA_HOST: edgex-core-data
       CLIENTS_DATA_HOST: edgex-core-data
@@ -833,11 +869,31 @@ services:
       CLIENTS_NOTIFICATIONS_HOST: edgex-support-notifications
       CLIENTS_SCHEDULER_HOST: edgex-support-scheduler
       DATABASES_PRIMARY_HOST: edgex-redis
-      EDGEX_SECURITY_SECRET_STORE: "false"
+      EDGEX_SECURITY_SECRET_STORE: "true"
+      ENABLE_REGISTRY_ACL: "true"
       EXECUTORPATH: /sys-mgmt-executor
       METRICSMECHANISM: executor
+      PROXY_SETUP_HOST: edgex-proxy-setup
       REGISTRY_HOST: edgex-core-consul
+      SECRETSTORE_HOST: edgex-vault
+      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_TOKENFILE: /tmp/edgex/secrets/edgex-sys-mgmt-agent/secrets-token.json
       SERVICE_HOST: edgex-sys-mgmt-agent
+      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_DATABASE_HOST: edgex-redis
+      STAGEGATE_DATABASE_PORT: '6379'
+      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_KONGDB_HOST: kong-db
+      STAGEGATE_KONGDB_PORT: '5432'
+      STAGEGATE_KONGDB_READYPORT: '54325'
+      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_REGISTRY_HOST: edgex-core-consul
+      STAGEGATE_REGISTRY_PORT: '8500'
+      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_SECRETSTORESETUP_HOST: edgex-secretstore-setup
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-sys-mgmt-agent
     image: nexus3.edgexfoundry.org:10004/docker-sys-mgmt-agent-go-arm64:master
     networks:
@@ -849,6 +905,8 @@ services:
     - no-new-privileges:true
     user: root:root
     volumes:
+    - edgex-init:/edgex-init:ro,z
+    - /tmp/edgex/secrets/edgex-sys-mgmt-agent:/tmp/edgex/secrets/edgex-sys-mgmt-agent:ro,z
     - /var/run/docker.sock:/var/run/docker.sock:z
   vault:
     cap_add:

--- a/docker-compose-pre-release.yml
+++ b/docker-compose-pre-release.yml
@@ -29,11 +29,18 @@ networks:
     driver: bridge
 services:
   app-service-rules:
+    command: /app-service-configurable -cp=consul.http://edgex-core-consul:8500 --registry
+      --confdir=/res
     container_name: edgex-app-service-configurable-rules
     depends_on:
     - consul
     - data
+    - security-bootstrapper
+    entrypoint:
+    - /edgex-init/ready_to_run_wait_install.sh
     environment:
+      API_GATEWAY_HOST: kong
+      API_GATEWAY_STATUS_PORT: '8001'
       CLIENTS_COMMAND_HOST: edgex-core-command
       CLIENTS_COREDATA_HOST: edgex-core-data
       CLIENTS_DATA_HOST: edgex-core-data
@@ -47,10 +54,30 @@ services:
       CLIENTS_SCHEDULER_HOST: edgex-support-scheduler
       DATABASES_PRIMARY_HOST: edgex-redis
       EDGEX_PROFILE: rules-engine
-      EDGEX_SECURITY_SECRET_STORE: "false"
+      EDGEX_SECURITY_SECRET_STORE: "true"
+      ENABLE_REGISTRY_ACL: "true"
+      PROXY_SETUP_HOST: edgex-proxy-setup
       REGISTRY_HOST: edgex-core-consul
+      SECRETSTORE_HOST: edgex-vault
+      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_TOKENFILE: /tmp/edgex/secrets/app-rules-engine/secrets-token.json
       SERVICE_HOST: edgex-app-service-configurable-rules
       SERVICE_PORT: 48100
+      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_DATABASE_HOST: edgex-redis
+      STAGEGATE_DATABASE_PORT: '6379'
+      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_KONGDB_HOST: kong-db
+      STAGEGATE_KONGDB_PORT: '5432'
+      STAGEGATE_KONGDB_READYPORT: '54325'
+      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_REGISTRY_HOST: edgex-core-consul
+      STAGEGATE_REGISTRY_PORT: '8500'
+      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_SECRETSTORESETUP_HOST: edgex-secretstore-setup
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_WAITFOR_TIMEOUT: 60s
       TRIGGER_EDGEXMESSAGEBUS_SUBSCRIBEHOST_HOST: edgex-core-data
       TRIGGER_PUBLISHTOPIC: events
     hostname: edgex-app-service-configurable-rules
@@ -63,6 +90,9 @@ services:
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
+    volumes:
+    - edgex-init:/edgex-init:ro,z
+    - /tmp/edgex/secrets/app-rules-engine:/tmp/edgex/secrets/app-rules-engine:ro,z
   command:
     command: /core-command -cp=consul.http://edgex-core-consul:8500 --registry --confdir=/res
     container_name: edgex-core-command
@@ -171,8 +201,8 @@ services:
     - consul-config:/consul/config:z
     - consul-data:/consul/data:z
     - edgex-init:/edgex-init:ro,z
-    - /tmp/edgex/secrets:/tmp/edgex/secrets:z
     - consul-acl-token:/tmp/edgex/secrets/consul-acl-token:z
+    - /tmp/edgex/secrets/edgex-consul:/tmp/edgex/secrets/edgex-consul:ro,z
   data:
     command: /core-data -cp=consul.http://edgex-core-consul:8500 --registry --confdir=/res
     container_name: edgex-core-data
@@ -812,6 +842,7 @@ services:
     volumes:
     - edgex-init:/edgex-init:z
   system:
+    command: /sys-mgmt-agent -cp=consul.http://edgex-core-consul:8500 --registry --confdir=/res
     container_name: edgex-sys-mgmt-agent
     depends_on:
     - command
@@ -820,7 +851,12 @@ services:
     - metadata
     - notifications
     - scheduler
+    - security-bootstrapper
+    entrypoint:
+    - /edgex-init/ready_to_run_wait_install.sh
     environment:
+      API_GATEWAY_HOST: kong
+      API_GATEWAY_STATUS_PORT: '8001'
       CLIENTS_COMMAND_HOST: edgex-core-command
       CLIENTS_COREDATA_HOST: edgex-core-data
       CLIENTS_DATA_HOST: edgex-core-data
@@ -833,11 +869,31 @@ services:
       CLIENTS_NOTIFICATIONS_HOST: edgex-support-notifications
       CLIENTS_SCHEDULER_HOST: edgex-support-scheduler
       DATABASES_PRIMARY_HOST: edgex-redis
-      EDGEX_SECURITY_SECRET_STORE: "false"
+      EDGEX_SECURITY_SECRET_STORE: "true"
+      ENABLE_REGISTRY_ACL: "true"
       EXECUTORPATH: /sys-mgmt-executor
       METRICSMECHANISM: executor
+      PROXY_SETUP_HOST: edgex-proxy-setup
       REGISTRY_HOST: edgex-core-consul
+      SECRETSTORE_HOST: edgex-vault
+      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_TOKENFILE: /tmp/edgex/secrets/edgex-sys-mgmt-agent/secrets-token.json
       SERVICE_HOST: edgex-sys-mgmt-agent
+      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_DATABASE_HOST: edgex-redis
+      STAGEGATE_DATABASE_PORT: '6379'
+      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_KONGDB_HOST: kong-db
+      STAGEGATE_KONGDB_PORT: '5432'
+      STAGEGATE_KONGDB_READYPORT: '54325'
+      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_REGISTRY_HOST: edgex-core-consul
+      STAGEGATE_REGISTRY_PORT: '8500'
+      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_SECRETSTORESETUP_HOST: edgex-secretstore-setup
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-sys-mgmt-agent
     image: nexus3.edgexfoundry.org:10004/docker-sys-mgmt-agent-go:master
     networks:
@@ -849,6 +905,8 @@ services:
     - no-new-privileges:true
     user: root:root
     volumes:
+    - edgex-init:/edgex-init:ro,z
+    - /tmp/edgex/secrets/edgex-sys-mgmt-agent:/tmp/edgex/secrets/edgex-sys-mgmt-agent:ro,z
     - /var/run/docker.sock:/var/run/docker.sock:z
   vault:
     cap_add:

--- a/taf/docker-compose-taf-arm64.yml
+++ b/taf/docker-compose-taf-arm64.yml
@@ -363,7 +363,7 @@ services:
     entrypoint:
     - /edgex-init/consul_wait_install.sh
     environment:
-      ADD_REGISTRY_ACL_ROLES: app-http-export,app-mqtt-export,app-functional-tests
+      ADD_REGISTRY_ACL_ROLES: app-http-export,app-mqtt-export,app-functional-tests,scalability-test-mqtt-export
       API_GATEWAY_HOST: kong
       API_GATEWAY_STATUS_PORT: '8001'
       EDGEX_SECURITY_SECRET_STORE: "true"
@@ -990,6 +990,7 @@ services:
       DATABASE_HOST: edgex-redis
       EDGEX_PROFILE: mqtt-export
       EDGEX_SECURITY_SECRET_STORE: "true"
+      EDGEX_SERVICE_KEY: scalability-test-mqtt-export
       ENABLE_REGISTRY_ACL: "true"
       PROXY_SETUP_HOST: edgex-proxy-setup
       REGISTRY_HOST: edgex-core-consul
@@ -1029,7 +1030,7 @@ services:
     user: 2002:2001
     volumes:
     - edgex-init:/edgex-init:ro,z
-    - /tmp/edgex/secrets/app-mqtt-export:/tmp/edgex/secrets/app-mqtt-export:ro,z
+    - /tmp/edgex/secrets/scalability-test-mqtt-export:/tmp/edgex/secrets/scalability-test-mqtt-export:ro,z
   scheduler:
     command: /support-scheduler -cp=consul.http://edgex-core-consul:8500 --registry
       --confdir=/res
@@ -1100,7 +1101,7 @@ services:
     - security-bootstrapper
     - vault
     environment:
-      ADD_SECRETSTORE_TOKENS: app-http-export,app-mqtt-export,app-functional-tests
+      ADD_SECRETSTORE_TOKENS: app-http-export,app-mqtt-export,app-functional-tests,scalability-test-mqtt-export
       API_GATEWAY_HOST: kong
       API_GATEWAY_STATUS_PORT: '8001'
       EDGEX_GROUP: '2001'

--- a/taf/docker-compose-taf-arm64.yml
+++ b/taf/docker-compose-taf-arm64.yml
@@ -996,7 +996,7 @@ services:
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault
       SECRETSTORE_PORT: '8200'
-      SERVICE_HOST: app-mqtt-export
+      SERVICE_HOST: scalability-test-mqtt-export
       SERVICE_PORT: 48106
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
       STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'

--- a/taf/docker-compose-taf-arm64.yml
+++ b/taf/docker-compose-taf-arm64.yml
@@ -29,11 +29,18 @@ networks:
     driver: bridge
 services:
   app-service-functional-tests:
+    command: /app-service-configurable -cp=consul.http://edgex-core-consul:8500 --registry
+      --confdir=/res
     container_name: app-functional-tests
     depends_on:
     - consul
     - data
+    - security-bootstrapper
+    entrypoint:
+    - /edgex-init/ready_to_run_wait_install.sh
     environment:
+      API_GATEWAY_HOST: kong
+      API_GATEWAY_STATUS_PORT: '8001'
       CLIENTS_COMMAND_HOST: edgex-core-command
       CLIENTS_COREDATA_HOST: edgex-core-data
       CLIENTS_DATA_HOST: edgex-core-data
@@ -48,10 +55,29 @@ services:
       DATABASES_PRIMARY_HOST: edgex-redis
       DATABASE_HOST: edgex-redis
       EDGEX_PROFILE: functional-tests
-      EDGEX_SECURITY_SECRET_STORE: "false"
+      EDGEX_SECURITY_SECRET_STORE: "true"
+      ENABLE_REGISTRY_ACL: "true"
+      PROXY_SETUP_HOST: edgex-proxy-setup
       REGISTRY_HOST: edgex-core-consul
+      SECRETSTORE_HOST: edgex-vault
+      SECRETSTORE_PORT: '8200'
       SERVICE_HOST: app-functional-tests
       SERVICE_PORT: 48105
+      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_DATABASE_HOST: edgex-redis
+      STAGEGATE_DATABASE_PORT: '6379'
+      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_KONGDB_HOST: kong-db
+      STAGEGATE_KONGDB_PORT: '5432'
+      STAGEGATE_KONGDB_READYPORT: '54325'
+      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_REGISTRY_HOST: edgex-core-consul
+      STAGEGATE_REGISTRY_PORT: '8500'
+      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_SECRETSTORESETUP_HOST: edgex-secretstore-setup
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_WAITFOR_TIMEOUT: 60s
       TRIGGER_EDGEXMESSAGEBUS_SUBSCRIBEHOST_HOST: edgex-core-data
     hostname: app-functional-tests
     image: nexus3.edgexfoundry.org:10004/docker-app-service-configurable-arm64:master
@@ -63,6 +89,9 @@ services:
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
+    volumes:
+    - edgex-init:/edgex-init:ro,z
+    - /tmp/edgex/secrets/app-functional-tests:/tmp/edgex/secrets/app-functional-tests:ro,z
   app-service-http-export:
     command: /app-service-configurable -cp=consul.http://edgex-core-consul:8500 --registry
       --confdir=/res
@@ -198,7 +227,7 @@ services:
     user: 2002:2001
     volumes:
     - edgex-init:/edgex-init:ro,z
-    - /tmp/edgex/secrets/app-mqtt-export-secrets:/tmp/edgex/secrets/app-mqtt-export-secrets:ro,z
+    - /tmp/edgex/secrets/app-mqtt-export:/tmp/edgex/secrets/app-mqtt-export:ro,z
   app-service-rules:
     command: /app-service-configurable -cp=consul.http://edgex-core-consul:8500 --registry
       --confdir=/res
@@ -334,7 +363,7 @@ services:
     entrypoint:
     - /edgex-init/consul_wait_install.sh
     environment:
-      ADD_REGISTRY_ACL_ROLES: app-http-export,app-mqtt-export
+      ADD_REGISTRY_ACL_ROLES: app-http-export,app-mqtt-export,app-functional-tests
       API_GATEWAY_HOST: kong
       API_GATEWAY_STATUS_PORT: '8001'
       EDGEX_SECURITY_SECRET_STORE: "true"
@@ -934,11 +963,18 @@ services:
     volumes:
     - kuiper-data:/kuiper/data:z
   scalability-test-mqtt-export:
+    command: /app-service-configurable -cp=consul.http://edgex-core-consul:8500 --registry
+      --confdir=/res
     container_name: scalability-test-mqtt-export
     depends_on:
     - consul
     - data
+    - security-bootstrapper
+    entrypoint:
+    - /edgex-init/ready_to_run_wait_install.sh
     environment:
+      API_GATEWAY_HOST: kong
+      API_GATEWAY_STATUS_PORT: '8001'
       CLIENTS_COMMAND_HOST: edgex-core-command
       CLIENTS_COREDATA_HOST: edgex-core-data
       CLIENTS_DATA_HOST: edgex-core-data
@@ -953,10 +989,29 @@ services:
       DATABASES_PRIMARY_HOST: edgex-redis
       DATABASE_HOST: edgex-redis
       EDGEX_PROFILE: mqtt-export
-      EDGEX_SECURITY_SECRET_STORE: "false"
+      EDGEX_SECURITY_SECRET_STORE: "true"
+      ENABLE_REGISTRY_ACL: "true"
+      PROXY_SETUP_HOST: edgex-proxy-setup
       REGISTRY_HOST: edgex-core-consul
+      SECRETSTORE_HOST: edgex-vault
+      SECRETSTORE_PORT: '8200'
       SERVICE_HOST: app-mqtt-export
       SERVICE_PORT: 48106
+      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_DATABASE_HOST: edgex-redis
+      STAGEGATE_DATABASE_PORT: '6379'
+      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_KONGDB_HOST: kong-db
+      STAGEGATE_KONGDB_PORT: '5432'
+      STAGEGATE_KONGDB_READYPORT: '54325'
+      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_REGISTRY_HOST: edgex-core-consul
+      STAGEGATE_REGISTRY_PORT: '8500'
+      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_SECRETSTORESETUP_HOST: edgex-secretstore-setup
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_WAITFOR_TIMEOUT: 60s
       TRIGGER_EDGEXMESSAGEBUS_SUBSCRIBEHOST_HOST: edgex-core-data
       WRITABLE_LOGLEVEL: DEBUG
       WRITABLE_PIPELINE_EXECUTIONORDER: TransformToJSON, MQTTSecretSend
@@ -972,6 +1027,9 @@ services:
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
+    volumes:
+    - edgex-init:/edgex-init:ro,z
+    - /tmp/edgex/secrets/app-mqtt-export:/tmp/edgex/secrets/app-mqtt-export:ro,z
   scheduler:
     command: /support-scheduler -cp=consul.http://edgex-core-consul:8500 --registry
       --confdir=/res
@@ -1042,7 +1100,7 @@ services:
     - security-bootstrapper
     - vault
     environment:
-      ADD_SECRETSTORE_TOKENS: app-http-export,app-mqtt-export
+      ADD_SECRETSTORE_TOKENS: app-http-export,app-mqtt-export,app-functional-tests
       API_GATEWAY_HOST: kong
       API_GATEWAY_STATUS_PORT: '8001'
       EDGEX_GROUP: '2001'

--- a/taf/docker-compose-taf-arm64.yml
+++ b/taf/docker-compose-taf-arm64.yml
@@ -29,7 +29,7 @@ networks:
     driver: bridge
 services:
   app-service-functional-tests:
-    container_name: app-service-functional-tests
+    container_name: app-functional-tests
     depends_on:
     - consul
     - data
@@ -50,10 +50,10 @@ services:
       EDGEX_PROFILE: functional-tests
       EDGEX_SECURITY_SECRET_STORE: "false"
       REGISTRY_HOST: edgex-core-consul
-      SERVICE_HOST: app-service-functional-tests
+      SERVICE_HOST: app-functional-tests
       SERVICE_PORT: 48105
       TRIGGER_EDGEXMESSAGEBUS_SUBSCRIBEHOST_HOST: edgex-core-data
-    hostname: app-service-functional-tests
+    hostname: app-functional-tests
     image: nexus3.edgexfoundry.org:10004/docker-app-service-configurable-arm64:master
     networks:
       edgex-network: {}
@@ -64,46 +64,9 @@ services:
     - no-new-privileges:true
     user: 2002:2001
   app-service-http-export:
-    container_name: app-service-http-export
-    depends_on:
-    - consul
-    - data
-    environment:
-      CLIENTS_COMMAND_HOST: edgex-core-command
-      CLIENTS_COREDATA_HOST: edgex-core-data
-      CLIENTS_DATA_HOST: edgex-core-data
-      CLIENTS_EDGEX-CORE-COMMAND_HOST: edgex-core-command
-      CLIENTS_EDGEX-CORE-DATA_HOST: edgex-core-data
-      CLIENTS_EDGEX-CORE-METADATA_HOST: edgex-core-metadata
-      CLIENTS_EDGEX-SUPPORT-NOTIFICATIONS_HOST: edgex-support-notifications
-      CLIENTS_EDGEX-SUPPORT-SCHEDULER_HOST: edgex-support-scheduler
-      CLIENTS_METADATA_HOST: edgex-core-metadata
-      CLIENTS_NOTIFICATIONS_HOST: edgex-support-notifications
-      CLIENTS_SCHEDULER_HOST: edgex-support-scheduler
-      DATABASES_PRIMARY_HOST: edgex-redis
-      DATABASE_HOST: edgex-redis
-      EDGEX_PROFILE: http-export
-      EDGEX_SECURITY_SECRET_STORE: "false"
-      REGISTRY_HOST: edgex-core-consul
-      SERVICE_HOST: app-service-http-export
-      SERVICE_PORT: 48101
-      TRIGGER_EDGEXMESSAGEBUS_SUBSCRIBEHOST_HOST: edgex-core-data
-      WRITABLE_LOGLEVEL: INFO
-      WRITABLE_PIPELINE_FUNCTIONS_HTTPEXPORT_PARAMETERS_URL: http://EXPORT_HOST_PLACE_HOLDER:7770
-    hostname: app-service-http-export
-    image: nexus3.edgexfoundry.org:10004/docker-app-service-configurable-arm64:master
-    networks:
-      edgex-network: {}
-    ports:
-    - 127.0.0.1:48101:48101/tcp
-    read_only: true
-    security_opt:
-    - no-new-privileges:true
-    user: 2002:2001
-  app-service-http-export-secrets:
     command: /app-service-configurable -cp=consul.http://edgex-core-consul:8500 --registry
       --confdir=/res
-    container_name: app-service-http-export-secrets
+    container_name: app-http-export
     depends_on:
     - consul
     - data
@@ -132,11 +95,9 @@ services:
       PROXY_SETUP_HOST: edgex-proxy-setup
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PATH: /v1/secret/edgex/app-service-http-export-secrets/
       SECRETSTORE_PORT: '8200'
-      SECRETSTORE_TOKENFILE: /tmp/edgex/secrets/app-service-http-export-secrets/secrets-token.json
-      SERVICE_HOST: app-service-http-export-secrets
-      SERVICE_PORT: 48102
+      SERVICE_HOST: app-http-export
+      SERVICE_PORT: 48101
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
       STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
       STAGEGATE_DATABASE_HOST: edgex-redis
@@ -154,100 +115,24 @@ services:
       STAGEGATE_WAITFOR_TIMEOUT: 60s
       TRIGGER_EDGEXMESSAGEBUS_SUBSCRIBEHOST_HOST: edgex-core-data
       WRITABLE_LOGLEVEL: INFO
-      WRITABLE_PIPELINE_FUNCTIONS_HTTPEXPORT_PARAMETERS_HEADERNAME: ''
-      WRITABLE_PIPELINE_FUNCTIONS_HTTPEXPORT_PARAMETERS_SECRETNAME: ''
-      WRITABLE_PIPELINE_FUNCTIONS_HTTPEXPORT_PARAMETERS_SECRETPATH: ''
       WRITABLE_PIPELINE_FUNCTIONS_HTTPEXPORT_PARAMETERS_URL: http://EXPORT_HOST_PLACE_HOLDER:7770
-    hostname: app-service-http-export-secrets
+    hostname: app-http-export
     image: nexus3.edgexfoundry.org:10004/docker-app-service-configurable-arm64:master
     networks:
       edgex-network: {}
     ports:
-    - 127.0.0.1:48102:48102/tcp
+    - 127.0.0.1:48101:48101/tcp
     read_only: true
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
     volumes:
     - edgex-init:/edgex-init:ro,z
-    - /tmp/edgex/secrets/app-service-http-export-secrets:/tmp/edgex/secrets/app-service-http-export-secrets:ro,z
+    - /tmp/edgex/secrets/app-http-export:/tmp/edgex/secrets/app-http-export:ro,z
   app-service-mqtt-export:
-    container_name: app-service-mqtt-export
-    depends_on:
-    - consul
-    - data
-    environment:
-      CLIENTS_COMMAND_HOST: edgex-core-command
-      CLIENTS_COREDATA_HOST: edgex-core-data
-      CLIENTS_DATA_HOST: edgex-core-data
-      CLIENTS_EDGEX-CORE-COMMAND_HOST: edgex-core-command
-      CLIENTS_EDGEX-CORE-DATA_HOST: edgex-core-data
-      CLIENTS_EDGEX-CORE-METADATA_HOST: edgex-core-metadata
-      CLIENTS_EDGEX-SUPPORT-NOTIFICATIONS_HOST: edgex-support-notifications
-      CLIENTS_EDGEX-SUPPORT-SCHEDULER_HOST: edgex-support-scheduler
-      CLIENTS_METADATA_HOST: edgex-core-metadata
-      CLIENTS_NOTIFICATIONS_HOST: edgex-support-notifications
-      CLIENTS_SCHEDULER_HOST: edgex-support-scheduler
-      DATABASES_PRIMARY_HOST: edgex-redis
-      DATABASE_HOST: edgex-redis
-      EDGEX_PROFILE: mqtt-export
-      EDGEX_SECURITY_SECRET_STORE: "false"
-      REGISTRY_HOST: edgex-core-consul
-      SERVICE_HOST: app-service-mqtt-export
-      SERVICE_PORT: 48103
-      TRIGGER_EDGEXMESSAGEBUS_SUBSCRIBEHOST_HOST: edgex-core-data
-      WRITABLE_LOGLEVEL: INFO
-      WRITABLE_PIPELINE_FUNCTIONS_MQTTEXPORT_PARAMETERS_BROKERADDRESS: tcp://MQTT_BROKER_ADDRESS_PLACE_HOLDER:1883
-      WRITABLE_PIPELINE_FUNCTIONS_MQTTEXPORT_PARAMETERS_TOPIC: edgex-events
-    hostname: app-service-mqtt-export
-    image: nexus3.edgexfoundry.org:10004/docker-app-service-configurable-arm64:master
-    networks:
-      edgex-network: {}
-    ports:
-    - 127.0.0.1:48103:48103/tcp
-    read_only: true
-    security_opt:
-    - no-new-privileges:true
-    user: 2002:2001
-  app-service-rules:
-    container_name: edgex-app-service-configurable-rules
-    depends_on:
-    - consul
-    - data
-    environment:
-      CLIENTS_COMMAND_HOST: edgex-core-command
-      CLIENTS_COREDATA_HOST: edgex-core-data
-      CLIENTS_DATA_HOST: edgex-core-data
-      CLIENTS_EDGEX-CORE-COMMAND_HOST: edgex-core-command
-      CLIENTS_EDGEX-CORE-DATA_HOST: edgex-core-data
-      CLIENTS_EDGEX-CORE-METADATA_HOST: edgex-core-metadata
-      CLIENTS_EDGEX-SUPPORT-NOTIFICATIONS_HOST: edgex-support-notifications
-      CLIENTS_EDGEX-SUPPORT-SCHEDULER_HOST: edgex-support-scheduler
-      CLIENTS_METADATA_HOST: edgex-core-metadata
-      CLIENTS_NOTIFICATIONS_HOST: edgex-support-notifications
-      CLIENTS_SCHEDULER_HOST: edgex-support-scheduler
-      DATABASES_PRIMARY_HOST: edgex-redis
-      EDGEX_PROFILE: rules-engine
-      EDGEX_SECURITY_SECRET_STORE: "false"
-      REGISTRY_HOST: edgex-core-consul
-      SERVICE_HOST: edgex-app-service-configurable-rules
-      SERVICE_PORT: 48100
-      TRIGGER_EDGEXMESSAGEBUS_SUBSCRIBEHOST_HOST: edgex-core-data
-      TRIGGER_PUBLISHTOPIC: events
-    hostname: edgex-app-service-configurable-rules
-    image: nexus3.edgexfoundry.org:10004/docker-app-service-configurable-arm64:master
-    networks:
-      edgex-network: {}
-    ports:
-    - 127.0.0.1:48100:48100/tcp
-    read_only: true
-    security_opt:
-    - no-new-privileges:true
-    user: 2002:2001
-  appservice-mqtt-export-secrets:
     command: /app-service-configurable -cp=consul.http://edgex-core-consul:8500 --registry
       --confdir=/res
-    container_name: app-service-mqtt-export-secrets
+    container_name: app-mqtt-export
     depends_on:
     - consul
     - data
@@ -276,11 +161,9 @@ services:
       PROXY_SETUP_HOST: edgex-proxy-setup
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PATH: /v1/secret/edgex/app-service-mqtt-export-secrets/
       SECRETSTORE_PORT: '8200'
-      SECRETSTORE_TOKENFILE: /tmp/edgex/secrets/app-service-mqtt-export-secrets/secrets-token.json
-      SERVICE_HOST: app-service-mqtt-export-secrets
-      SERVICE_PORT: 48104
+      SERVICE_HOST: app-mqtt-export
+      SERVICE_PORT: 48103
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
       STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
       STAGEGATE_DATABASE_HOST: edgex-redis
@@ -303,19 +186,84 @@ services:
       WRITABLE_PIPELINE_FUNCTIONS_MQTTEXPORT_PARAMETERS_AUTHMODE: usernamepassword
       WRITABLE_PIPELINE_FUNCTIONS_MQTTEXPORT_PARAMETERS_BROKERADDRESS: tcp://MQTT_BROKER_ADDRESS_PLACE_HOLDER:1883
       WRITABLE_PIPELINE_FUNCTIONS_MQTTEXPORT_PARAMETERS_TOPIC: edgex-events
-    hostname: app-service-mqtt-export-secrets
+    hostname: app-mqtt-export
     image: nexus3.edgexfoundry.org:10004/docker-app-service-configurable-arm64:master
     networks:
       edgex-network: {}
     ports:
-    - 127.0.0.1:48104:48104/tcp
+    - 127.0.0.1:48103:48103/tcp
     read_only: true
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
     volumes:
     - edgex-init:/edgex-init:ro,z
-    - /tmp/edgex/secrets/app-service-mqtt-export-secrets:/tmp/edgex/secrets/app-service-mqtt-export-secrets:ro,z
+    - /tmp/edgex/secrets/app-mqtt-export-secrets:/tmp/edgex/secrets/app-mqtt-export-secrets:ro,z
+  app-service-rules:
+    command: /app-service-configurable -cp=consul.http://edgex-core-consul:8500 --registry
+      --confdir=/res
+    container_name: edgex-app-service-configurable-rules
+    depends_on:
+    - consul
+    - data
+    - security-bootstrapper
+    entrypoint:
+    - /edgex-init/ready_to_run_wait_install.sh
+    environment:
+      API_GATEWAY_HOST: kong
+      API_GATEWAY_STATUS_PORT: '8001'
+      CLIENTS_COMMAND_HOST: edgex-core-command
+      CLIENTS_COREDATA_HOST: edgex-core-data
+      CLIENTS_DATA_HOST: edgex-core-data
+      CLIENTS_EDGEX-CORE-COMMAND_HOST: edgex-core-command
+      CLIENTS_EDGEX-CORE-DATA_HOST: edgex-core-data
+      CLIENTS_EDGEX-CORE-METADATA_HOST: edgex-core-metadata
+      CLIENTS_EDGEX-SUPPORT-NOTIFICATIONS_HOST: edgex-support-notifications
+      CLIENTS_EDGEX-SUPPORT-SCHEDULER_HOST: edgex-support-scheduler
+      CLIENTS_METADATA_HOST: edgex-core-metadata
+      CLIENTS_NOTIFICATIONS_HOST: edgex-support-notifications
+      CLIENTS_SCHEDULER_HOST: edgex-support-scheduler
+      DATABASES_PRIMARY_HOST: edgex-redis
+      EDGEX_PROFILE: rules-engine
+      EDGEX_SECURITY_SECRET_STORE: "true"
+      ENABLE_REGISTRY_ACL: "true"
+      PROXY_SETUP_HOST: edgex-proxy-setup
+      REGISTRY_HOST: edgex-core-consul
+      SECRETSTORE_HOST: edgex-vault
+      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_TOKENFILE: /tmp/edgex/secrets/app-rules-engine/secrets-token.json
+      SERVICE_HOST: edgex-app-service-configurable-rules
+      SERVICE_PORT: 48100
+      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_DATABASE_HOST: edgex-redis
+      STAGEGATE_DATABASE_PORT: '6379'
+      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_KONGDB_HOST: kong-db
+      STAGEGATE_KONGDB_PORT: '5432'
+      STAGEGATE_KONGDB_READYPORT: '54325'
+      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_REGISTRY_HOST: edgex-core-consul
+      STAGEGATE_REGISTRY_PORT: '8500'
+      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_SECRETSTORESETUP_HOST: edgex-secretstore-setup
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_WAITFOR_TIMEOUT: 60s
+      TRIGGER_EDGEXMESSAGEBUS_SUBSCRIBEHOST_HOST: edgex-core-data
+      TRIGGER_PUBLISHTOPIC: events
+    hostname: edgex-app-service-configurable-rules
+    image: nexus3.edgexfoundry.org:10004/docker-app-service-configurable-arm64:master
+    networks:
+      edgex-network: {}
+    ports:
+    - 127.0.0.1:48100:48100/tcp
+    read_only: true
+    security_opt:
+    - no-new-privileges:true
+    user: 2002:2001
+    volumes:
+    - edgex-init:/edgex-init:ro,z
+    - /tmp/edgex/secrets/app-rules-engine:/tmp/edgex/secrets/app-rules-engine:ro,z
   command:
     command: /core-command -cp=consul.http://edgex-core-consul:8500 --registry --confdir=/res
     container_name: edgex-core-command
@@ -386,6 +334,7 @@ services:
     entrypoint:
     - /edgex-init/consul_wait_install.sh
     environment:
+      ADD_REGISTRY_ACL_ROLES: app-http-export,app-mqtt-export
       API_GATEWAY_HOST: kong
       API_GATEWAY_STATUS_PORT: '8001'
       EDGEX_SECURITY_SECRET_STORE: "true"
@@ -424,8 +373,8 @@ services:
     - consul-config:/consul/config:z
     - consul-data:/consul/data:z
     - edgex-init:/edgex-init:ro,z
-    - /tmp/edgex/secrets:/tmp/edgex/secrets:z
     - consul-acl-token:/tmp/edgex/secrets/consul-acl-token:z
+    - /tmp/edgex/secrets/edgex-consul:/tmp/edgex/secrets/edgex-consul:ro,z
   data:
     command: /core-data -cp=consul.http://edgex-core-consul:8500 --registry --confdir=/res
     container_name: edgex-core-data
@@ -1006,7 +955,7 @@ services:
       EDGEX_PROFILE: mqtt-export
       EDGEX_SECURITY_SECRET_STORE: "false"
       REGISTRY_HOST: edgex-core-consul
-      SERVICE_HOST: app-service-mqtt-export
+      SERVICE_HOST: app-mqtt-export
       SERVICE_PORT: 48106
       TRIGGER_EDGEXMESSAGEBUS_SUBSCRIBEHOST_HOST: edgex-core-data
       WRITABLE_LOGLEVEL: DEBUG
@@ -1093,7 +1042,7 @@ services:
     - security-bootstrapper
     - vault
     environment:
-      ADD_SECRETSTORE_TOKENS: app-service-http-export-secrets,app-service-mqtt-export-secrets
+      ADD_SECRETSTORE_TOKENS: app-http-export,app-mqtt-export
       API_GATEWAY_HOST: kong
       API_GATEWAY_STATUS_PORT: '8001'
       EDGEX_GROUP: '2001'
@@ -1167,6 +1116,7 @@ services:
     volumes:
     - edgex-init:/edgex-init:z
   system:
+    command: /sys-mgmt-agent -cp=consul.http://edgex-core-consul:8500 --registry --confdir=/res
     container_name: edgex-sys-mgmt-agent
     depends_on:
     - command
@@ -1175,7 +1125,12 @@ services:
     - metadata
     - notifications
     - scheduler
+    - security-bootstrapper
+    entrypoint:
+    - /edgex-init/ready_to_run_wait_install.sh
     environment:
+      API_GATEWAY_HOST: kong
+      API_GATEWAY_STATUS_PORT: '8001'
       CLIENTS_COMMAND_HOST: edgex-core-command
       CLIENTS_COREDATA_HOST: edgex-core-data
       CLIENTS_DATA_HOST: edgex-core-data
@@ -1188,11 +1143,31 @@ services:
       CLIENTS_NOTIFICATIONS_HOST: edgex-support-notifications
       CLIENTS_SCHEDULER_HOST: edgex-support-scheduler
       DATABASES_PRIMARY_HOST: edgex-redis
-      EDGEX_SECURITY_SECRET_STORE: "false"
+      EDGEX_SECURITY_SECRET_STORE: "true"
+      ENABLE_REGISTRY_ACL: "true"
       EXECUTORPATH: /sys-mgmt-executor
       METRICSMECHANISM: executor
+      PROXY_SETUP_HOST: edgex-proxy-setup
       REGISTRY_HOST: edgex-core-consul
+      SECRETSTORE_HOST: edgex-vault
+      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_TOKENFILE: /tmp/edgex/secrets/edgex-sys-mgmt-agent/secrets-token.json
       SERVICE_HOST: edgex-sys-mgmt-agent
+      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_DATABASE_HOST: edgex-redis
+      STAGEGATE_DATABASE_PORT: '6379'
+      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_KONGDB_HOST: kong-db
+      STAGEGATE_KONGDB_PORT: '5432'
+      STAGEGATE_KONGDB_READYPORT: '54325'
+      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_REGISTRY_HOST: edgex-core-consul
+      STAGEGATE_REGISTRY_PORT: '8500'
+      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_SECRETSTORESETUP_HOST: edgex-secretstore-setup
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-sys-mgmt-agent
     image: nexus3.edgexfoundry.org:10004/docker-sys-mgmt-agent-go-arm64:master
     networks:
@@ -1204,6 +1179,8 @@ services:
     - no-new-privileges:true
     user: root:root
     volumes:
+    - edgex-init:/edgex-init:ro,z
+    - /tmp/edgex/secrets/edgex-sys-mgmt-agent:/tmp/edgex/secrets/edgex-sys-mgmt-agent:ro,z
     - /var/run/docker.sock:/var/run/docker.sock:z
   vault:
     cap_add:

--- a/taf/docker-compose-taf-no-secty-arm64.yml
+++ b/taf/docker-compose-taf-no-secty-arm64.yml
@@ -518,8 +518,9 @@ services:
       DATABASE_HOST: edgex-redis
       EDGEX_PROFILE: mqtt-export
       EDGEX_SECURITY_SECRET_STORE: "false"
+      EDGEX_SERVICE_KEY: scalability-test-mqtt-export
       REGISTRY_HOST: edgex-core-consul
-      SERVICE_HOST: app-mqtt-export
+      SERVICE_HOST: scalability-test-mqtt-export
       SERVICE_PORT: 48106
       TRIGGER_EDGEXMESSAGEBUS_SUBSCRIBEHOST_HOST: edgex-core-data
       WRITABLE_LOGLEVEL: DEBUG

--- a/taf/docker-compose-taf-no-secty-arm64.yml
+++ b/taf/docker-compose-taf-no-secty-arm64.yml
@@ -29,7 +29,7 @@ networks:
     driver: bridge
 services:
   app-service-functional-tests:
-    container_name: app-service-functional-tests
+    container_name: app-functional-tests
     depends_on:
     - consul
     - data
@@ -50,10 +50,10 @@ services:
       EDGEX_PROFILE: functional-tests
       EDGEX_SECURITY_SECRET_STORE: "false"
       REGISTRY_HOST: edgex-core-consul
-      SERVICE_HOST: app-service-functional-tests
+      SERVICE_HOST: app-functional-tests
       SERVICE_PORT: 48105
       TRIGGER_EDGEXMESSAGEBUS_SUBSCRIBEHOST_HOST: edgex-core-data
-    hostname: app-service-functional-tests
+    hostname: app-functional-tests
     image: nexus3.edgexfoundry.org:10004/docker-app-service-configurable-arm64:master
     networks:
       edgex-network: {}
@@ -64,7 +64,7 @@ services:
     - no-new-privileges:true
     user: 2002:2001
   app-service-http-export:
-    container_name: app-service-http-export
+    container_name: app-http-export
     depends_on:
     - consul
     - data
@@ -85,12 +85,12 @@ services:
       EDGEX_PROFILE: http-export
       EDGEX_SECURITY_SECRET_STORE: "false"
       REGISTRY_HOST: edgex-core-consul
-      SERVICE_HOST: app-service-http-export
+      SERVICE_HOST: app-http-export
       SERVICE_PORT: 48101
       TRIGGER_EDGEXMESSAGEBUS_SUBSCRIBEHOST_HOST: edgex-core-data
       WRITABLE_LOGLEVEL: INFO
       WRITABLE_PIPELINE_FUNCTIONS_HTTPEXPORT_PARAMETERS_URL: http://EXPORT_HOST_PLACE_HOLDER:7770
-    hostname: app-service-http-export
+    hostname: app-http-export
     image: nexus3.edgexfoundry.org:10004/docker-app-service-configurable-arm64:master
     networks:
       edgex-network: {}
@@ -101,7 +101,7 @@ services:
     - no-new-privileges:true
     user: 2002:2001
   app-service-mqtt-export:
-    container_name: app-service-mqtt-export
+    container_name: app-mqtt-export
     depends_on:
     - consul
     - data
@@ -122,13 +122,13 @@ services:
       EDGEX_PROFILE: mqtt-export
       EDGEX_SECURITY_SECRET_STORE: "false"
       REGISTRY_HOST: edgex-core-consul
-      SERVICE_HOST: app-service-mqtt-export
+      SERVICE_HOST: app-mqtt-export
       SERVICE_PORT: 48103
       TRIGGER_EDGEXMESSAGEBUS_SUBSCRIBEHOST_HOST: edgex-core-data
       WRITABLE_LOGLEVEL: INFO
       WRITABLE_PIPELINE_FUNCTIONS_MQTTEXPORT_PARAMETERS_BROKERADDRESS: tcp://MQTT_BROKER_ADDRESS_PLACE_HOLDER:1883
       WRITABLE_PIPELINE_FUNCTIONS_MQTTEXPORT_PARAMETERS_TOPIC: edgex-events
-    hostname: app-service-mqtt-export
+    hostname: app-mqtt-export
     image: nexus3.edgexfoundry.org:10004/docker-app-service-configurable-arm64:master
     networks:
       edgex-network: {}
@@ -519,7 +519,7 @@ services:
       EDGEX_PROFILE: mqtt-export
       EDGEX_SECURITY_SECRET_STORE: "false"
       REGISTRY_HOST: edgex-core-consul
-      SERVICE_HOST: app-service-mqtt-export
+      SERVICE_HOST: app-mqtt-export
       SERVICE_PORT: 48106
       TRIGGER_EDGEXMESSAGEBUS_SUBSCRIBEHOST_HOST: edgex-core-data
       WRITABLE_LOGLEVEL: DEBUG

--- a/taf/docker-compose-taf-no-secty.yml
+++ b/taf/docker-compose-taf-no-secty.yml
@@ -518,8 +518,9 @@ services:
       DATABASE_HOST: edgex-redis
       EDGEX_PROFILE: mqtt-export
       EDGEX_SECURITY_SECRET_STORE: "false"
+      EDGEX_SERVICE_KEY: scalability-test-mqtt-export
       REGISTRY_HOST: edgex-core-consul
-      SERVICE_HOST: app-mqtt-export
+      SERVICE_HOST: scalability-test-mqtt-export
       SERVICE_PORT: 48106
       TRIGGER_EDGEXMESSAGEBUS_SUBSCRIBEHOST_HOST: edgex-core-data
       WRITABLE_LOGLEVEL: DEBUG

--- a/taf/docker-compose-taf-no-secty.yml
+++ b/taf/docker-compose-taf-no-secty.yml
@@ -29,7 +29,7 @@ networks:
     driver: bridge
 services:
   app-service-functional-tests:
-    container_name: app-service-functional-tests
+    container_name: app-functional-tests
     depends_on:
     - consul
     - data
@@ -50,10 +50,10 @@ services:
       EDGEX_PROFILE: functional-tests
       EDGEX_SECURITY_SECRET_STORE: "false"
       REGISTRY_HOST: edgex-core-consul
-      SERVICE_HOST: app-service-functional-tests
+      SERVICE_HOST: app-functional-tests
       SERVICE_PORT: 48105
       TRIGGER_EDGEXMESSAGEBUS_SUBSCRIBEHOST_HOST: edgex-core-data
-    hostname: app-service-functional-tests
+    hostname: app-functional-tests
     image: nexus3.edgexfoundry.org:10004/docker-app-service-configurable:master
     networks:
       edgex-network: {}
@@ -64,7 +64,7 @@ services:
     - no-new-privileges:true
     user: 2002:2001
   app-service-http-export:
-    container_name: app-service-http-export
+    container_name: app-http-export
     depends_on:
     - consul
     - data
@@ -85,12 +85,12 @@ services:
       EDGEX_PROFILE: http-export
       EDGEX_SECURITY_SECRET_STORE: "false"
       REGISTRY_HOST: edgex-core-consul
-      SERVICE_HOST: app-service-http-export
+      SERVICE_HOST: app-http-export
       SERVICE_PORT: 48101
       TRIGGER_EDGEXMESSAGEBUS_SUBSCRIBEHOST_HOST: edgex-core-data
       WRITABLE_LOGLEVEL: INFO
       WRITABLE_PIPELINE_FUNCTIONS_HTTPEXPORT_PARAMETERS_URL: http://EXPORT_HOST_PLACE_HOLDER:7770
-    hostname: app-service-http-export
+    hostname: app-http-export
     image: nexus3.edgexfoundry.org:10004/docker-app-service-configurable:master
     networks:
       edgex-network: {}
@@ -101,7 +101,7 @@ services:
     - no-new-privileges:true
     user: 2002:2001
   app-service-mqtt-export:
-    container_name: app-service-mqtt-export
+    container_name: app-mqtt-export
     depends_on:
     - consul
     - data
@@ -122,13 +122,13 @@ services:
       EDGEX_PROFILE: mqtt-export
       EDGEX_SECURITY_SECRET_STORE: "false"
       REGISTRY_HOST: edgex-core-consul
-      SERVICE_HOST: app-service-mqtt-export
+      SERVICE_HOST: app-mqtt-export
       SERVICE_PORT: 48103
       TRIGGER_EDGEXMESSAGEBUS_SUBSCRIBEHOST_HOST: edgex-core-data
       WRITABLE_LOGLEVEL: INFO
       WRITABLE_PIPELINE_FUNCTIONS_MQTTEXPORT_PARAMETERS_BROKERADDRESS: tcp://MQTT_BROKER_ADDRESS_PLACE_HOLDER:1883
       WRITABLE_PIPELINE_FUNCTIONS_MQTTEXPORT_PARAMETERS_TOPIC: edgex-events
-    hostname: app-service-mqtt-export
+    hostname: app-mqtt-export
     image: nexus3.edgexfoundry.org:10004/docker-app-service-configurable:master
     networks:
       edgex-network: {}
@@ -519,7 +519,7 @@ services:
       EDGEX_PROFILE: mqtt-export
       EDGEX_SECURITY_SECRET_STORE: "false"
       REGISTRY_HOST: edgex-core-consul
-      SERVICE_HOST: app-service-mqtt-export
+      SERVICE_HOST: app-mqtt-export
       SERVICE_PORT: 48106
       TRIGGER_EDGEXMESSAGEBUS_SUBSCRIBEHOST_HOST: edgex-core-data
       WRITABLE_LOGLEVEL: DEBUG

--- a/taf/docker-compose-taf-perf-arm64.yml
+++ b/taf/docker-compose-taf-perf-arm64.yml
@@ -29,7 +29,7 @@ networks:
     driver: bridge
 services:
   app-service-mqtt-export:
-    container_name: app-service-mqtt-export
+    container_name: app-mqtt-export
     depends_on:
     - consul
     - data
@@ -50,13 +50,13 @@ services:
       EDGEX_PROFILE: mqtt-export
       EDGEX_SECURITY_SECRET_STORE: "false"
       REGISTRY_HOST: edgex-core-consul
-      SERVICE_HOST: app-service-mqtt-export
+      SERVICE_HOST: app-mqtt-export
       SERVICE_PORT: 48103
       TRIGGER_EDGEXMESSAGEBUS_SUBSCRIBEHOST_HOST: edgex-core-data
       WRITABLE_LOGLEVEL: INFO
       WRITABLE_PIPELINE_FUNCTIONS_MQTTEXPORT_PARAMETERS_BROKERADDRESS: tcp://MQTT_BROKER_ADDRESS_PLACE_HOLDER:1883
       WRITABLE_PIPELINE_FUNCTIONS_MQTTEXPORT_PARAMETERS_TOPIC: edgex-events
-    hostname: app-service-mqtt-export
+    hostname: app-mqtt-export
     image: nexus3.edgexfoundry.org:10004/docker-app-service-configurable-arm64:master
     networks:
       edgex-network: {}
@@ -67,11 +67,18 @@ services:
     - no-new-privileges:true
     user: 2002:2001
   app-service-rules:
+    command: /app-service-configurable -cp=consul.http://edgex-core-consul:8500 --registry
+      --confdir=/res
     container_name: edgex-app-service-configurable-rules
     depends_on:
     - consul
     - data
+    - security-bootstrapper
+    entrypoint:
+    - /edgex-init/ready_to_run_wait_install.sh
     environment:
+      API_GATEWAY_HOST: kong
+      API_GATEWAY_STATUS_PORT: '8001'
       CLIENTS_COMMAND_HOST: edgex-core-command
       CLIENTS_COREDATA_HOST: edgex-core-data
       CLIENTS_DATA_HOST: edgex-core-data
@@ -85,10 +92,30 @@ services:
       CLIENTS_SCHEDULER_HOST: edgex-support-scheduler
       DATABASES_PRIMARY_HOST: edgex-redis
       EDGEX_PROFILE: rules-engine
-      EDGEX_SECURITY_SECRET_STORE: "false"
+      EDGEX_SECURITY_SECRET_STORE: "true"
+      ENABLE_REGISTRY_ACL: "true"
+      PROXY_SETUP_HOST: edgex-proxy-setup
       REGISTRY_HOST: edgex-core-consul
+      SECRETSTORE_HOST: edgex-vault
+      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_TOKENFILE: /tmp/edgex/secrets/app-rules-engine/secrets-token.json
       SERVICE_HOST: edgex-app-service-configurable-rules
       SERVICE_PORT: 48100
+      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_DATABASE_HOST: edgex-redis
+      STAGEGATE_DATABASE_PORT: '6379'
+      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_KONGDB_HOST: kong-db
+      STAGEGATE_KONGDB_PORT: '5432'
+      STAGEGATE_KONGDB_READYPORT: '54325'
+      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_REGISTRY_HOST: edgex-core-consul
+      STAGEGATE_REGISTRY_PORT: '8500'
+      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_SECRETSTORESETUP_HOST: edgex-secretstore-setup
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_WAITFOR_TIMEOUT: 60s
       TRIGGER_EDGEXMESSAGEBUS_SUBSCRIBEHOST_HOST: edgex-core-data
       TRIGGER_PUBLISHTOPIC: events
     hostname: edgex-app-service-configurable-rules
@@ -101,6 +128,9 @@ services:
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
+    volumes:
+    - edgex-init:/edgex-init:ro,z
+    - /tmp/edgex/secrets/app-rules-engine:/tmp/edgex/secrets/app-rules-engine:ro,z
   command:
     command: /core-command -cp=consul.http://edgex-core-consul:8500 --registry --confdir=/res
     container_name: edgex-core-command
@@ -209,8 +239,8 @@ services:
     - consul-config:/consul/config:z
     - consul-data:/consul/data:z
     - edgex-init:/edgex-init:ro,z
-    - /tmp/edgex/secrets:/tmp/edgex/secrets:z
     - consul-acl-token:/tmp/edgex/secrets/consul-acl-token:z
+    - /tmp/edgex/secrets/edgex-consul:/tmp/edgex/secrets/edgex-consul:ro,z
   data:
     command: /core-data -cp=consul.http://edgex-core-consul:8500 --registry --confdir=/res
     container_name: edgex-core-data
@@ -862,6 +892,7 @@ services:
     volumes:
     - edgex-init:/edgex-init:z
   system:
+    command: /sys-mgmt-agent -cp=consul.http://edgex-core-consul:8500 --registry --confdir=/res
     container_name: edgex-sys-mgmt-agent
     depends_on:
     - command
@@ -870,7 +901,12 @@ services:
     - metadata
     - notifications
     - scheduler
+    - security-bootstrapper
+    entrypoint:
+    - /edgex-init/ready_to_run_wait_install.sh
     environment:
+      API_GATEWAY_HOST: kong
+      API_GATEWAY_STATUS_PORT: '8001'
       CLIENTS_COMMAND_HOST: edgex-core-command
       CLIENTS_COREDATA_HOST: edgex-core-data
       CLIENTS_DATA_HOST: edgex-core-data
@@ -883,11 +919,31 @@ services:
       CLIENTS_NOTIFICATIONS_HOST: edgex-support-notifications
       CLIENTS_SCHEDULER_HOST: edgex-support-scheduler
       DATABASES_PRIMARY_HOST: edgex-redis
-      EDGEX_SECURITY_SECRET_STORE: "false"
+      EDGEX_SECURITY_SECRET_STORE: "true"
+      ENABLE_REGISTRY_ACL: "true"
       EXECUTORPATH: /sys-mgmt-executor
       METRICSMECHANISM: executor
+      PROXY_SETUP_HOST: edgex-proxy-setup
       REGISTRY_HOST: edgex-core-consul
+      SECRETSTORE_HOST: edgex-vault
+      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_TOKENFILE: /tmp/edgex/secrets/edgex-sys-mgmt-agent/secrets-token.json
       SERVICE_HOST: edgex-sys-mgmt-agent
+      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_DATABASE_HOST: edgex-redis
+      STAGEGATE_DATABASE_PORT: '6379'
+      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_KONGDB_HOST: kong-db
+      STAGEGATE_KONGDB_PORT: '5432'
+      STAGEGATE_KONGDB_READYPORT: '54325'
+      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_REGISTRY_HOST: edgex-core-consul
+      STAGEGATE_REGISTRY_PORT: '8500'
+      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_SECRETSTORESETUP_HOST: edgex-secretstore-setup
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-sys-mgmt-agent
     image: nexus3.edgexfoundry.org:10004/docker-sys-mgmt-agent-go-arm64:master
     networks:
@@ -899,6 +955,8 @@ services:
     - no-new-privileges:true
     user: root:root
     volumes:
+    - edgex-init:/edgex-init:ro,z
+    - /tmp/edgex/secrets/edgex-sys-mgmt-agent:/tmp/edgex/secrets/edgex-sys-mgmt-agent:ro,z
     - /var/run/docker.sock:/var/run/docker.sock:z
   vault:
     cap_add:

--- a/taf/docker-compose-taf-perf-arm64.yml
+++ b/taf/docker-compose-taf-perf-arm64.yml
@@ -233,7 +233,7 @@ services:
     entrypoint:
     - /edgex-init/consul_wait_install.sh
     environment:
-      ADD_REGISTRY_ACL_ROLES: ''
+      ADD_REGISTRY_ACL_ROLES: app-http-export,app-mqtt-export,app-functional-tests
       API_GATEWAY_HOST: kong
       API_GATEWAY_STATUS_PORT: '8001'
       EDGEX_SECURITY_SECRET_STORE: "true"
@@ -852,7 +852,7 @@ services:
     - security-bootstrapper
     - vault
     environment:
-      ADD_SECRETSTORE_TOKENS: ''
+      ADD_SECRETSTORE_TOKENS: app-http-export,app-mqtt-export,app-functional-tests
       API_GATEWAY_HOST: kong
       API_GATEWAY_STATUS_PORT: '8001'
       EDGEX_GROUP: '2001'

--- a/taf/docker-compose-taf-perf-arm64.yml
+++ b/taf/docker-compose-taf-perf-arm64.yml
@@ -29,11 +29,18 @@ networks:
     driver: bridge
 services:
   app-service-mqtt-export:
+    command: /app-service-configurable -cp=consul.http://edgex-core-consul:8500 --registry
+      --confdir=/res
     container_name: app-mqtt-export
     depends_on:
     - consul
     - data
+    - security-bootstrapper
+    entrypoint:
+    - /edgex-init/ready_to_run_wait_install.sh
     environment:
+      API_GATEWAY_HOST: kong
+      API_GATEWAY_STATUS_PORT: '8001'
       CLIENTS_COMMAND_HOST: edgex-core-command
       CLIENTS_COREDATA_HOST: edgex-core-data
       CLIENTS_DATA_HOST: edgex-core-data
@@ -48,12 +55,34 @@ services:
       DATABASES_PRIMARY_HOST: edgex-redis
       DATABASE_HOST: edgex-redis
       EDGEX_PROFILE: mqtt-export
-      EDGEX_SECURITY_SECRET_STORE: "false"
+      EDGEX_SECURITY_SECRET_STORE: "true"
+      ENABLE_REGISTRY_ACL: "true"
+      PROXY_SETUP_HOST: edgex-proxy-setup
       REGISTRY_HOST: edgex-core-consul
+      SECRETSTORE_HOST: edgex-vault
+      SECRETSTORE_PORT: '8200'
       SERVICE_HOST: app-mqtt-export
       SERVICE_PORT: 48103
+      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_DATABASE_HOST: edgex-redis
+      STAGEGATE_DATABASE_PORT: '6379'
+      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_KONGDB_HOST: kong-db
+      STAGEGATE_KONGDB_PORT: '5432'
+      STAGEGATE_KONGDB_READYPORT: '54325'
+      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_REGISTRY_HOST: edgex-core-consul
+      STAGEGATE_REGISTRY_PORT: '8500'
+      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_SECRETSTORESETUP_HOST: edgex-secretstore-setup
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_WAITFOR_TIMEOUT: 60s
       TRIGGER_EDGEXMESSAGEBUS_SUBSCRIBEHOST_HOST: edgex-core-data
+      WRITABLE_INSECURESECRETS_MQTT_SECRETS_PASSWORD: PASSWORD_PLACE_HOLDER
+      WRITABLE_INSECURESECRETS_MQTT_SECRETS_USERNAME: USERNAME_PLACEH_OLDER
       WRITABLE_LOGLEVEL: INFO
+      WRITABLE_PIPELINE_FUNCTIONS_MQTTEXPORT_PARAMETERS_AUTHMODE: usernamepassword
       WRITABLE_PIPELINE_FUNCTIONS_MQTTEXPORT_PARAMETERS_BROKERADDRESS: tcp://MQTT_BROKER_ADDRESS_PLACE_HOLDER:1883
       WRITABLE_PIPELINE_FUNCTIONS_MQTTEXPORT_PARAMETERS_TOPIC: edgex-events
     hostname: app-mqtt-export
@@ -66,6 +95,9 @@ services:
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
+    volumes:
+    - edgex-init:/edgex-init:ro,z
+    - /tmp/edgex/secrets/app-mqtt-export:/tmp/edgex/secrets/app-mqtt-export:ro,z
   app-service-rules:
     command: /app-service-configurable -cp=consul.http://edgex-core-consul:8500 --registry
       --confdir=/res
@@ -201,6 +233,7 @@ services:
     entrypoint:
     - /edgex-init/consul_wait_install.sh
     environment:
+      ADD_REGISTRY_ACL_ROLES: ''
       API_GATEWAY_HOST: kong
       API_GATEWAY_STATUS_PORT: '8001'
       EDGEX_SECURITY_SECRET_STORE: "true"
@@ -819,6 +852,7 @@ services:
     - security-bootstrapper
     - vault
     environment:
+      ADD_SECRETSTORE_TOKENS: ''
       API_GATEWAY_HOST: kong
       API_GATEWAY_STATUS_PORT: '8001'
       EDGEX_GROUP: '2001'

--- a/taf/docker-compose-taf-perf-arm64.yml
+++ b/taf/docker-compose-taf-perf-arm64.yml
@@ -233,7 +233,7 @@ services:
     entrypoint:
     - /edgex-init/consul_wait_install.sh
     environment:
-      ADD_REGISTRY_ACL_ROLES: app-http-export,app-mqtt-export,app-functional-tests
+      ADD_REGISTRY_ACL_ROLES: app-http-export,app-mqtt-export,app-functional-tests,scalability-test-mqtt-export
       API_GATEWAY_HOST: kong
       API_GATEWAY_STATUS_PORT: '8001'
       EDGEX_SECURITY_SECRET_STORE: "true"
@@ -852,7 +852,7 @@ services:
     - security-bootstrapper
     - vault
     environment:
-      ADD_SECRETSTORE_TOKENS: app-http-export,app-mqtt-export,app-functional-tests
+      ADD_SECRETSTORE_TOKENS: app-http-export,app-mqtt-export,app-functional-tests,scalability-test-mqtt-export
       API_GATEWAY_HOST: kong
       API_GATEWAY_STATUS_PORT: '8001'
       EDGEX_GROUP: '2001'

--- a/taf/docker-compose-taf-perf-no-secty-arm64.yml
+++ b/taf/docker-compose-taf-perf-no-secty-arm64.yml
@@ -29,7 +29,7 @@ networks:
     driver: bridge
 services:
   app-service-mqtt-export:
-    container_name: app-service-mqtt-export
+    container_name: app-mqtt-export
     depends_on:
     - consul
     - data
@@ -50,13 +50,13 @@ services:
       EDGEX_PROFILE: mqtt-export
       EDGEX_SECURITY_SECRET_STORE: "false"
       REGISTRY_HOST: edgex-core-consul
-      SERVICE_HOST: app-service-mqtt-export
+      SERVICE_HOST: app-mqtt-export
       SERVICE_PORT: 48103
       TRIGGER_EDGEXMESSAGEBUS_SUBSCRIBEHOST_HOST: edgex-core-data
       WRITABLE_LOGLEVEL: INFO
       WRITABLE_PIPELINE_FUNCTIONS_MQTTEXPORT_PARAMETERS_BROKERADDRESS: tcp://MQTT_BROKER_ADDRESS_PLACE_HOLDER:1883
       WRITABLE_PIPELINE_FUNCTIONS_MQTTEXPORT_PARAMETERS_TOPIC: edgex-events
-    hostname: app-service-mqtt-export
+    hostname: app-mqtt-export
     image: nexus3.edgexfoundry.org:10004/docker-app-service-configurable-arm64:master
     networks:
       edgex-network: {}

--- a/taf/docker-compose-taf-perf-no-secty.yml
+++ b/taf/docker-compose-taf-perf-no-secty.yml
@@ -29,7 +29,7 @@ networks:
     driver: bridge
 services:
   app-service-mqtt-export:
-    container_name: app-service-mqtt-export
+    container_name: app-mqtt-export
     depends_on:
     - consul
     - data
@@ -50,13 +50,13 @@ services:
       EDGEX_PROFILE: mqtt-export
       EDGEX_SECURITY_SECRET_STORE: "false"
       REGISTRY_HOST: edgex-core-consul
-      SERVICE_HOST: app-service-mqtt-export
+      SERVICE_HOST: app-mqtt-export
       SERVICE_PORT: 48103
       TRIGGER_EDGEXMESSAGEBUS_SUBSCRIBEHOST_HOST: edgex-core-data
       WRITABLE_LOGLEVEL: INFO
       WRITABLE_PIPELINE_FUNCTIONS_MQTTEXPORT_PARAMETERS_BROKERADDRESS: tcp://MQTT_BROKER_ADDRESS_PLACE_HOLDER:1883
       WRITABLE_PIPELINE_FUNCTIONS_MQTTEXPORT_PARAMETERS_TOPIC: edgex-events
-    hostname: app-service-mqtt-export
+    hostname: app-mqtt-export
     image: nexus3.edgexfoundry.org:10004/docker-app-service-configurable:master
     networks:
       edgex-network: {}

--- a/taf/docker-compose-taf-perf.yml
+++ b/taf/docker-compose-taf-perf.yml
@@ -29,7 +29,7 @@ networks:
     driver: bridge
 services:
   app-service-mqtt-export:
-    container_name: app-service-mqtt-export
+    container_name: app-mqtt-export
     depends_on:
     - consul
     - data
@@ -50,13 +50,13 @@ services:
       EDGEX_PROFILE: mqtt-export
       EDGEX_SECURITY_SECRET_STORE: "false"
       REGISTRY_HOST: edgex-core-consul
-      SERVICE_HOST: app-service-mqtt-export
+      SERVICE_HOST: app-mqtt-export
       SERVICE_PORT: 48103
       TRIGGER_EDGEXMESSAGEBUS_SUBSCRIBEHOST_HOST: edgex-core-data
       WRITABLE_LOGLEVEL: INFO
       WRITABLE_PIPELINE_FUNCTIONS_MQTTEXPORT_PARAMETERS_BROKERADDRESS: tcp://MQTT_BROKER_ADDRESS_PLACE_HOLDER:1883
       WRITABLE_PIPELINE_FUNCTIONS_MQTTEXPORT_PARAMETERS_TOPIC: edgex-events
-    hostname: app-service-mqtt-export
+    hostname: app-mqtt-export
     image: nexus3.edgexfoundry.org:10004/docker-app-service-configurable:master
     networks:
       edgex-network: {}
@@ -67,11 +67,18 @@ services:
     - no-new-privileges:true
     user: 2002:2001
   app-service-rules:
+    command: /app-service-configurable -cp=consul.http://edgex-core-consul:8500 --registry
+      --confdir=/res
     container_name: edgex-app-service-configurable-rules
     depends_on:
     - consul
     - data
+    - security-bootstrapper
+    entrypoint:
+    - /edgex-init/ready_to_run_wait_install.sh
     environment:
+      API_GATEWAY_HOST: kong
+      API_GATEWAY_STATUS_PORT: '8001'
       CLIENTS_COMMAND_HOST: edgex-core-command
       CLIENTS_COREDATA_HOST: edgex-core-data
       CLIENTS_DATA_HOST: edgex-core-data
@@ -85,10 +92,30 @@ services:
       CLIENTS_SCHEDULER_HOST: edgex-support-scheduler
       DATABASES_PRIMARY_HOST: edgex-redis
       EDGEX_PROFILE: rules-engine
-      EDGEX_SECURITY_SECRET_STORE: "false"
+      EDGEX_SECURITY_SECRET_STORE: "true"
+      ENABLE_REGISTRY_ACL: "true"
+      PROXY_SETUP_HOST: edgex-proxy-setup
       REGISTRY_HOST: edgex-core-consul
+      SECRETSTORE_HOST: edgex-vault
+      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_TOKENFILE: /tmp/edgex/secrets/app-rules-engine/secrets-token.json
       SERVICE_HOST: edgex-app-service-configurable-rules
       SERVICE_PORT: 48100
+      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_DATABASE_HOST: edgex-redis
+      STAGEGATE_DATABASE_PORT: '6379'
+      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_KONGDB_HOST: kong-db
+      STAGEGATE_KONGDB_PORT: '5432'
+      STAGEGATE_KONGDB_READYPORT: '54325'
+      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_REGISTRY_HOST: edgex-core-consul
+      STAGEGATE_REGISTRY_PORT: '8500'
+      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_SECRETSTORESETUP_HOST: edgex-secretstore-setup
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_WAITFOR_TIMEOUT: 60s
       TRIGGER_EDGEXMESSAGEBUS_SUBSCRIBEHOST_HOST: edgex-core-data
       TRIGGER_PUBLISHTOPIC: events
     hostname: edgex-app-service-configurable-rules
@@ -101,6 +128,9 @@ services:
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
+    volumes:
+    - edgex-init:/edgex-init:ro,z
+    - /tmp/edgex/secrets/app-rules-engine:/tmp/edgex/secrets/app-rules-engine:ro,z
   command:
     command: /core-command -cp=consul.http://edgex-core-consul:8500 --registry --confdir=/res
     container_name: edgex-core-command
@@ -209,8 +239,8 @@ services:
     - consul-config:/consul/config:z
     - consul-data:/consul/data:z
     - edgex-init:/edgex-init:ro,z
-    - /tmp/edgex/secrets:/tmp/edgex/secrets:z
     - consul-acl-token:/tmp/edgex/secrets/consul-acl-token:z
+    - /tmp/edgex/secrets/edgex-consul:/tmp/edgex/secrets/edgex-consul:ro,z
   data:
     command: /core-data -cp=consul.http://edgex-core-consul:8500 --registry --confdir=/res
     container_name: edgex-core-data
@@ -862,6 +892,7 @@ services:
     volumes:
     - edgex-init:/edgex-init:z
   system:
+    command: /sys-mgmt-agent -cp=consul.http://edgex-core-consul:8500 --registry --confdir=/res
     container_name: edgex-sys-mgmt-agent
     depends_on:
     - command
@@ -870,7 +901,12 @@ services:
     - metadata
     - notifications
     - scheduler
+    - security-bootstrapper
+    entrypoint:
+    - /edgex-init/ready_to_run_wait_install.sh
     environment:
+      API_GATEWAY_HOST: kong
+      API_GATEWAY_STATUS_PORT: '8001'
       CLIENTS_COMMAND_HOST: edgex-core-command
       CLIENTS_COREDATA_HOST: edgex-core-data
       CLIENTS_DATA_HOST: edgex-core-data
@@ -883,11 +919,31 @@ services:
       CLIENTS_NOTIFICATIONS_HOST: edgex-support-notifications
       CLIENTS_SCHEDULER_HOST: edgex-support-scheduler
       DATABASES_PRIMARY_HOST: edgex-redis
-      EDGEX_SECURITY_SECRET_STORE: "false"
+      EDGEX_SECURITY_SECRET_STORE: "true"
+      ENABLE_REGISTRY_ACL: "true"
       EXECUTORPATH: /sys-mgmt-executor
       METRICSMECHANISM: executor
+      PROXY_SETUP_HOST: edgex-proxy-setup
       REGISTRY_HOST: edgex-core-consul
+      SECRETSTORE_HOST: edgex-vault
+      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_TOKENFILE: /tmp/edgex/secrets/edgex-sys-mgmt-agent/secrets-token.json
       SERVICE_HOST: edgex-sys-mgmt-agent
+      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_DATABASE_HOST: edgex-redis
+      STAGEGATE_DATABASE_PORT: '6379'
+      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_KONGDB_HOST: kong-db
+      STAGEGATE_KONGDB_PORT: '5432'
+      STAGEGATE_KONGDB_READYPORT: '54325'
+      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_REGISTRY_HOST: edgex-core-consul
+      STAGEGATE_REGISTRY_PORT: '8500'
+      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_SECRETSTORESETUP_HOST: edgex-secretstore-setup
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-sys-mgmt-agent
     image: nexus3.edgexfoundry.org:10004/docker-sys-mgmt-agent-go:master
     networks:
@@ -899,6 +955,8 @@ services:
     - no-new-privileges:true
     user: root:root
     volumes:
+    - edgex-init:/edgex-init:ro,z
+    - /tmp/edgex/secrets/edgex-sys-mgmt-agent:/tmp/edgex/secrets/edgex-sys-mgmt-agent:ro,z
     - /var/run/docker.sock:/var/run/docker.sock:z
   vault:
     cap_add:

--- a/taf/docker-compose-taf-perf.yml
+++ b/taf/docker-compose-taf-perf.yml
@@ -233,7 +233,7 @@ services:
     entrypoint:
     - /edgex-init/consul_wait_install.sh
     environment:
-      ADD_REGISTRY_ACL_ROLES: ''
+      ADD_REGISTRY_ACL_ROLES: app-http-export,app-mqtt-export,app-functional-tests
       API_GATEWAY_HOST: kong
       API_GATEWAY_STATUS_PORT: '8001'
       EDGEX_SECURITY_SECRET_STORE: "true"
@@ -852,7 +852,7 @@ services:
     - security-bootstrapper
     - vault
     environment:
-      ADD_SECRETSTORE_TOKENS: ''
+      ADD_SECRETSTORE_TOKENS: app-http-export,app-mqtt-export,app-functional-tests
       API_GATEWAY_HOST: kong
       API_GATEWAY_STATUS_PORT: '8001'
       EDGEX_GROUP: '2001'

--- a/taf/docker-compose-taf-perf.yml
+++ b/taf/docker-compose-taf-perf.yml
@@ -29,11 +29,18 @@ networks:
     driver: bridge
 services:
   app-service-mqtt-export:
+    command: /app-service-configurable -cp=consul.http://edgex-core-consul:8500 --registry
+      --confdir=/res
     container_name: app-mqtt-export
     depends_on:
     - consul
     - data
+    - security-bootstrapper
+    entrypoint:
+    - /edgex-init/ready_to_run_wait_install.sh
     environment:
+      API_GATEWAY_HOST: kong
+      API_GATEWAY_STATUS_PORT: '8001'
       CLIENTS_COMMAND_HOST: edgex-core-command
       CLIENTS_COREDATA_HOST: edgex-core-data
       CLIENTS_DATA_HOST: edgex-core-data
@@ -48,12 +55,34 @@ services:
       DATABASES_PRIMARY_HOST: edgex-redis
       DATABASE_HOST: edgex-redis
       EDGEX_PROFILE: mqtt-export
-      EDGEX_SECURITY_SECRET_STORE: "false"
+      EDGEX_SECURITY_SECRET_STORE: "true"
+      ENABLE_REGISTRY_ACL: "true"
+      PROXY_SETUP_HOST: edgex-proxy-setup
       REGISTRY_HOST: edgex-core-consul
+      SECRETSTORE_HOST: edgex-vault
+      SECRETSTORE_PORT: '8200'
       SERVICE_HOST: app-mqtt-export
       SERVICE_PORT: 48103
+      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_DATABASE_HOST: edgex-redis
+      STAGEGATE_DATABASE_PORT: '6379'
+      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_KONGDB_HOST: kong-db
+      STAGEGATE_KONGDB_PORT: '5432'
+      STAGEGATE_KONGDB_READYPORT: '54325'
+      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_REGISTRY_HOST: edgex-core-consul
+      STAGEGATE_REGISTRY_PORT: '8500'
+      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_SECRETSTORESETUP_HOST: edgex-secretstore-setup
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_WAITFOR_TIMEOUT: 60s
       TRIGGER_EDGEXMESSAGEBUS_SUBSCRIBEHOST_HOST: edgex-core-data
+      WRITABLE_INSECURESECRETS_MQTT_SECRETS_PASSWORD: PASSWORD_PLACE_HOLDER
+      WRITABLE_INSECURESECRETS_MQTT_SECRETS_USERNAME: USERNAME_PLACEH_OLDER
       WRITABLE_LOGLEVEL: INFO
+      WRITABLE_PIPELINE_FUNCTIONS_MQTTEXPORT_PARAMETERS_AUTHMODE: usernamepassword
       WRITABLE_PIPELINE_FUNCTIONS_MQTTEXPORT_PARAMETERS_BROKERADDRESS: tcp://MQTT_BROKER_ADDRESS_PLACE_HOLDER:1883
       WRITABLE_PIPELINE_FUNCTIONS_MQTTEXPORT_PARAMETERS_TOPIC: edgex-events
     hostname: app-mqtt-export
@@ -66,6 +95,9 @@ services:
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
+    volumes:
+    - edgex-init:/edgex-init:ro,z
+    - /tmp/edgex/secrets/app-mqtt-export:/tmp/edgex/secrets/app-mqtt-export:ro,z
   app-service-rules:
     command: /app-service-configurable -cp=consul.http://edgex-core-consul:8500 --registry
       --confdir=/res
@@ -201,6 +233,7 @@ services:
     entrypoint:
     - /edgex-init/consul_wait_install.sh
     environment:
+      ADD_REGISTRY_ACL_ROLES: ''
       API_GATEWAY_HOST: kong
       API_GATEWAY_STATUS_PORT: '8001'
       EDGEX_SECURITY_SECRET_STORE: "true"
@@ -819,6 +852,7 @@ services:
     - security-bootstrapper
     - vault
     environment:
+      ADD_SECRETSTORE_TOKENS: ''
       API_GATEWAY_HOST: kong
       API_GATEWAY_STATUS_PORT: '8001'
       EDGEX_GROUP: '2001'

--- a/taf/docker-compose-taf-perf.yml
+++ b/taf/docker-compose-taf-perf.yml
@@ -233,7 +233,7 @@ services:
     entrypoint:
     - /edgex-init/consul_wait_install.sh
     environment:
-      ADD_REGISTRY_ACL_ROLES: app-http-export,app-mqtt-export,app-functional-tests
+      ADD_REGISTRY_ACL_ROLES: app-http-export,app-mqtt-export,app-functional-tests,scalability-test-mqtt-export
       API_GATEWAY_HOST: kong
       API_GATEWAY_STATUS_PORT: '8001'
       EDGEX_SECURITY_SECRET_STORE: "true"
@@ -852,7 +852,7 @@ services:
     - security-bootstrapper
     - vault
     environment:
-      ADD_SECRETSTORE_TOKENS: app-http-export,app-mqtt-export,app-functional-tests
+      ADD_SECRETSTORE_TOKENS: app-http-export,app-mqtt-export,app-functional-tests,scalability-test-mqtt-export
       API_GATEWAY_HOST: kong
       API_GATEWAY_STATUS_PORT: '8001'
       EDGEX_GROUP: '2001'

--- a/taf/docker-compose-taf.yml
+++ b/taf/docker-compose-taf.yml
@@ -29,11 +29,18 @@ networks:
     driver: bridge
 services:
   app-service-functional-tests:
+    command: /app-service-configurable -cp=consul.http://edgex-core-consul:8500 --registry
+      --confdir=/res
     container_name: app-functional-tests
     depends_on:
     - consul
     - data
+    - security-bootstrapper
+    entrypoint:
+    - /edgex-init/ready_to_run_wait_install.sh
     environment:
+      API_GATEWAY_HOST: kong
+      API_GATEWAY_STATUS_PORT: '8001'
       CLIENTS_COMMAND_HOST: edgex-core-command
       CLIENTS_COREDATA_HOST: edgex-core-data
       CLIENTS_DATA_HOST: edgex-core-data
@@ -48,10 +55,29 @@ services:
       DATABASES_PRIMARY_HOST: edgex-redis
       DATABASE_HOST: edgex-redis
       EDGEX_PROFILE: functional-tests
-      EDGEX_SECURITY_SECRET_STORE: "false"
+      EDGEX_SECURITY_SECRET_STORE: "true"
+      ENABLE_REGISTRY_ACL: "true"
+      PROXY_SETUP_HOST: edgex-proxy-setup
       REGISTRY_HOST: edgex-core-consul
+      SECRETSTORE_HOST: edgex-vault
+      SECRETSTORE_PORT: '8200'
       SERVICE_HOST: app-functional-tests
       SERVICE_PORT: 48105
+      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_DATABASE_HOST: edgex-redis
+      STAGEGATE_DATABASE_PORT: '6379'
+      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_KONGDB_HOST: kong-db
+      STAGEGATE_KONGDB_PORT: '5432'
+      STAGEGATE_KONGDB_READYPORT: '54325'
+      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_REGISTRY_HOST: edgex-core-consul
+      STAGEGATE_REGISTRY_PORT: '8500'
+      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_SECRETSTORESETUP_HOST: edgex-secretstore-setup
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_WAITFOR_TIMEOUT: 60s
       TRIGGER_EDGEXMESSAGEBUS_SUBSCRIBEHOST_HOST: edgex-core-data
     hostname: app-functional-tests
     image: nexus3.edgexfoundry.org:10004/docker-app-service-configurable:master
@@ -63,6 +89,9 @@ services:
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
+    volumes:
+    - edgex-init:/edgex-init:ro,z
+    - /tmp/edgex/secrets/app-functional-tests:/tmp/edgex/secrets/app-functional-tests:ro,z
   app-service-http-export:
     command: /app-service-configurable -cp=consul.http://edgex-core-consul:8500 --registry
       --confdir=/res
@@ -198,7 +227,7 @@ services:
     user: 2002:2001
     volumes:
     - edgex-init:/edgex-init:ro,z
-    - /tmp/edgex/secrets/app-mqtt-export-secrets:/tmp/edgex/secrets/app-mqtt-export-secrets:ro,z
+    - /tmp/edgex/secrets/app-mqtt-export:/tmp/edgex/secrets/app-mqtt-export:ro,z
   app-service-rules:
     command: /app-service-configurable -cp=consul.http://edgex-core-consul:8500 --registry
       --confdir=/res
@@ -334,7 +363,7 @@ services:
     entrypoint:
     - /edgex-init/consul_wait_install.sh
     environment:
-      ADD_REGISTRY_ACL_ROLES: app-http-export,app-mqtt-export
+      ADD_REGISTRY_ACL_ROLES: app-http-export,app-mqtt-export,app-functional-tests
       API_GATEWAY_HOST: kong
       API_GATEWAY_STATUS_PORT: '8001'
       EDGEX_SECURITY_SECRET_STORE: "true"
@@ -934,11 +963,18 @@ services:
     volumes:
     - kuiper-data:/kuiper/data:z
   scalability-test-mqtt-export:
+    command: /app-service-configurable -cp=consul.http://edgex-core-consul:8500 --registry
+      --confdir=/res
     container_name: scalability-test-mqtt-export
     depends_on:
     - consul
     - data
+    - security-bootstrapper
+    entrypoint:
+    - /edgex-init/ready_to_run_wait_install.sh
     environment:
+      API_GATEWAY_HOST: kong
+      API_GATEWAY_STATUS_PORT: '8001'
       CLIENTS_COMMAND_HOST: edgex-core-command
       CLIENTS_COREDATA_HOST: edgex-core-data
       CLIENTS_DATA_HOST: edgex-core-data
@@ -953,10 +989,29 @@ services:
       DATABASES_PRIMARY_HOST: edgex-redis
       DATABASE_HOST: edgex-redis
       EDGEX_PROFILE: mqtt-export
-      EDGEX_SECURITY_SECRET_STORE: "false"
+      EDGEX_SECURITY_SECRET_STORE: "true"
+      ENABLE_REGISTRY_ACL: "true"
+      PROXY_SETUP_HOST: edgex-proxy-setup
       REGISTRY_HOST: edgex-core-consul
+      SECRETSTORE_HOST: edgex-vault
+      SECRETSTORE_PORT: '8200'
       SERVICE_HOST: app-mqtt-export
       SERVICE_PORT: 48106
+      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_DATABASE_HOST: edgex-redis
+      STAGEGATE_DATABASE_PORT: '6379'
+      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_KONGDB_HOST: kong-db
+      STAGEGATE_KONGDB_PORT: '5432'
+      STAGEGATE_KONGDB_READYPORT: '54325'
+      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_REGISTRY_HOST: edgex-core-consul
+      STAGEGATE_REGISTRY_PORT: '8500'
+      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_SECRETSTORESETUP_HOST: edgex-secretstore-setup
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_WAITFOR_TIMEOUT: 60s
       TRIGGER_EDGEXMESSAGEBUS_SUBSCRIBEHOST_HOST: edgex-core-data
       WRITABLE_LOGLEVEL: DEBUG
       WRITABLE_PIPELINE_EXECUTIONORDER: TransformToJSON, MQTTSecretSend
@@ -972,6 +1027,9 @@ services:
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
+    volumes:
+    - edgex-init:/edgex-init:ro,z
+    - /tmp/edgex/secrets/app-mqtt-export:/tmp/edgex/secrets/app-mqtt-export:ro,z
   scheduler:
     command: /support-scheduler -cp=consul.http://edgex-core-consul:8500 --registry
       --confdir=/res
@@ -1042,7 +1100,7 @@ services:
     - security-bootstrapper
     - vault
     environment:
-      ADD_SECRETSTORE_TOKENS: app-http-export,app-mqtt-export
+      ADD_SECRETSTORE_TOKENS: app-http-export,app-mqtt-export,app-functional-tests
       API_GATEWAY_HOST: kong
       API_GATEWAY_STATUS_PORT: '8001'
       EDGEX_GROUP: '2001'

--- a/taf/docker-compose-taf.yml
+++ b/taf/docker-compose-taf.yml
@@ -363,7 +363,7 @@ services:
     entrypoint:
     - /edgex-init/consul_wait_install.sh
     environment:
-      ADD_REGISTRY_ACL_ROLES: app-http-export,app-mqtt-export,app-functional-tests
+      ADD_REGISTRY_ACL_ROLES: app-http-export,app-mqtt-export,app-functional-tests,scalability-test-mqtt-export
       API_GATEWAY_HOST: kong
       API_GATEWAY_STATUS_PORT: '8001'
       EDGEX_SECURITY_SECRET_STORE: "true"
@@ -990,6 +990,7 @@ services:
       DATABASE_HOST: edgex-redis
       EDGEX_PROFILE: mqtt-export
       EDGEX_SECURITY_SECRET_STORE: "true"
+      EDGEX_SERVICE_KEY: scalability-test-mqtt-export
       ENABLE_REGISTRY_ACL: "true"
       PROXY_SETUP_HOST: edgex-proxy-setup
       REGISTRY_HOST: edgex-core-consul
@@ -1029,7 +1030,7 @@ services:
     user: 2002:2001
     volumes:
     - edgex-init:/edgex-init:ro,z
-    - /tmp/edgex/secrets/app-mqtt-export:/tmp/edgex/secrets/app-mqtt-export:ro,z
+    - /tmp/edgex/secrets/scalability-test-mqtt-export:/tmp/edgex/secrets/scalability-test-mqtt-export:ro,z
   scheduler:
     command: /support-scheduler -cp=consul.http://edgex-core-consul:8500 --registry
       --confdir=/res
@@ -1100,7 +1101,7 @@ services:
     - security-bootstrapper
     - vault
     environment:
-      ADD_SECRETSTORE_TOKENS: app-http-export,app-mqtt-export,app-functional-tests
+      ADD_SECRETSTORE_TOKENS: app-http-export,app-mqtt-export,app-functional-tests,scalability-test-mqtt-export
       API_GATEWAY_HOST: kong
       API_GATEWAY_STATUS_PORT: '8001'
       EDGEX_GROUP: '2001'

--- a/taf/docker-compose-taf.yml
+++ b/taf/docker-compose-taf.yml
@@ -996,7 +996,7 @@ services:
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault
       SECRETSTORE_PORT: '8200'
-      SERVICE_HOST: app-mqtt-export
+      SERVICE_HOST: scalability-test-mqtt-export
       SERVICE_PORT: 48106
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
       STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'

--- a/taf/docker-compose-taf.yml
+++ b/taf/docker-compose-taf.yml
@@ -29,7 +29,7 @@ networks:
     driver: bridge
 services:
   app-service-functional-tests:
-    container_name: app-service-functional-tests
+    container_name: app-functional-tests
     depends_on:
     - consul
     - data
@@ -50,10 +50,10 @@ services:
       EDGEX_PROFILE: functional-tests
       EDGEX_SECURITY_SECRET_STORE: "false"
       REGISTRY_HOST: edgex-core-consul
-      SERVICE_HOST: app-service-functional-tests
+      SERVICE_HOST: app-functional-tests
       SERVICE_PORT: 48105
       TRIGGER_EDGEXMESSAGEBUS_SUBSCRIBEHOST_HOST: edgex-core-data
-    hostname: app-service-functional-tests
+    hostname: app-functional-tests
     image: nexus3.edgexfoundry.org:10004/docker-app-service-configurable:master
     networks:
       edgex-network: {}
@@ -64,46 +64,9 @@ services:
     - no-new-privileges:true
     user: 2002:2001
   app-service-http-export:
-    container_name: app-service-http-export
-    depends_on:
-    - consul
-    - data
-    environment:
-      CLIENTS_COMMAND_HOST: edgex-core-command
-      CLIENTS_COREDATA_HOST: edgex-core-data
-      CLIENTS_DATA_HOST: edgex-core-data
-      CLIENTS_EDGEX-CORE-COMMAND_HOST: edgex-core-command
-      CLIENTS_EDGEX-CORE-DATA_HOST: edgex-core-data
-      CLIENTS_EDGEX-CORE-METADATA_HOST: edgex-core-metadata
-      CLIENTS_EDGEX-SUPPORT-NOTIFICATIONS_HOST: edgex-support-notifications
-      CLIENTS_EDGEX-SUPPORT-SCHEDULER_HOST: edgex-support-scheduler
-      CLIENTS_METADATA_HOST: edgex-core-metadata
-      CLIENTS_NOTIFICATIONS_HOST: edgex-support-notifications
-      CLIENTS_SCHEDULER_HOST: edgex-support-scheduler
-      DATABASES_PRIMARY_HOST: edgex-redis
-      DATABASE_HOST: edgex-redis
-      EDGEX_PROFILE: http-export
-      EDGEX_SECURITY_SECRET_STORE: "false"
-      REGISTRY_HOST: edgex-core-consul
-      SERVICE_HOST: app-service-http-export
-      SERVICE_PORT: 48101
-      TRIGGER_EDGEXMESSAGEBUS_SUBSCRIBEHOST_HOST: edgex-core-data
-      WRITABLE_LOGLEVEL: INFO
-      WRITABLE_PIPELINE_FUNCTIONS_HTTPEXPORT_PARAMETERS_URL: http://EXPORT_HOST_PLACE_HOLDER:7770
-    hostname: app-service-http-export
-    image: nexus3.edgexfoundry.org:10004/docker-app-service-configurable:master
-    networks:
-      edgex-network: {}
-    ports:
-    - 127.0.0.1:48101:48101/tcp
-    read_only: true
-    security_opt:
-    - no-new-privileges:true
-    user: 2002:2001
-  app-service-http-export-secrets:
     command: /app-service-configurable -cp=consul.http://edgex-core-consul:8500 --registry
       --confdir=/res
-    container_name: app-service-http-export-secrets
+    container_name: app-http-export
     depends_on:
     - consul
     - data
@@ -132,11 +95,9 @@ services:
       PROXY_SETUP_HOST: edgex-proxy-setup
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PATH: /v1/secret/edgex/app-service-http-export-secrets/
       SECRETSTORE_PORT: '8200'
-      SECRETSTORE_TOKENFILE: /tmp/edgex/secrets/app-service-http-export-secrets/secrets-token.json
-      SERVICE_HOST: app-service-http-export-secrets
-      SERVICE_PORT: 48102
+      SERVICE_HOST: app-http-export
+      SERVICE_PORT: 48101
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
       STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
       STAGEGATE_DATABASE_HOST: edgex-redis
@@ -154,100 +115,24 @@ services:
       STAGEGATE_WAITFOR_TIMEOUT: 60s
       TRIGGER_EDGEXMESSAGEBUS_SUBSCRIBEHOST_HOST: edgex-core-data
       WRITABLE_LOGLEVEL: INFO
-      WRITABLE_PIPELINE_FUNCTIONS_HTTPEXPORT_PARAMETERS_HEADERNAME: ''
-      WRITABLE_PIPELINE_FUNCTIONS_HTTPEXPORT_PARAMETERS_SECRETNAME: ''
-      WRITABLE_PIPELINE_FUNCTIONS_HTTPEXPORT_PARAMETERS_SECRETPATH: ''
       WRITABLE_PIPELINE_FUNCTIONS_HTTPEXPORT_PARAMETERS_URL: http://EXPORT_HOST_PLACE_HOLDER:7770
-    hostname: app-service-http-export-secrets
+    hostname: app-http-export
     image: nexus3.edgexfoundry.org:10004/docker-app-service-configurable:master
     networks:
       edgex-network: {}
     ports:
-    - 127.0.0.1:48102:48102/tcp
+    - 127.0.0.1:48101:48101/tcp
     read_only: true
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
     volumes:
     - edgex-init:/edgex-init:ro,z
-    - /tmp/edgex/secrets/app-service-http-export-secrets:/tmp/edgex/secrets/app-service-http-export-secrets:ro,z
+    - /tmp/edgex/secrets/app-http-export:/tmp/edgex/secrets/app-http-export:ro,z
   app-service-mqtt-export:
-    container_name: app-service-mqtt-export
-    depends_on:
-    - consul
-    - data
-    environment:
-      CLIENTS_COMMAND_HOST: edgex-core-command
-      CLIENTS_COREDATA_HOST: edgex-core-data
-      CLIENTS_DATA_HOST: edgex-core-data
-      CLIENTS_EDGEX-CORE-COMMAND_HOST: edgex-core-command
-      CLIENTS_EDGEX-CORE-DATA_HOST: edgex-core-data
-      CLIENTS_EDGEX-CORE-METADATA_HOST: edgex-core-metadata
-      CLIENTS_EDGEX-SUPPORT-NOTIFICATIONS_HOST: edgex-support-notifications
-      CLIENTS_EDGEX-SUPPORT-SCHEDULER_HOST: edgex-support-scheduler
-      CLIENTS_METADATA_HOST: edgex-core-metadata
-      CLIENTS_NOTIFICATIONS_HOST: edgex-support-notifications
-      CLIENTS_SCHEDULER_HOST: edgex-support-scheduler
-      DATABASES_PRIMARY_HOST: edgex-redis
-      DATABASE_HOST: edgex-redis
-      EDGEX_PROFILE: mqtt-export
-      EDGEX_SECURITY_SECRET_STORE: "false"
-      REGISTRY_HOST: edgex-core-consul
-      SERVICE_HOST: app-service-mqtt-export
-      SERVICE_PORT: 48103
-      TRIGGER_EDGEXMESSAGEBUS_SUBSCRIBEHOST_HOST: edgex-core-data
-      WRITABLE_LOGLEVEL: INFO
-      WRITABLE_PIPELINE_FUNCTIONS_MQTTEXPORT_PARAMETERS_BROKERADDRESS: tcp://MQTT_BROKER_ADDRESS_PLACE_HOLDER:1883
-      WRITABLE_PIPELINE_FUNCTIONS_MQTTEXPORT_PARAMETERS_TOPIC: edgex-events
-    hostname: app-service-mqtt-export
-    image: nexus3.edgexfoundry.org:10004/docker-app-service-configurable:master
-    networks:
-      edgex-network: {}
-    ports:
-    - 127.0.0.1:48103:48103/tcp
-    read_only: true
-    security_opt:
-    - no-new-privileges:true
-    user: 2002:2001
-  app-service-rules:
-    container_name: edgex-app-service-configurable-rules
-    depends_on:
-    - consul
-    - data
-    environment:
-      CLIENTS_COMMAND_HOST: edgex-core-command
-      CLIENTS_COREDATA_HOST: edgex-core-data
-      CLIENTS_DATA_HOST: edgex-core-data
-      CLIENTS_EDGEX-CORE-COMMAND_HOST: edgex-core-command
-      CLIENTS_EDGEX-CORE-DATA_HOST: edgex-core-data
-      CLIENTS_EDGEX-CORE-METADATA_HOST: edgex-core-metadata
-      CLIENTS_EDGEX-SUPPORT-NOTIFICATIONS_HOST: edgex-support-notifications
-      CLIENTS_EDGEX-SUPPORT-SCHEDULER_HOST: edgex-support-scheduler
-      CLIENTS_METADATA_HOST: edgex-core-metadata
-      CLIENTS_NOTIFICATIONS_HOST: edgex-support-notifications
-      CLIENTS_SCHEDULER_HOST: edgex-support-scheduler
-      DATABASES_PRIMARY_HOST: edgex-redis
-      EDGEX_PROFILE: rules-engine
-      EDGEX_SECURITY_SECRET_STORE: "false"
-      REGISTRY_HOST: edgex-core-consul
-      SERVICE_HOST: edgex-app-service-configurable-rules
-      SERVICE_PORT: 48100
-      TRIGGER_EDGEXMESSAGEBUS_SUBSCRIBEHOST_HOST: edgex-core-data
-      TRIGGER_PUBLISHTOPIC: events
-    hostname: edgex-app-service-configurable-rules
-    image: nexus3.edgexfoundry.org:10004/docker-app-service-configurable:master
-    networks:
-      edgex-network: {}
-    ports:
-    - 127.0.0.1:48100:48100/tcp
-    read_only: true
-    security_opt:
-    - no-new-privileges:true
-    user: 2002:2001
-  appservice-mqtt-export-secrets:
     command: /app-service-configurable -cp=consul.http://edgex-core-consul:8500 --registry
       --confdir=/res
-    container_name: app-service-mqtt-export-secrets
+    container_name: app-mqtt-export
     depends_on:
     - consul
     - data
@@ -276,11 +161,9 @@ services:
       PROXY_SETUP_HOST: edgex-proxy-setup
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PATH: /v1/secret/edgex/app-service-mqtt-export-secrets/
       SECRETSTORE_PORT: '8200'
-      SECRETSTORE_TOKENFILE: /tmp/edgex/secrets/app-service-mqtt-export-secrets/secrets-token.json
-      SERVICE_HOST: app-service-mqtt-export-secrets
-      SERVICE_PORT: 48104
+      SERVICE_HOST: app-mqtt-export
+      SERVICE_PORT: 48103
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
       STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
       STAGEGATE_DATABASE_HOST: edgex-redis
@@ -303,19 +186,84 @@ services:
       WRITABLE_PIPELINE_FUNCTIONS_MQTTEXPORT_PARAMETERS_AUTHMODE: usernamepassword
       WRITABLE_PIPELINE_FUNCTIONS_MQTTEXPORT_PARAMETERS_BROKERADDRESS: tcp://MQTT_BROKER_ADDRESS_PLACE_HOLDER:1883
       WRITABLE_PIPELINE_FUNCTIONS_MQTTEXPORT_PARAMETERS_TOPIC: edgex-events
-    hostname: app-service-mqtt-export-secrets
+    hostname: app-mqtt-export
     image: nexus3.edgexfoundry.org:10004/docker-app-service-configurable:master
     networks:
       edgex-network: {}
     ports:
-    - 127.0.0.1:48104:48104/tcp
+    - 127.0.0.1:48103:48103/tcp
     read_only: true
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
     volumes:
     - edgex-init:/edgex-init:ro,z
-    - /tmp/edgex/secrets/app-service-mqtt-export-secrets:/tmp/edgex/secrets/app-service-mqtt-export-secrets:ro,z
+    - /tmp/edgex/secrets/app-mqtt-export-secrets:/tmp/edgex/secrets/app-mqtt-export-secrets:ro,z
+  app-service-rules:
+    command: /app-service-configurable -cp=consul.http://edgex-core-consul:8500 --registry
+      --confdir=/res
+    container_name: edgex-app-service-configurable-rules
+    depends_on:
+    - consul
+    - data
+    - security-bootstrapper
+    entrypoint:
+    - /edgex-init/ready_to_run_wait_install.sh
+    environment:
+      API_GATEWAY_HOST: kong
+      API_GATEWAY_STATUS_PORT: '8001'
+      CLIENTS_COMMAND_HOST: edgex-core-command
+      CLIENTS_COREDATA_HOST: edgex-core-data
+      CLIENTS_DATA_HOST: edgex-core-data
+      CLIENTS_EDGEX-CORE-COMMAND_HOST: edgex-core-command
+      CLIENTS_EDGEX-CORE-DATA_HOST: edgex-core-data
+      CLIENTS_EDGEX-CORE-METADATA_HOST: edgex-core-metadata
+      CLIENTS_EDGEX-SUPPORT-NOTIFICATIONS_HOST: edgex-support-notifications
+      CLIENTS_EDGEX-SUPPORT-SCHEDULER_HOST: edgex-support-scheduler
+      CLIENTS_METADATA_HOST: edgex-core-metadata
+      CLIENTS_NOTIFICATIONS_HOST: edgex-support-notifications
+      CLIENTS_SCHEDULER_HOST: edgex-support-scheduler
+      DATABASES_PRIMARY_HOST: edgex-redis
+      EDGEX_PROFILE: rules-engine
+      EDGEX_SECURITY_SECRET_STORE: "true"
+      ENABLE_REGISTRY_ACL: "true"
+      PROXY_SETUP_HOST: edgex-proxy-setup
+      REGISTRY_HOST: edgex-core-consul
+      SECRETSTORE_HOST: edgex-vault
+      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_TOKENFILE: /tmp/edgex/secrets/app-rules-engine/secrets-token.json
+      SERVICE_HOST: edgex-app-service-configurable-rules
+      SERVICE_PORT: 48100
+      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_DATABASE_HOST: edgex-redis
+      STAGEGATE_DATABASE_PORT: '6379'
+      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_KONGDB_HOST: kong-db
+      STAGEGATE_KONGDB_PORT: '5432'
+      STAGEGATE_KONGDB_READYPORT: '54325'
+      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_REGISTRY_HOST: edgex-core-consul
+      STAGEGATE_REGISTRY_PORT: '8500'
+      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_SECRETSTORESETUP_HOST: edgex-secretstore-setup
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_WAITFOR_TIMEOUT: 60s
+      TRIGGER_EDGEXMESSAGEBUS_SUBSCRIBEHOST_HOST: edgex-core-data
+      TRIGGER_PUBLISHTOPIC: events
+    hostname: edgex-app-service-configurable-rules
+    image: nexus3.edgexfoundry.org:10004/docker-app-service-configurable:master
+    networks:
+      edgex-network: {}
+    ports:
+    - 127.0.0.1:48100:48100/tcp
+    read_only: true
+    security_opt:
+    - no-new-privileges:true
+    user: 2002:2001
+    volumes:
+    - edgex-init:/edgex-init:ro,z
+    - /tmp/edgex/secrets/app-rules-engine:/tmp/edgex/secrets/app-rules-engine:ro,z
   command:
     command: /core-command -cp=consul.http://edgex-core-consul:8500 --registry --confdir=/res
     container_name: edgex-core-command
@@ -386,6 +334,7 @@ services:
     entrypoint:
     - /edgex-init/consul_wait_install.sh
     environment:
+      ADD_REGISTRY_ACL_ROLES: app-http-export,app-mqtt-export
       API_GATEWAY_HOST: kong
       API_GATEWAY_STATUS_PORT: '8001'
       EDGEX_SECURITY_SECRET_STORE: "true"
@@ -424,8 +373,8 @@ services:
     - consul-config:/consul/config:z
     - consul-data:/consul/data:z
     - edgex-init:/edgex-init:ro,z
-    - /tmp/edgex/secrets:/tmp/edgex/secrets:z
     - consul-acl-token:/tmp/edgex/secrets/consul-acl-token:z
+    - /tmp/edgex/secrets/edgex-consul:/tmp/edgex/secrets/edgex-consul:ro,z
   data:
     command: /core-data -cp=consul.http://edgex-core-consul:8500 --registry --confdir=/res
     container_name: edgex-core-data
@@ -1006,7 +955,7 @@ services:
       EDGEX_PROFILE: mqtt-export
       EDGEX_SECURITY_SECRET_STORE: "false"
       REGISTRY_HOST: edgex-core-consul
-      SERVICE_HOST: app-service-mqtt-export
+      SERVICE_HOST: app-mqtt-export
       SERVICE_PORT: 48106
       TRIGGER_EDGEXMESSAGEBUS_SUBSCRIBEHOST_HOST: edgex-core-data
       WRITABLE_LOGLEVEL: DEBUG
@@ -1093,7 +1042,7 @@ services:
     - security-bootstrapper
     - vault
     environment:
-      ADD_SECRETSTORE_TOKENS: app-service-http-export-secrets,app-service-mqtt-export-secrets
+      ADD_SECRETSTORE_TOKENS: app-http-export,app-mqtt-export
       API_GATEWAY_HOST: kong
       API_GATEWAY_STATUS_PORT: '8001'
       EDGEX_GROUP: '2001'
@@ -1167,6 +1116,7 @@ services:
     volumes:
     - edgex-init:/edgex-init:z
   system:
+    command: /sys-mgmt-agent -cp=consul.http://edgex-core-consul:8500 --registry --confdir=/res
     container_name: edgex-sys-mgmt-agent
     depends_on:
     - command
@@ -1175,7 +1125,12 @@ services:
     - metadata
     - notifications
     - scheduler
+    - security-bootstrapper
+    entrypoint:
+    - /edgex-init/ready_to_run_wait_install.sh
     environment:
+      API_GATEWAY_HOST: kong
+      API_GATEWAY_STATUS_PORT: '8001'
       CLIENTS_COMMAND_HOST: edgex-core-command
       CLIENTS_COREDATA_HOST: edgex-core-data
       CLIENTS_DATA_HOST: edgex-core-data
@@ -1188,11 +1143,31 @@ services:
       CLIENTS_NOTIFICATIONS_HOST: edgex-support-notifications
       CLIENTS_SCHEDULER_HOST: edgex-support-scheduler
       DATABASES_PRIMARY_HOST: edgex-redis
-      EDGEX_SECURITY_SECRET_STORE: "false"
+      EDGEX_SECURITY_SECRET_STORE: "true"
+      ENABLE_REGISTRY_ACL: "true"
       EXECUTORPATH: /sys-mgmt-executor
       METRICSMECHANISM: executor
+      PROXY_SETUP_HOST: edgex-proxy-setup
       REGISTRY_HOST: edgex-core-consul
+      SECRETSTORE_HOST: edgex-vault
+      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_TOKENFILE: /tmp/edgex/secrets/edgex-sys-mgmt-agent/secrets-token.json
       SERVICE_HOST: edgex-sys-mgmt-agent
+      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_DATABASE_HOST: edgex-redis
+      STAGEGATE_DATABASE_PORT: '6379'
+      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_KONGDB_HOST: kong-db
+      STAGEGATE_KONGDB_PORT: '5432'
+      STAGEGATE_KONGDB_READYPORT: '54325'
+      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_REGISTRY_HOST: edgex-core-consul
+      STAGEGATE_REGISTRY_PORT: '8500'
+      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_SECRETSTORESETUP_HOST: edgex-secretstore-setup
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-sys-mgmt-agent
     image: nexus3.edgexfoundry.org:10004/docker-sys-mgmt-agent-go:master
     networks:
@@ -1204,6 +1179,8 @@ services:
     - no-new-privileges:true
     user: root:root
     volumes:
+    - edgex-init:/edgex-init:ro,z
+    - /tmp/edgex/secrets/edgex-sys-mgmt-agent:/tmp/edgex/secrets/edgex-sys-mgmt-agent:ro,z
     - /var/run/docker.sock:/var/run/docker.sock:z
   vault:
     cap_add:


### PR DESCRIPTION

- add edgex-sys-mgmt and app-service-rule-engine into security yaml for them to be waiting on consul-bootstrapper

Closes: #52

Signed-off-by: Jim Wang <yutsung.jim.wang@intel.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-examples/blob/master/.github/CONTRIBUTING.md.

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->
no waiting mechanism for both services of `system-management` and `app-service-rule-engine` yet

## Issue Number: #52 


## What is the new behavior?
Add waiting mechanism for both services of `system-management` and `app-service-rule-engine`

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x ] No

## New Imports
Are there any new imports or modules? If so, what are they used for and why?
N/A

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information