### PR TITLE
fix(security): Fix the issue of missing device-modbus's Kong route

### DIFF
--- a/compose-builder/Makefile
+++ b/compose-builder/Makefile
@@ -296,7 +296,7 @@ ifeq (taf-secty, $(filter taf-secty,$(ARGS)))
 	# Note that the services in this list should be separated by ';', but that causes issues with build scripts, so
 	# have to list them individually.
 	KNOWN_SECRETS_LIST:=redisdb[app-rules-engine],redisdb[app-http-export],redisdb[app-mqtt-export],redisdb[scalability-test-mqtt-export],redisdb[device-modbus],redisdb[device-rest]
-	EXTRA_PROXY_ROUTE_LIST:=edgex-device-modbus.http://device-modbus:59901
+	EXTRA_PROXY_ROUTE_LIST:=device-modbus.http://edgex-device-modbus:59901
 
 	COMPOSE_FILES:= \
 		-f docker-compose-base.yml \
@@ -346,7 +346,7 @@ else
 			# Note that the services in this list should be separated by ';', but that causes issues with build scripts, so
 			# have to list them individually.
 			KNOWN_SECRETS_LIST:=redisdb[app-rules-engine],redisdb[app-http-export],redisdb[app-mqtt-export],redisdb[scalability-test-mqtt-export],redisdb[device-rest]
-			EXTRA_PROXY_ROUTE_LIST:=edgex-device-modbus.http://device-modbus:59901
+			EXTRA_PROXY_ROUTE_LIST:=device-modbus.http://edgex-device-modbus:59901
 
     		COMPOSE_FILES:= \
     			-f docker-compose-base.yml \

--- a/compose-builder/Makefile
+++ b/compose-builder/Makefile
@@ -25,6 +25,7 @@ include .env
 COMPOSE_FILES:=-f docker-compose-base.yml
 TOKEN_LIST:=""
 KNOWN_SECRETS_LIST:="redisdb[app-rules-engine]"
+EXTRA_PROXY_ROUTE_LIST:=""
 GEN_EXT_DIR:=gen_ext_scty
 
 # Must have spaces around words for `filter-out` function to work properly.
@@ -295,6 +296,8 @@ ifeq (taf-secty, $(filter taf-secty,$(ARGS)))
 	# Note that the services in this list should be separated by ';', but that causes issues with build scripts, so
 	# have to list them individually.
 	KNOWN_SECRETS_LIST:=redisdb[app-rules-engine],redisdb[app-http-export],redisdb[app-mqtt-export],redisdb[scalability-test-mqtt-export],redisdb[device-modbus],redisdb[device-rest]
+	EXTRA_PROXY_ROUTE_LIST:=edgex-device-modbus.http://device-modbus:59901
+
 	COMPOSE_FILES:= \
 		-f docker-compose-base.yml \
 		-f add-security.yml \
@@ -343,6 +346,7 @@ else
 			# Note that the services in this list should be separated by ';', but that causes issues with build scripts, so
 			# have to list them individually.
 			KNOWN_SECRETS_LIST:=redisdb[app-rules-engine],redisdb[app-http-export],redisdb[app-mqtt-export],redisdb[scalability-test-mqtt-export],redisdb[device-rest]
+			EXTRA_PROXY_ROUTE_LIST:=edgex-device-modbus.http://device-modbus:59901
 
     		COMPOSE_FILES:= \
     			-f docker-compose-base.yml \
@@ -431,6 +435,7 @@ gen:
 	ARCH=$(ARCH) \
 	TOKEN_LIST=$(TOKEN_LIST) \
 	KNOWN_SECRETS_LIST=$(KNOWN_SECRETS_LIST) \
+	EXTRA_PROXY_ROUTE_LIST=$(EXTRA_PROXY_ROUTE_LIST) \
 	GEN_EXT_DIR=$(GEN_EXT_DIR) \
 	docker-compose -p edgex $(COMPOSE_FILES) config > docker-compose.yml
 	rm -rf ./$(GEN_EXT_DIR)
@@ -460,6 +465,7 @@ down: ui-down
 	ARCH= \
 	TOKEN_LIST= \
 	KNOWN_SECRETS_LIST= \
+	EXTRA_PROXY_ROUTE_LIST= \
 	docker-compose -p edgex \
 		-f docker-compose-base.yml \
 		-f add-device-bacnet.yml \

--- a/compose-builder/add-service-secure-template.yml
+++ b/compose-builder/add-service-secure-template.yml
@@ -25,6 +25,10 @@ services:
     environment:
       ADD_REGISTRY_ACL_ROLES: ${TOKEN_LIST}
 
+  proxy-setup:
+    environment:
+      ADD_PROXY_ROUTE: ${EXTRA_PROXY_ROUTE_LIST}
+
   ${SERVICE_NAME}:
     entrypoint: ["/edgex-init/ready_to_run_wait_install.sh"]
     command: "/${EXECUTABLE} ${DEFAULT_EDGEX_RUN_CMD_PARMS}"

--- a/docker-compose-arm64.yml
+++ b/docker-compose-arm64.yml
@@ -638,6 +638,7 @@ services:
     entrypoint:
     - /edgex-init/proxy_setup_wait_install.sh
     environment:
+      ADD_PROXY_ROUTE: ''
       API_GATEWAY_HOST: kong
       API_GATEWAY_STATUS_PORT: '8100'
       EDGEX_SECURITY_SECRET_STORE: "true"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -638,6 +638,7 @@ services:
     entrypoint:
     - /edgex-init/proxy_setup_wait_install.sh
     environment:
+      ADD_PROXY_ROUTE: ''
       API_GATEWAY_HOST: kong
       API_GATEWAY_STATUS_PORT: '8100'
       EDGEX_SECURITY_SECRET_STORE: "true"

--- a/taf/docker-compose-taf-arm64.yml
+++ b/taf/docker-compose-taf-arm64.yml
@@ -901,7 +901,7 @@ services:
     entrypoint:
     - /edgex-init/proxy_setup_wait_install.sh
     environment:
-      ADD_PROXY_ROUTE: edgex-device-modbus.http://device-modbus:59901
+      ADD_PROXY_ROUTE: device-modbus.http://edgex-device-modbus:59901
       API_GATEWAY_HOST: kong
       API_GATEWAY_STATUS_PORT: '8100'
       EDGEX_SECURITY_SECRET_STORE: "true"

--- a/taf/docker-compose-taf-arm64.yml
+++ b/taf/docker-compose-taf-arm64.yml
@@ -901,6 +901,7 @@ services:
     entrypoint:
     - /edgex-init/proxy_setup_wait_install.sh
     environment:
+      ADD_PROXY_ROUTE: edgex-device-modbus.http://device-modbus:59901
       API_GATEWAY_HOST: kong
       API_GATEWAY_STATUS_PORT: '8100'
       EDGEX_SECURITY_SECRET_STORE: "true"

--- a/taf/docker-compose-taf-perf-arm64.yml
+++ b/taf/docker-compose-taf-perf-arm64.yml
@@ -715,7 +715,7 @@ services:
     entrypoint:
     - /edgex-init/proxy_setup_wait_install.sh
     environment:
-      ADD_PROXY_ROUTE: edgex-device-modbus.http://device-modbus:59901
+      ADD_PROXY_ROUTE: device-modbus.http://edgex-device-modbus:59901
       API_GATEWAY_HOST: kong
       API_GATEWAY_STATUS_PORT: '8100'
       EDGEX_SECURITY_SECRET_STORE: "true"

--- a/taf/docker-compose-taf-perf-arm64.yml
+++ b/taf/docker-compose-taf-perf-arm64.yml
@@ -715,6 +715,7 @@ services:
     entrypoint:
     - /edgex-init/proxy_setup_wait_install.sh
     environment:
+      ADD_PROXY_ROUTE: edgex-device-modbus.http://device-modbus:59901
       API_GATEWAY_HOST: kong
       API_GATEWAY_STATUS_PORT: '8100'
       EDGEX_SECURITY_SECRET_STORE: "true"

--- a/taf/docker-compose-taf-perf.yml
+++ b/taf/docker-compose-taf-perf.yml
@@ -715,7 +715,7 @@ services:
     entrypoint:
     - /edgex-init/proxy_setup_wait_install.sh
     environment:
-      ADD_PROXY_ROUTE: edgex-device-modbus.http://device-modbus:59901
+      ADD_PROXY_ROUTE: device-modbus.http://edgex-device-modbus:59901
       API_GATEWAY_HOST: kong
       API_GATEWAY_STATUS_PORT: '8100'
       EDGEX_SECURITY_SECRET_STORE: "true"

--- a/taf/docker-compose-taf-perf.yml
+++ b/taf/docker-compose-taf-perf.yml
@@ -715,6 +715,7 @@ services:
     entrypoint:
     - /edgex-init/proxy_setup_wait_install.sh
     environment:
+      ADD_PROXY_ROUTE: edgex-device-modbus.http://device-modbus:59901
       API_GATEWAY_HOST: kong
       API_GATEWAY_STATUS_PORT: '8100'
       EDGEX_SECURITY_SECRET_STORE: "true"

--- a/taf/docker-compose-taf.yml
+++ b/taf/docker-compose-taf.yml
@@ -901,7 +901,7 @@ services:
     entrypoint:
     - /edgex-init/proxy_setup_wait_install.sh
     environment:
-      ADD_PROXY_ROUTE: edgex-device-modbus.http://device-modbus:59901
+      ADD_PROXY_ROUTE: device-modbus.http://edgex-device-modbus:59901
       API_GATEWAY_HOST: kong
       API_GATEWAY_STATUS_PORT: '8100'
       EDGEX_SECURITY_SECRET_STORE: "true"

--- a/taf/docker-compose-taf.yml
+++ b/taf/docker-compose-taf.yml
@@ -901,6 +901,7 @@ services:
     entrypoint:
     - /edgex-init/proxy_setup_wait_install.sh
     environment:
+      ADD_PROXY_ROUTE: edgex-device-modbus.http://device-modbus:59901
       API_GATEWAY_HOST: kong
       API_GATEWAY_STATUS_PORT: '8100'
       EDGEX_SECURITY_SECRET_STORE: "true"


### PR DESCRIPTION
Fix the missing Kong route of `device-modbus` on TAF test using env `ADD_PROXY_ROUTE` of `proxy-setup`

Fixes: #100

Signed-off-by: Jim Wang <yutsung.jim.wang@intel.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-examples/blob/master/.github/CONTRIBUTING.md.

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->
kong route seems to be missing based on the error log of TAF testing on `device-modbus` through Kong.

## Issue Number:  #100 


## What is the new behavior?
Added kong route through env `ADD_PROXY_ROUTE` for device-modbus.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x ] No

## New Imports
Are there any new imports or modules? If so, what are they used for and why?

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information