### PR TITLE
refactor: Enable adding UI service when generating a compose file

### DIFF
--- a/compose-builder/Makefile
+++ b/compose-builder/Makefile
@@ -34,7 +34,7 @@ define OPTIONS
  - taf-secty taf-no-secty taf-perf taf-perf-no-secty -
  - ds-bacnet ds-camera ds-grove ds-modbus ds-mqtt ds-random ds-rest ds-snmp ds-virtual -
  - asc-http asc-http-s asc-mqtt asc-mqtt-s -
- - modbus-sim ui -
+ - modbus-sim ui ui-only -
 endef
 export OPTIONS
 
@@ -140,6 +140,15 @@ else
 	COMPOSE_FILES:=$(COMPOSE_FILES) -f add-security.yml
 endif
 
+ifeq (ui, $(filter ui,$(ARGS)))
+	COMPOSE_FILES:=$(COMPOSE_FILES) -f add-ui.yml
+endif
+
+ifeq (ui-only, $(filter ui-only,$(ARGS)))
+	COMPOSE_FILES:=-f stand-alone-ui.yml -f add-ui.yml
+	UI:=-ui
+endif
+
 # Build compose for TAF secure testing (ignore all other compose file options)
 ifeq (taf-secty, $(filter taf-secty,$(ARGS)))
 	TOKEN_LIST:=app-service-http-export-secrets,app-service-mqtt-export-secrets
@@ -197,11 +206,6 @@ else
 	endif
 endif
 
-ifeq (ui, $(filter ui,$(ARGS)))
-	COMPOSE_FILES:=-f docker-compose-ui.yml
-	UI:=-ui
-endif
-
 SERVICES:=$(filter-out ${OPTIONS},$(ARGS))
 
 ifeq (true, $(DS_GROVE))
@@ -225,8 +229,8 @@ build:
 	make compose ds-rest ds-virtual arm64
 	make compose ds-rest ds-virtual no-secty
 	make compose ds-rest ds-virtual no-secty arm64
-	make compose ui
-	make compose ui arm64
+	make compose ui-only
+	make compose ui-only arm64
 	make taf-compose taf-secty
 	make taf-compose taf-no-secty
 	make taf-compose taf-secty arm64

--- a/compose-builder/README.md
+++ b/compose-builder/README.md
@@ -164,7 +164,10 @@ Options:
     asc-mqtt-s:  Runs with App Service MQTT Export Secrets included
     mqtt-broker: Runs with a MQTT Broker service included 
     mqtt-bus:    Runs with services configure for MQTT Message Bus 
-    ui:          Runs only the EdgeX UI service. `ds-x`, 'mqtt', 'no-ds' & 'no-secty' are ignored. Typically used after the other Edgex Services have been started
+    ui:          Runs with the UI service included
+    ui-only:     Runs only the EdgeX UI service. `asc-x`, `ds-x`, 'mqtt', 'no-ds' &
+                 'no-secty' are ignored. Typically used after the other Edgex Services
+                 have been started
 Services:
     <names...>: Runs only services listed (and their dependent services) where 'name' matches a service name in one of the compose files used
 ```
@@ -206,7 +209,7 @@ Options:
     asc-mqtt-s:  Pull includes App Service MQTT Export Secrets
     mqtt-broker: Pull includes MQTT Broker service
     mqtt-bus:    Pull includes additional service for MQTT Message Bus
-    ui:          Pulls only the EdgeX UI service image. `ds-x`, 'mqtt', 'no-ds' & 'no-secty' are ignored
+    ui:          Pulls only the EdgeX UI service image.
 Services:
     <names...>: Pulls only images for the service(s) listed
 ```
@@ -239,7 +242,8 @@ Options:
     mqtt-broker: Generates compose file with a MQTT Broker service included 
     mqtt-bus:    Generates compose file with services configure for MQTT Message Bus 
                  The MQTT Broker service is also included. 
-    ui:          Generates stand-alone compose file for EdgeX UI
+    ui:          Generates compose file with UI sevice included             
+    ui-only:     Generates stand-alone compose file for EdgeX UI
 ```
 #### Clean
 
@@ -313,8 +317,9 @@ Options:
     asc-mqtt-s:  Generates compose file with App Service MQTT Export Secrets included
     mqtt-broker: Generates compose file with a MQTT Broker service included 
     mqtt-bus:    Generates compose file with services configure for MQTT Message Bus 
-                 The MQTT Broker service is also included. 
-    ui:          Generates stand-alone compose file for EdgeX UI	
+                 The MQTT Broker service is also included.
+    ui:          Generates compose file with UI sevice included             
+    ui-only:     Generates stand-alone compose file for EdgeX UI	
 ```
 
 #### Taf-compose
@@ -340,5 +345,3 @@ Options:
     taf-no-secty: Generates performance TAF testing compose file without security services
     arm64:        Generates TAF compose file using ARM64 images
 ```
-
-#### 

--- a/compose-builder/README.md
+++ b/compose-builder/README.md
@@ -165,9 +165,7 @@ Options:
     mqtt-broker: Runs with a MQTT Broker service included 
     mqtt-bus:    Runs with services configure for MQTT Message Bus 
     ui:          Runs with the UI service included
-    ui-only:     Runs only the EdgeX UI service. `asc-x`, `ds-x`, 'mqtt', 'no-ds' &
-                 'no-secty' are ignored. Typically used after the other Edgex Services
-                 have been started
+    ui-only:     Runs only the EdgeX UI service. `asc-x`, `ds-x`, 'mqtt', 'no-ds' & 'no-secty' are ignored. Typically used after the other Edgex Services have been started
 Services:
     <names...>: Runs only services listed (and their dependent services) where 'name' matches a service name in one of the compose files used
 ```
@@ -209,7 +207,9 @@ Options:
     asc-mqtt-s:  Pull includes App Service MQTT Export Secrets
     mqtt-broker: Pull includes MQTT Broker service
     mqtt-bus:    Pull includes additional service for MQTT Message Bus
-    ui:          Pulls only the EdgeX UI service image.
+    ui:          Pulls includes the EdgeX UI service.
+    ui-only:     Pulls only the EdgeX UI service image. `asc-x`, `ds-x`, 'mqtt', 'no-ds & 'no-secty' are ignored.
+
 Services:
     <names...>: Pulls only images for the service(s) listed
 ```

--- a/compose-builder/add-ui.yml
+++ b/compose-builder/add-ui.yml
@@ -1,3 +1,4 @@
+# /*******************************************************************************
 #  * Copyright 2021 Intel Corporation.
 #  *
 #  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
@@ -10,36 +11,21 @@
 #  * or implied. See the License for the specific language governing permissions and limitations under
 #  * the License.
 #  *
-#  * EdgeX Foundry, Hanoi, version "master"
 #  *******************************************************************************/
-#
-#
-#
-# ************************ This is a generated compose file ****************************
-#
-# DO NOT MAKE CHANGES that are intended to be permanent to EdgeX edgex-compose repo.
-#
-# Permanent changes can be made to the source compose files located in the compose-builder folder
-# at the top level of the edgex-compose repo.
-#
-# From the compose-builder folder use `make build` to regenerate all standard compose files variations
-#
-networks:
-  edgex-network:
-    external: true
-    name: edgex_edgex-network
+
+version: '3.7'
+
 services:
   ui:
+    image: ${UI_REPOSITORY}/docker-edgex-ui-go${ARCH}:${EDGEX_UI_VERSION}
+    ports:
+      - "127.0.0.1:4000:4000"
     container_name: edgex-ui-go
     hostname: edgex-ui-go
-    image: nexus3.edgexfoundry.org:10004/docker-edgex-ui-go-arm64:master
-    networks:
-      edgex-network: {}
-    ports:
-    - 127.0.0.1:4000:4000/tcp
     read_only: true
+    networks:
+      - edgex-network
     security_opt:
-    - no-new-privileges:true
-    user: 2002:2001
-version: '3.7'
+      - no-new-privileges:true
+    user: "${EDGEX_USER}:${EDGEX_GROUP}"
 

--- a/compose-builder/stand-alone-ui.yml
+++ b/compose-builder/stand-alone-ui.yml
@@ -19,16 +19,6 @@ networks:
     external:
       name: edgex_edgex-network
 
-services:
-  ui:
-    image: ${UI_REPOSITORY}/docker-edgex-ui-go${ARCH}:${EDGEX_UI_VERSION}
-    ports:
-      - "127.0.0.1:4000:4000"
-    container_name: edgex-ui-go
-    hostname: edgex-ui-go
-    read_only: true
-    networks:
-      - edgex-network
-    security_opt: 
-      - no-new-privileges:true
-    user: "${EDGEX_USER}:${EDGEX_GROUP}"
+# This file is used in conjunction with the add-ui.yml file.
+# Here it just sets up the external network for the UI to run standalone and be able to communicate with
+# the EdgeX stack. It makes the assumption the stack was started with the -p=edgex option.

--- a/docker-compose-pre-release-ui.yml
+++ b/docker-compose-pre-release-ui.yml
@@ -34,7 +34,7 @@ services:
     hostname: edgex-ui-go
     image: nexus3.edgexfoundry.org:10004/docker-edgex-ui-go:master
     networks:
-      edgex-network: null
+      edgex-network: {}
     ports:
     - 127.0.0.1:4000:4000/tcp
     read_only: true


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-examples/blob/master/.github/CONTRIBUTING.md.

## What is the current behavior?
Currently the UI is run from stand-alone compose file after the EdgeX stack is up and running

## Issue Number: #36


## What is the new behavior?
Now a user has the option of including the UI in there single EdgeX custom compose file. Note the standard release compose files still don not include the UI, thus we still have the stand-alone UI compose files.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
Are there any new imports or modules? If so, what are they used for and why?
no
## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information