### PR TITLE
fix(security): Fix TAF failing to start device-virtual

### DIFF
--- a/compose-builder/Makefile
+++ b/compose-builder/Makefile
@@ -239,17 +239,22 @@ ifeq (taf-secty, $(filter taf-secty,$(ARGS)))
 		-f add-device-virtual.yml \
 		-f add-device-rest.yml \
 		-f add-device-modbus.yml \
+		-f add-taf-device-services-mods.yml \
 		-f add-mqtt-broker.yml \
 		-f add-modbus-simulator.yml
 	asc_http_export_ext:= $(shell GEN_EXT_DIR="$(GEN_EXT_DIR)" ./gen_secure_compose_ext.sh app-service-http-export \
 		app-http-export app-service-configurable)
 	asc_mqtt_export_ext:= $(shell GEN_EXT_DIR="$(GEN_EXT_DIR)" ./gen_secure_compose_ext.sh app-service-mqtt-export \
 		app-mqtt-export app-service-configurable)
-	ds_virtual_ext:= $(shell GEN_EXT_DIR="$(GEN_EXT_DIR)" ./gen_secure_compose_ext.sh device-virtual)
 	ds_rest_ext:= $(shell GEN_EXT_DIR="$(GEN_EXT_DIR)" ./gen_secure_compose_ext.sh device-rest device-rest device-rest-go)
-	ds_modbus_ext:= $(shell GEN_EXT_DIR="$(GEN_EXT_DIR)" ./gen_secure_compose_ext.sh device-modbus)
+	# taf has its special place holder from taf-device-services-mods and thus we need to keep it
+	# and extend security related things on top of it
+	ds_virtual_ext:= $(shell GEN_EXT_DIR="$(GEN_EXT_DIR)" ./gen_secure_compose_ext.sh device-virtual \
+		device-virtual device-virtual ' --registry --confdir=CONF_DIR_PLACE_HOLDER')
+	ds_modbus_ext:= $(shell GEN_EXT_DIR="$(GEN_EXT_DIR)" ./gen_secure_compose_ext.sh device-modbus \
+		device-modbus device-modbus ' --registry --confdir=CONF_DIR_PLACE_HOLDER')
 	COMPOSE_FILES:=$(COMPOSE_FILES) -f $(asc_http_export_ext) -f $(asc_mqtt_export_ext)
-	COMPOSE_FILES:=$(COMPOSE_FILES) -f $(ds_virtual_ext) -f $(ds_rest_ext) -f $(ds_modbus_ext) -f add-taf-device-services-mods.yml
+	COMPOSE_FILES:=$(COMPOSE_FILES) -f $(ds_virtual_ext) -f $(ds_rest_ext) -f $(ds_modbus_ext)
 else
 	# Build compose for TAF non-secure testing (ignore all other compose file options)
     ifeq (taf-no-secty, $(filter taf-no-secty,$(ARGS)))

--- a/taf/docker-compose-taf-arm64.yml
+++ b/taf/docker-compose-taf-arm64.yml
@@ -531,7 +531,7 @@ services:
     - redis-config:/run/redis/conf:z
     - /tmp/edgex/secrets/edgex-security-bootstrap-redis:/tmp/edgex/secrets/edgex-security-bootstrap-redis:ro,z
   device-modbus:
-    command: --registry --confdir=CONF_DIR_PLACE_HOLDER
+    command: /device-modbus --registry --confdir=CONF_DIR_PLACE_HOLDER
     container_name: edgex-device-modbus
     depends_on:
     - consul
@@ -652,7 +652,7 @@ services:
     - edgex-init:/edgex-init:ro,z
     - /tmp/edgex/secrets/device-rest:/tmp/edgex/secrets/device-rest:ro,z
   device-virtual:
-    command: --registry --confdir=CONF_DIR_PLACE_HOLDER
+    command: /device-virtual --registry --confdir=CONF_DIR_PLACE_HOLDER
     container_name: edgex-device-virtual
     depends_on:
     - consul

--- a/taf/docker-compose-taf.yml
+++ b/taf/docker-compose-taf.yml
@@ -531,7 +531,7 @@ services:
     - redis-config:/run/redis/conf:z
     - /tmp/edgex/secrets/edgex-security-bootstrap-redis:/tmp/edgex/secrets/edgex-security-bootstrap-redis:ro,z
   device-modbus:
-    command: --registry --confdir=CONF_DIR_PLACE_HOLDER
+    command: /device-modbus --registry --confdir=CONF_DIR_PLACE_HOLDER
     container_name: edgex-device-modbus
     depends_on:
     - consul
@@ -652,7 +652,7 @@ services:
     - edgex-init:/edgex-init:ro,z
     - /tmp/edgex/secrets/device-rest:/tmp/edgex/secrets/device-rest:ro,z
   device-virtual:
-    command: --registry --confdir=CONF_DIR_PLACE_HOLDER
+    command: /device-virtual --registry --confdir=CONF_DIR_PLACE_HOLDER
     container_name: edgex-device-virtual
     depends_on:
     - consul


### PR DESCRIPTION
Fix the issue on device-virtual and device modbus for TAF tests failed to
 start them as they lost the executables of services in command section

Fixes: #64

Signed-off-by: Jim Wang <yutsung.jim.wang@intel.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-examples/blob/master/.github/CONTRIBUTING.md.

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->
Currently TAF test fails to start device-virtual/device-modbus as they lost the executables from the command section when run in security mode.

## Issue Number: #64 


## What is the new behavior?
Added the lost commands via extending them from the script and keeping the special PLACE_HOLDER in parameter snippet.


## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x ] No

## New Imports
Are there any new imports or modules? If so, what are they used for and why?

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information