### PR TITLE
fix: Add command to V2 MQTT Broker for no-auth

### DIFF
--- a/compose-builder/add-mqtt-broker.yml
+++ b/compose-builder/add-mqtt-broker.yml
@@ -18,6 +18,7 @@ version: '3.7'
 services:
   mqtt-broker:
     image: eclipse-mosquitto:${MOSQUITTO_VERSION}
+    command: "/usr/sbin/mosquitto -c /mosquitto-no-auth.conf"
     ports:
       - "1883:1883"
     container_name: edgex-mqtt-broker

--- a/taf/docker-compose-taf-arm64.yml
+++ b/taf/docker-compose-taf-arm64.yml
@@ -904,6 +904,7 @@ services:
     - no-new-privileges:true
     user: 2002:2001
   mqtt-broker:
+    command: /usr/sbin/mosquitto -c /mosquitto-no-auth.conf
     container_name: edgex-mqtt-broker
     hostname: edgex-mqtt-broker
     image: eclipse-mosquitto:2.0

--- a/taf/docker-compose-taf-no-secty-arm64.yml
+++ b/taf/docker-compose-taf-no-secty-arm64.yml
@@ -436,6 +436,7 @@ services:
     - no-new-privileges:true
     user: 2002:2001
   mqtt-broker:
+    command: /usr/sbin/mosquitto -c /mosquitto-no-auth.conf
     container_name: edgex-mqtt-broker
     hostname: edgex-mqtt-broker
     image: eclipse-mosquitto:2.0

--- a/taf/docker-compose-taf-no-secty.yml
+++ b/taf/docker-compose-taf-no-secty.yml
@@ -436,6 +436,7 @@ services:
     - no-new-privileges:true
     user: 2002:2001
   mqtt-broker:
+    command: /usr/sbin/mosquitto -c /mosquitto-no-auth.conf
     container_name: edgex-mqtt-broker
     hostname: edgex-mqtt-broker
     image: eclipse-mosquitto:2.0

--- a/taf/docker-compose-taf-perf-arm64.yml
+++ b/taf/docker-compose-taf-perf-arm64.yml
@@ -696,6 +696,7 @@ services:
     - edgex-init:/edgex-init:ro,z
     - /tmp/edgex/secrets/edgex-core-metadata:/tmp/edgex/secrets/edgex-core-metadata:ro,z
   mqtt-broker:
+    command: /usr/sbin/mosquitto -c /mosquitto-no-auth.conf
     container_name: edgex-mqtt-broker
     hostname: edgex-mqtt-broker
     image: eclipse-mosquitto:2.0

--- a/taf/docker-compose-taf-perf-no-secty-arm64.yml
+++ b/taf/docker-compose-taf-perf-no-secty-arm64.yml
@@ -310,6 +310,7 @@ services:
     - no-new-privileges:true
     user: 2002:2001
   mqtt-broker:
+    command: /usr/sbin/mosquitto -c /mosquitto-no-auth.conf
     container_name: edgex-mqtt-broker
     hostname: edgex-mqtt-broker
     image: eclipse-mosquitto:2.0

--- a/taf/docker-compose-taf-perf-no-secty.yml
+++ b/taf/docker-compose-taf-perf-no-secty.yml
@@ -310,6 +310,7 @@ services:
     - no-new-privileges:true
     user: 2002:2001
   mqtt-broker:
+    command: /usr/sbin/mosquitto -c /mosquitto-no-auth.conf
     container_name: edgex-mqtt-broker
     hostname: edgex-mqtt-broker
     image: eclipse-mosquitto:2.0

--- a/taf/docker-compose-taf-perf.yml
+++ b/taf/docker-compose-taf-perf.yml
@@ -696,6 +696,7 @@ services:
     - edgex-init:/edgex-init:ro,z
     - /tmp/edgex/secrets/edgex-core-metadata:/tmp/edgex/secrets/edgex-core-metadata:ro,z
   mqtt-broker:
+    command: /usr/sbin/mosquitto -c /mosquitto-no-auth.conf
     container_name: edgex-mqtt-broker
     hostname: edgex-mqtt-broker
     image: eclipse-mosquitto:2.0

--- a/taf/docker-compose-taf.yml
+++ b/taf/docker-compose-taf.yml
@@ -904,6 +904,7 @@ services:
     - no-new-privileges:true
     user: 2002:2001
   mqtt-broker:
+    command: /usr/sbin/mosquitto -c /mosquitto-no-auth.conf
     container_name: edgex-mqtt-broker
     hostname: edgex-mqtt-broker
     image: eclipse-mosquitto:2.0


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-examples/blob/master/.github/CONTRIBUTING.md.

## What is the current behavior?
mosquitto V2 has a breaking change for default of  a allow_anonymous which is now false which breaks TAF tests.


## Issue Number: #81


## What is the new behavior?
Add `command:` to mosquitto (MQTT Broker) that selects built in no-auth config file with has allow_anonymous=true

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information