### PR TITLE
feat(security): Update compose for adding consul header into Kong's route

### DIFF
--- a/compose-builder/add-security.yml
+++ b/compose-builder/add-security.yml
@@ -105,6 +105,8 @@ services:
       - common-security.env
       - common-sec-stage-gate.env
     environment:
+      EDGEX_USER: ${EDGEX_USER}
+      EDGEX_GROUP: ${EDGEX_GROUP}
       # uncomment and modify the following "ADD_REGISTRY_ACL_ROLES" to add additional registry ACL roles on the fly
       # the list is comma-separated service keys for these services
       #ADD_REGISTRY_ACL_ROLES: app-sample,app-rules-engine-redis, app-rules-engine-mqtt, app-push-to-core
@@ -244,9 +246,11 @@ services:
       ROUTES_EDGEX-SUPPORT-SCHEDULER_HOST: edgex-support-scheduler
       ROUTES_RULES-ENGINE_HOST: edgex-kuiper
       ROUTES_DEVICE-VIRTUAL_HOST: edgex-device-virtual
+      ROUTES_EDGEX-CORE-CONSUL_HOST: edgex-core-consul
     volumes:
       - edgex-init:/edgex-init:ro,z
       - /tmp/edgex/secrets/edgex-security-proxy-setup:/tmp/edgex/secrets/edgex-security-proxy-setup:ro,z
+      - consul-acl-token:/tmp/edgex/secrets/consul-acl-token:ro,z
     depends_on:
       - security-bootstrapper
       - secretstore-setup

--- a/docker-compose-arm64.yml
+++ b/docker-compose-arm64.yml
@@ -166,7 +166,9 @@ services:
       ADD_REGISTRY_ACL_ROLES: edgex-device-rest
       API_GATEWAY_HOST: kong
       API_GATEWAY_STATUS_PORT: '8100'
+      EDGEX_GROUP: '2001'
       EDGEX_SECURITY_SECRET_STORE: "true"
+      EDGEX_USER: '2002'
       ENABLE_REGISTRY_ACL: "true"
       PROXY_SETUP_HOST: edgex-proxy-setup
       SECRETSTORE_HOST: edgex-vault
@@ -701,6 +703,7 @@ services:
       PROXY_SETUP_HOST: edgex-proxy-setup
       ROUTES_DEVICE-VIRTUAL_HOST: edgex-device-virtual
       ROUTES_EDGEX-CORE-COMMAND_HOST: edgex-core-command
+      ROUTES_EDGEX-CORE-CONSUL_HOST: edgex-core-consul
       ROUTES_EDGEX-CORE-DATA_HOST: edgex-core-data
       ROUTES_EDGEX-CORE-METADATA_HOST: edgex-core-metadata
       ROUTES_EDGEX-SUPPORT-NOTIFICATIONS_HOST: edgex-support-notifications
@@ -733,6 +736,7 @@ services:
     user: 2002:2001
     volumes:
     - edgex-init:/edgex-init:ro,z
+    - consul-acl-token:/tmp/edgex/secrets/consul-acl-token:ro,z
     - /tmp/edgex/secrets/edgex-security-proxy-setup:/tmp/edgex/secrets/edgex-security-proxy-setup:ro,z
   rulesengine:
     container_name: edgex-kuiper

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -166,7 +166,9 @@ services:
       ADD_REGISTRY_ACL_ROLES: edgex-device-rest
       API_GATEWAY_HOST: kong
       API_GATEWAY_STATUS_PORT: '8100'
+      EDGEX_GROUP: '2001'
       EDGEX_SECURITY_SECRET_STORE: "true"
+      EDGEX_USER: '2002'
       ENABLE_REGISTRY_ACL: "true"
       PROXY_SETUP_HOST: edgex-proxy-setup
       SECRETSTORE_HOST: edgex-vault
@@ -701,6 +703,7 @@ services:
       PROXY_SETUP_HOST: edgex-proxy-setup
       ROUTES_DEVICE-VIRTUAL_HOST: edgex-device-virtual
       ROUTES_EDGEX-CORE-COMMAND_HOST: edgex-core-command
+      ROUTES_EDGEX-CORE-CONSUL_HOST: edgex-core-consul
       ROUTES_EDGEX-CORE-DATA_HOST: edgex-core-data
       ROUTES_EDGEX-CORE-METADATA_HOST: edgex-core-metadata
       ROUTES_EDGEX-SUPPORT-NOTIFICATIONS_HOST: edgex-support-notifications
@@ -733,6 +736,7 @@ services:
     user: 2002:2001
     volumes:
     - edgex-init:/edgex-init:ro,z
+    - consul-acl-token:/tmp/edgex/secrets/consul-acl-token:ro,z
     - /tmp/edgex/secrets/edgex-security-proxy-setup:/tmp/edgex/secrets/edgex-security-proxy-setup:ro,z
   rulesengine:
     container_name: edgex-kuiper

--- a/taf/docker-compose-taf-arm64.yml
+++ b/taf/docker-compose-taf-arm64.yml
@@ -369,7 +369,9 @@ services:
       ADD_REGISTRY_ACL_ROLES: app-http-export,app-mqtt-export,app-functional-tests,scalability-test-mqtt-export,edgex-device-modbus,edgex-device-rest
       API_GATEWAY_HOST: kong
       API_GATEWAY_STATUS_PORT: '8100'
+      EDGEX_GROUP: '2001'
       EDGEX_SECURITY_SECRET_STORE: "true"
+      EDGEX_USER: '2002'
       ENABLE_REGISTRY_ACL: "true"
       PROXY_SETUP_HOST: edgex-proxy-setup
       SECRETSTORE_HOST: edgex-vault
@@ -992,6 +994,7 @@ services:
       PROXY_SETUP_HOST: edgex-proxy-setup
       ROUTES_DEVICE-VIRTUAL_HOST: edgex-device-virtual
       ROUTES_EDGEX-CORE-COMMAND_HOST: edgex-core-command
+      ROUTES_EDGEX-CORE-CONSUL_HOST: edgex-core-consul
       ROUTES_EDGEX-CORE-DATA_HOST: edgex-core-data
       ROUTES_EDGEX-CORE-METADATA_HOST: edgex-core-metadata
       ROUTES_EDGEX-SUPPORT-NOTIFICATIONS_HOST: edgex-support-notifications
@@ -1024,6 +1027,7 @@ services:
     user: 2002:2001
     volumes:
     - edgex-init:/edgex-init:ro,z
+    - consul-acl-token:/tmp/edgex/secrets/consul-acl-token:ro,z
     - /tmp/edgex/secrets/edgex-security-proxy-setup:/tmp/edgex/secrets/edgex-security-proxy-setup:ro,z
   rulesengine:
     container_name: edgex-kuiper

--- a/taf/docker-compose-taf-perf-arm64.yml
+++ b/taf/docker-compose-taf-perf-arm64.yml
@@ -237,7 +237,9 @@ services:
       ADD_REGISTRY_ACL_ROLES: app-http-export,app-mqtt-export,app-functional-tests,scalability-test-mqtt-export,edgex-device-rest
       API_GATEWAY_HOST: kong
       API_GATEWAY_STATUS_PORT: '8100'
+      EDGEX_GROUP: '2001'
       EDGEX_SECURITY_SECRET_STORE: "true"
+      EDGEX_USER: '2002'
       ENABLE_REGISTRY_ACL: "true"
       PROXY_SETUP_HOST: edgex-proxy-setup
       SECRETSTORE_HOST: edgex-vault
@@ -784,6 +786,7 @@ services:
       PROXY_SETUP_HOST: edgex-proxy-setup
       ROUTES_DEVICE-VIRTUAL_HOST: edgex-device-virtual
       ROUTES_EDGEX-CORE-COMMAND_HOST: edgex-core-command
+      ROUTES_EDGEX-CORE-CONSUL_HOST: edgex-core-consul
       ROUTES_EDGEX-CORE-DATA_HOST: edgex-core-data
       ROUTES_EDGEX-CORE-METADATA_HOST: edgex-core-metadata
       ROUTES_EDGEX-SUPPORT-NOTIFICATIONS_HOST: edgex-support-notifications
@@ -816,6 +819,7 @@ services:
     user: 2002:2001
     volumes:
     - edgex-init:/edgex-init:ro,z
+    - consul-acl-token:/tmp/edgex/secrets/consul-acl-token:ro,z
     - /tmp/edgex/secrets/edgex-security-proxy-setup:/tmp/edgex/secrets/edgex-security-proxy-setup:ro,z
   rulesengine:
     container_name: edgex-kuiper

--- a/taf/docker-compose-taf-perf.yml
+++ b/taf/docker-compose-taf-perf.yml
@@ -237,7 +237,9 @@ services:
       ADD_REGISTRY_ACL_ROLES: app-http-export,app-mqtt-export,app-functional-tests,scalability-test-mqtt-export,edgex-device-rest
       API_GATEWAY_HOST: kong
       API_GATEWAY_STATUS_PORT: '8100'
+      EDGEX_GROUP: '2001'
       EDGEX_SECURITY_SECRET_STORE: "true"
+      EDGEX_USER: '2002'
       ENABLE_REGISTRY_ACL: "true"
       PROXY_SETUP_HOST: edgex-proxy-setup
       SECRETSTORE_HOST: edgex-vault
@@ -784,6 +786,7 @@ services:
       PROXY_SETUP_HOST: edgex-proxy-setup
       ROUTES_DEVICE-VIRTUAL_HOST: edgex-device-virtual
       ROUTES_EDGEX-CORE-COMMAND_HOST: edgex-core-command
+      ROUTES_EDGEX-CORE-CONSUL_HOST: edgex-core-consul
       ROUTES_EDGEX-CORE-DATA_HOST: edgex-core-data
       ROUTES_EDGEX-CORE-METADATA_HOST: edgex-core-metadata
       ROUTES_EDGEX-SUPPORT-NOTIFICATIONS_HOST: edgex-support-notifications
@@ -816,6 +819,7 @@ services:
     user: 2002:2001
     volumes:
     - edgex-init:/edgex-init:ro,z
+    - consul-acl-token:/tmp/edgex/secrets/consul-acl-token:ro,z
     - /tmp/edgex/secrets/edgex-security-proxy-setup:/tmp/edgex/secrets/edgex-security-proxy-setup:ro,z
   rulesengine:
     container_name: edgex-kuiper

--- a/taf/docker-compose-taf.yml
+++ b/taf/docker-compose-taf.yml
@@ -369,7 +369,9 @@ services:
       ADD_REGISTRY_ACL_ROLES: app-http-export,app-mqtt-export,app-functional-tests,scalability-test-mqtt-export,edgex-device-modbus,edgex-device-rest
       API_GATEWAY_HOST: kong
       API_GATEWAY_STATUS_PORT: '8100'
+      EDGEX_GROUP: '2001'
       EDGEX_SECURITY_SECRET_STORE: "true"
+      EDGEX_USER: '2002'
       ENABLE_REGISTRY_ACL: "true"
       PROXY_SETUP_HOST: edgex-proxy-setup
       SECRETSTORE_HOST: edgex-vault
@@ -992,6 +994,7 @@ services:
       PROXY_SETUP_HOST: edgex-proxy-setup
       ROUTES_DEVICE-VIRTUAL_HOST: edgex-device-virtual
       ROUTES_EDGEX-CORE-COMMAND_HOST: edgex-core-command
+      ROUTES_EDGEX-CORE-CONSUL_HOST: edgex-core-consul
       ROUTES_EDGEX-CORE-DATA_HOST: edgex-core-data
       ROUTES_EDGEX-CORE-METADATA_HOST: edgex-core-metadata
       ROUTES_EDGEX-SUPPORT-NOTIFICATIONS_HOST: edgex-support-notifications
@@ -1024,6 +1027,7 @@ services:
     user: 2002:2001
     volumes:
     - edgex-init:/edgex-init:ro,z
+    - consul-acl-token:/tmp/edgex/secrets/consul-acl-token:ro,z
     - /tmp/edgex/secrets/edgex-security-proxy-setup:/tmp/edgex/secrets/edgex-security-proxy-setup:ro,z
   rulesengine:
     container_name: edgex-kuiper


### PR DESCRIPTION
- adding env. override for consul's route
- adding volume share between proxy-setup and consul for bootstrap acl token

Closes: #71

Signed-off-by: Jim Wang <yutsung.jim.wang@intel.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-examples/blob/master/.github/CONTRIBUTING.md.

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->
currently there is no consul service route in Kong

## Issue Number: #71 


## What is the new behavior?
added consul service route in Kong through proxy-setup and this depends on `edgex-go` PR https://github.com/edgexfoundry/edgex-go/pull/3391 and enabling Kong's Admin API PR https://github.com/edgexfoundry/edgex-compose/pull/60 in this repo.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x ] No

## New Imports
Are there any new imports or modules? If so, what are they used for and why?

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?
In draft mode until other two dependent PRs merged into master
1. edgex-go's adding consul service into kong's route PR: https://github.com/edgexfoundry/edgex-go/pull/3391 
2. edgex-compose's enabling Kong's Admin API PR https://github.com/edgexfoundry/edgex-compose/pull/60 in this repo.


## Other information