### PR TITLE
fix: Update the ui-down target to use new UI compose files.

### DIFF
--- a/compose-builder/Makefile
+++ b/compose-builder/Makefile
@@ -283,7 +283,7 @@ get-consul-acl-token:
 
 ui-down:
 	ARCH= \
-	docker-compose -p edgex -f docker-compose-ui.yml down
+	docker-compose -p edgex -f stand-alone-ui.yml -f add-ui.yml down
 
 down: ui-down
 	DEV= \

--- a/compose-builder/README.md
+++ b/compose-builder/README.md
@@ -81,7 +81,7 @@ This folder contains the following compose files:
     UI **extending** compose file, which adds the **Edgex UI** service.
 
 - **stand-alone-ui.yml**
-    Stand-alone **extending** compose file compose file for running the optional EdgeX UI stand-alone.    Used in conjunction with the **add-ui.yml** file. This file just sets up the external network for the UI to run stand-alone and be able to communicate with the EdgeX stack. It makes the assumption the stack was started with the `-p=edgex` option. 
+    Stand-alone **extending** compose file for running the optional EdgeX UI stand-alone.    Used in conjunction with the **add-ui.yml** file. This file just sets up the external network for the UI to run stand-alone and be able to communicate with the EdgeX stack. It makes the assumption the stack was started with the `-p=edgex` option. 
 
 ### Environment Files
 

--- a/compose-builder/README.md
+++ b/compose-builder/README.md
@@ -77,8 +77,11 @@ This folder contains the following compose files:
     TAF App Services **extending** compose file. Adds additional App Service for the TAF testing compose files.
 - **add-taf-device-services-mods.yml**
     TAF Device Services **extending** compose file. Modifies setting of Device Virtual and Device Modbus for the TAF testing compose files. **Must be used in conjunction with add-device-modbus.yml and add-device-virtual.yml**
-- **docker-compose-ui.yml**
-    Stand-alone compose file for running the optional EdgeX UI. Runs in `host` network mode and only supports connecting to local Edgex services via 127.0.0.1 IP address.
+- **add-ui.yml**
+    UI **extending** compose file, which adds the **Edgex UI** service.
+
+- **stand-alone-ui.yml**
+    Stand-alone **extending** compose file compose file for running the optional EdgeX UI stand-alone.    Used in conjunction with the **add-ui.yml** file. This file just sets up the external network for the UI to run stand-alone and be able to communicate with the EdgeX stack. It makes the assumption the stack was started with the `-p=edgex` option. 
 
 ### Environment Files
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-examples/blob/master/.github/CONTRIBUTING.md.

## What is the current behavior?
`make ui-down` fails due to YAML file no longer exists
Documentation for UI YAML file incorrect.

## Issue Number: #56

## What is the new behavior?
`make ui-down` now works properly
Documentation for UI YAML file corrected.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
Are there any new imports or modules? If so, what are they used for and why?

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information