### PR TITLE
feat: Add Secure MessageBus credentials injection for Kuiper

### DIFF
--- a/compose-builder/Makefile
+++ b/compose-builder/Makefile
@@ -279,6 +279,12 @@ ifeq (no-secty, $(filter no-secty,$(ARGS)))
 	NO_SECURITY:=-no-secty
 else
 	COMPOSE_FILES:=$(COMPOSE_FILES) -f add-security.yml
+	ifneq (mqtt-bus, $(filter mqtt-bus,$(ARGS)))
+		ifneq (zmq-bus, $(filter zmq-bus,$(ARGS)))
+		    # Using secure redis messagebus by default if MQTT/ZMQ bus not specified
+			COMPOSE_FILES:=$(COMPOSE_FILES) -f add-secure-redis-messagebus.yml
+		endif
+	endif
 endif
 
 ifeq (ui, $(filter ui,$(ARGS)))
@@ -301,6 +307,7 @@ ifeq (taf-secty, $(filter taf-secty,$(ARGS)))
 	COMPOSE_FILES:= \
 		-f docker-compose-base.yml \
 		-f add-security.yml \
+		-f add-secure-redis-messagebus.yml \
 		-f add-taf-app-services.yml \
 		-f add-taf-app-services-secure.yml \
 		-f add-asc-http-export.yml \
@@ -351,6 +358,7 @@ else
     		COMPOSE_FILES:= \
     			-f docker-compose-base.yml \
     			-f add-security.yml \
+    			-f add-secure-redis-messagebus.yml \
     			-f add-asc-mqtt-export.yml \
     			-f add-device-virtual.yml \
     			-f add-device-rest.yml \

--- a/compose-builder/README.md
+++ b/compose-builder/README.md
@@ -41,6 +41,8 @@ This folder contains the following compose files:
     Base non-secure mode compose file. Contains all the services that run in the non-secure configuration.  
 - **add-security.yml**
     Security **extending** compose file. Adds the additional security services and configuration of services so that all the services are running in the secure configuration.
+- **add-secure-redis-messagebus.yml**
+    Secure Redis MessageBus **extending** compose file. Adds the additional security configuration for when Redis is used as MessageBus in secure mode so Kuiper can connect to the secure MesssageBus.
 - **add-device-bacnet.yml**
     Device Service **extending** compose file, which adds the **Device Bacnet**  service.
 - **add-device-camera.yml**
@@ -80,7 +82,6 @@ This folder contains the following compose files:
     TAF Device Services **extending** compose file. Modifies setting of Device Virtual and Device Modbus for the TAF testing compose files. **Must be used in conjunction with add-device-modbus.yml and add-device-virtual.yml**
 - **add-ui.yml**
     UI **extending** compose file, which adds the **Edgex UI** service.
-
 - **stand-alone-ui.yml**
     Stand-alone **extending** compose file for running the optional EdgeX UI stand-alone.    Used in conjunction with the **add-ui.yml** file. This file just sets up the external network for the UI to run stand-alone and be able to communicate with the EdgeX stack. It makes the assumption the stack was started with the `-p=edgex` option. 
 

--- a/compose-builder/add-secure-redis-messagebus.yml
+++ b/compose-builder/add-secure-redis-messagebus.yml
@@ -26,7 +26,13 @@ services:
       SECUREMESSAGEBUS_TYPE: redis
 
   rulesengine:
+    entrypoint: [ "/edgex-init/kuiper_wait_install.sh" ]
+    env_file:
+      - common-sec-stage-gate.env
     volumes:
       - kuiper-config:/kuiper/etc/sources:z
+      - edgex-init:/edgex-init:ro,z
     depends_on:
+      - security-bootstrapper
       - secretstore-setup
+      - database

--- a/compose-builder/add-secure-redis-messagebus.yml
+++ b/compose-builder/add-secure-redis-messagebus.yml
@@ -1,0 +1,32 @@
+# /*******************************************************************************
+#  * Copyright 2021 Intel Corporation.
+#  *
+#  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+#  * in compliance with the License. You may obtain a copy of the License at
+#  *
+#  * http://www.apache.org/licenses/LICENSE-2.0
+#  *
+#  * Unless required by applicable law or agreed to in writing, software distributed under the License
+#  * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  * or implied. See the License for the specific language governing permissions and limitations under
+#  * the License.
+#  *
+#  *******************************************************************************/
+
+version: '3.7'
+
+volumes:
+  kuiper-config:
+
+services:
+  secretstore-setup:
+    volumes:
+      - kuiper-config:/tmp/kuiper:z
+    environment:
+      SECUREMESSAGEBUS_TYPE: redis
+
+  rulesengine:
+    volumes:
+      - kuiper-config:/kuiper/etc/sources:z
+    depends_on:
+      - secretstore-setup

--- a/compose-builder/docker-compose-base.yml
+++ b/compose-builder/docker-compose-base.yml
@@ -233,10 +233,9 @@ services:
     volumes:
       - kuiper-data:/kuiper/data:z
     environment:
-#      KUIPER_DEBUG: "true"
+#      KUIPER__BASIC__DEBUG: "true"
       KUIPER__BASIC__CONSOLELOG: "true"
       KUIPER__BASIC__RESTPORT: 59720
-      EDGEX__DEFAULT__SERVICESERVER: http://edgex-metadata-data:59881
       EDGEX__DEFAULT__TYPE: redis
       EDGEX__DEFAULT__SERVER: edgex-redis
       EDGEX__DEFAULT__PROTOCOL: redis

--- a/docker-compose-arm64.yml
+++ b/docker-compose-arm64.yml
@@ -687,11 +687,11 @@ services:
     container_name: edgex-kuiper
     depends_on:
     - database
+    - secretstore-setup
     environment:
       EDGEX__DEFAULT__PORT: 6379
       EDGEX__DEFAULT__PROTOCOL: redis
       EDGEX__DEFAULT__SERVER: edgex-redis
-      EDGEX__DEFAULT__SERVICESERVER: http://edgex-metadata-data:59881
       EDGEX__DEFAULT__TOPIC: rules-events
       EDGEX__DEFAULT__TYPE: redis
       KUIPER__BASIC__CONSOLELOG: "true"
@@ -708,6 +708,7 @@ services:
     user: kuiper:kuiper
     volumes:
     - kuiper-data:/kuiper/data:z
+    - kuiper-config:/kuiper/etc/sources:z
   scheduler:
     command: /support-scheduler -cp=consul.http://edgex-core-consul:8500 --registry
       --confdir=/res
@@ -781,6 +782,7 @@ services:
       PROXY_SETUP_HOST: edgex-proxy-setup
       SECRETSTORE_HOST: edgex-vault
       SECRETSTORE_PORT: '8200'
+      SECUREMESSAGEBUS_TYPE: redis
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
       STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
       STAGEGATE_DATABASE_HOST: edgex-redis
@@ -811,6 +813,7 @@ services:
     - edgex-init:/edgex-init:ro,z
     - /tmp/edgex/secrets:/tmp/edgex/secrets:z
     - kong:/tmp/kong:z
+    - kuiper-config:/tmp/kuiper:z
     - vault-config:/vault/config:z
   security-bootstrapper:
     container_name: edgex-security-bootstrapper
@@ -957,6 +960,7 @@ volumes:
   db-data: {}
   edgex-init: {}
   kong: {}
+  kuiper-config: {}
   kuiper-data: {}
   postgres-config: {}
   postgres-data: {}

--- a/docker-compose-arm64.yml
+++ b/docker-compose-arm64.yml
@@ -688,7 +688,12 @@ services:
     depends_on:
     - database
     - secretstore-setup
+    - security-bootstrapper
+    entrypoint:
+    - /edgex-init/kuiper_wait_install.sh
     environment:
+      API_GATEWAY_HOST: kong
+      API_GATEWAY_STATUS_PORT: '8100'
       EDGEX__DEFAULT__PORT: 6379
       EDGEX__DEFAULT__PROTOCOL: redis
       EDGEX__DEFAULT__SERVER: edgex-redis
@@ -696,6 +701,22 @@ services:
       EDGEX__DEFAULT__TYPE: redis
       KUIPER__BASIC__CONSOLELOG: "true"
       KUIPER__BASIC__RESTPORT: 59720
+      PROXY_SETUP_HOST: edgex-proxy-setup
+      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_DATABASE_HOST: edgex-redis
+      STAGEGATE_DATABASE_PORT: '6379'
+      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_KONGDB_HOST: kong-db
+      STAGEGATE_KONGDB_PORT: '5432'
+      STAGEGATE_KONGDB_READYPORT: '54325'
+      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_REGISTRY_HOST: edgex-core-consul
+      STAGEGATE_REGISTRY_PORT: '8500'
+      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_SECRETSTORESETUP_HOST: edgex-secretstore-setup
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-kuiper
     image: emqx/kuiper:1.2.1-beta.0-alpine
     networks:
@@ -707,6 +728,7 @@ services:
     - no-new-privileges:true
     user: kuiper:kuiper
     volumes:
+    - edgex-init:/edgex-init:ro,z
     - kuiper-data:/kuiper/data:z
     - kuiper-config:/kuiper/etc/sources:z
   scheduler:

--- a/docker-compose-no-secty-arm64.yml
+++ b/docker-compose-no-secty-arm64.yml
@@ -268,7 +268,6 @@ services:
       EDGEX__DEFAULT__PORT: 6379
       EDGEX__DEFAULT__PROTOCOL: redis
       EDGEX__DEFAULT__SERVER: edgex-redis
-      EDGEX__DEFAULT__SERVICESERVER: http://edgex-metadata-data:59881
       EDGEX__DEFAULT__TOPIC: rules-events
       EDGEX__DEFAULT__TYPE: redis
       KUIPER__BASIC__CONSOLELOG: "true"

--- a/docker-compose-no-secty.yml
+++ b/docker-compose-no-secty.yml
@@ -268,7 +268,6 @@ services:
       EDGEX__DEFAULT__PORT: 6379
       EDGEX__DEFAULT__PROTOCOL: redis
       EDGEX__DEFAULT__SERVER: edgex-redis
-      EDGEX__DEFAULT__SERVICESERVER: http://edgex-metadata-data:59881
       EDGEX__DEFAULT__TOPIC: rules-events
       EDGEX__DEFAULT__TYPE: redis
       KUIPER__BASIC__CONSOLELOG: "true"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -687,11 +687,11 @@ services:
     container_name: edgex-kuiper
     depends_on:
     - database
+    - secretstore-setup
     environment:
       EDGEX__DEFAULT__PORT: 6379
       EDGEX__DEFAULT__PROTOCOL: redis
       EDGEX__DEFAULT__SERVER: edgex-redis
-      EDGEX__DEFAULT__SERVICESERVER: http://edgex-metadata-data:59881
       EDGEX__DEFAULT__TOPIC: rules-events
       EDGEX__DEFAULT__TYPE: redis
       KUIPER__BASIC__CONSOLELOG: "true"
@@ -708,6 +708,7 @@ services:
     user: kuiper:kuiper
     volumes:
     - kuiper-data:/kuiper/data:z
+    - kuiper-config:/kuiper/etc/sources:z
   scheduler:
     command: /support-scheduler -cp=consul.http://edgex-core-consul:8500 --registry
       --confdir=/res
@@ -781,6 +782,7 @@ services:
       PROXY_SETUP_HOST: edgex-proxy-setup
       SECRETSTORE_HOST: edgex-vault
       SECRETSTORE_PORT: '8200'
+      SECUREMESSAGEBUS_TYPE: redis
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
       STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
       STAGEGATE_DATABASE_HOST: edgex-redis
@@ -811,6 +813,7 @@ services:
     - edgex-init:/edgex-init:ro,z
     - /tmp/edgex/secrets:/tmp/edgex/secrets:z
     - kong:/tmp/kong:z
+    - kuiper-config:/tmp/kuiper:z
     - vault-config:/vault/config:z
   security-bootstrapper:
     container_name: edgex-security-bootstrapper
@@ -957,6 +960,7 @@ volumes:
   db-data: {}
   edgex-init: {}
   kong: {}
+  kuiper-config: {}
   kuiper-data: {}
   postgres-config: {}
   postgres-data: {}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -688,7 +688,12 @@ services:
     depends_on:
     - database
     - secretstore-setup
+    - security-bootstrapper
+    entrypoint:
+    - /edgex-init/kuiper_wait_install.sh
     environment:
+      API_GATEWAY_HOST: kong
+      API_GATEWAY_STATUS_PORT: '8100'
       EDGEX__DEFAULT__PORT: 6379
       EDGEX__DEFAULT__PROTOCOL: redis
       EDGEX__DEFAULT__SERVER: edgex-redis
@@ -696,6 +701,22 @@ services:
       EDGEX__DEFAULT__TYPE: redis
       KUIPER__BASIC__CONSOLELOG: "true"
       KUIPER__BASIC__RESTPORT: 59720
+      PROXY_SETUP_HOST: edgex-proxy-setup
+      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_DATABASE_HOST: edgex-redis
+      STAGEGATE_DATABASE_PORT: '6379'
+      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_KONGDB_HOST: kong-db
+      STAGEGATE_KONGDB_PORT: '5432'
+      STAGEGATE_KONGDB_READYPORT: '54325'
+      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_REGISTRY_HOST: edgex-core-consul
+      STAGEGATE_REGISTRY_PORT: '8500'
+      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_SECRETSTORESETUP_HOST: edgex-secretstore-setup
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-kuiper
     image: emqx/kuiper:1.2.1-beta.0-alpine
     networks:
@@ -707,6 +728,7 @@ services:
     - no-new-privileges:true
     user: kuiper:kuiper
     volumes:
+    - edgex-init:/edgex-init:ro,z
     - kuiper-data:/kuiper/data:z
     - kuiper-config:/kuiper/etc/sources:z
   scheduler:

--- a/taf/docker-compose-taf-arm64.yml
+++ b/taf/docker-compose-taf-arm64.yml
@@ -950,11 +950,11 @@ services:
     container_name: edgex-kuiper
     depends_on:
     - database
+    - secretstore-setup
     environment:
       EDGEX__DEFAULT__PORT: 6379
       EDGEX__DEFAULT__PROTOCOL: redis
       EDGEX__DEFAULT__SERVER: edgex-redis
-      EDGEX__DEFAULT__SERVICESERVER: http://edgex-metadata-data:59881
       EDGEX__DEFAULT__TOPIC: rules-events
       EDGEX__DEFAULT__TYPE: redis
       KUIPER__BASIC__CONSOLELOG: "true"
@@ -971,6 +971,7 @@ services:
     user: kuiper:kuiper
     volumes:
     - kuiper-data:/kuiper/data:z
+    - kuiper-config:/kuiper/etc/sources:z
   scalability-test-mqtt-export:
     command: /app-service-configurable -cp=consul.http://edgex-core-consul:8500 --registry
       --confdir=/res
@@ -1109,6 +1110,7 @@ services:
       PROXY_SETUP_HOST: edgex-proxy-setup
       SECRETSTORE_HOST: edgex-vault
       SECRETSTORE_PORT: '8200'
+      SECUREMESSAGEBUS_TYPE: redis
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
       STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
       STAGEGATE_DATABASE_HOST: edgex-redis
@@ -1139,6 +1141,7 @@ services:
     - edgex-init:/edgex-init:ro,z
     - /tmp/edgex/secrets:/tmp/edgex/secrets:z
     - kong:/tmp/kong:z
+    - kuiper-config:/tmp/kuiper:z
     - vault-config:/vault/config:z
   security-bootstrapper:
     container_name: edgex-security-bootstrapper
@@ -1286,6 +1289,7 @@ volumes:
   db-data: {}
   edgex-init: {}
   kong: {}
+  kuiper-config: {}
   kuiper-data: {}
   postgres-config: {}
   postgres-data: {}

--- a/taf/docker-compose-taf-arm64.yml
+++ b/taf/docker-compose-taf-arm64.yml
@@ -951,7 +951,12 @@ services:
     depends_on:
     - database
     - secretstore-setup
+    - security-bootstrapper
+    entrypoint:
+    - /edgex-init/kuiper_wait_install.sh
     environment:
+      API_GATEWAY_HOST: kong
+      API_GATEWAY_STATUS_PORT: '8100'
       EDGEX__DEFAULT__PORT: 6379
       EDGEX__DEFAULT__PROTOCOL: redis
       EDGEX__DEFAULT__SERVER: edgex-redis
@@ -959,6 +964,22 @@ services:
       EDGEX__DEFAULT__TYPE: redis
       KUIPER__BASIC__CONSOLELOG: "true"
       KUIPER__BASIC__RESTPORT: 59720
+      PROXY_SETUP_HOST: edgex-proxy-setup
+      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_DATABASE_HOST: edgex-redis
+      STAGEGATE_DATABASE_PORT: '6379'
+      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_KONGDB_HOST: kong-db
+      STAGEGATE_KONGDB_PORT: '5432'
+      STAGEGATE_KONGDB_READYPORT: '54325'
+      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_REGISTRY_HOST: edgex-core-consul
+      STAGEGATE_REGISTRY_PORT: '8500'
+      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_SECRETSTORESETUP_HOST: edgex-secretstore-setup
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-kuiper
     image: emqx/kuiper:1.2.1-beta.0-alpine
     networks:
@@ -970,6 +991,7 @@ services:
     - no-new-privileges:true
     user: kuiper:kuiper
     volumes:
+    - edgex-init:/edgex-init:ro,z
     - kuiper-data:/kuiper/data:z
     - kuiper-config:/kuiper/etc/sources:z
   scalability-test-mqtt-export:

--- a/taf/docker-compose-taf-no-secty-arm64.yml
+++ b/taf/docker-compose-taf-no-secty-arm64.yml
@@ -421,7 +421,6 @@ services:
       EDGEX__DEFAULT__PORT: 6379
       EDGEX__DEFAULT__PROTOCOL: redis
       EDGEX__DEFAULT__SERVER: edgex-redis
-      EDGEX__DEFAULT__SERVICESERVER: http://edgex-metadata-data:59881
       EDGEX__DEFAULT__TOPIC: rules-events
       EDGEX__DEFAULT__TYPE: redis
       KUIPER__BASIC__CONSOLELOG: "true"

--- a/taf/docker-compose-taf-no-secty.yml
+++ b/taf/docker-compose-taf-no-secty.yml
@@ -421,7 +421,6 @@ services:
       EDGEX__DEFAULT__PORT: 6379
       EDGEX__DEFAULT__PROTOCOL: redis
       EDGEX__DEFAULT__SERVER: edgex-redis
-      EDGEX__DEFAULT__SERVICESERVER: http://edgex-metadata-data:59881
       EDGEX__DEFAULT__TOPIC: rules-events
       EDGEX__DEFAULT__TYPE: redis
       KUIPER__BASIC__CONSOLELOG: "true"

--- a/taf/docker-compose-taf-perf-arm64.yml
+++ b/taf/docker-compose-taf-perf-arm64.yml
@@ -765,7 +765,12 @@ services:
     depends_on:
     - database
     - secretstore-setup
+    - security-bootstrapper
+    entrypoint:
+    - /edgex-init/kuiper_wait_install.sh
     environment:
+      API_GATEWAY_HOST: kong
+      API_GATEWAY_STATUS_PORT: '8100'
       EDGEX__DEFAULT__PORT: 6379
       EDGEX__DEFAULT__PROTOCOL: redis
       EDGEX__DEFAULT__SERVER: edgex-redis
@@ -773,6 +778,22 @@ services:
       EDGEX__DEFAULT__TYPE: redis
       KUIPER__BASIC__CONSOLELOG: "true"
       KUIPER__BASIC__RESTPORT: 59720
+      PROXY_SETUP_HOST: edgex-proxy-setup
+      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_DATABASE_HOST: edgex-redis
+      STAGEGATE_DATABASE_PORT: '6379'
+      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_KONGDB_HOST: kong-db
+      STAGEGATE_KONGDB_PORT: '5432'
+      STAGEGATE_KONGDB_READYPORT: '54325'
+      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_REGISTRY_HOST: edgex-core-consul
+      STAGEGATE_REGISTRY_PORT: '8500'
+      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_SECRETSTORESETUP_HOST: edgex-secretstore-setup
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-kuiper
     image: emqx/kuiper:1.2.1-beta.0-alpine
     networks:
@@ -784,6 +805,7 @@ services:
     - no-new-privileges:true
     user: kuiper:kuiper
     volumes:
+    - edgex-init:/edgex-init:ro,z
     - kuiper-data:/kuiper/data:z
     - kuiper-config:/kuiper/etc/sources:z
   scheduler:

--- a/taf/docker-compose-taf-perf-arm64.yml
+++ b/taf/docker-compose-taf-perf-arm64.yml
@@ -764,11 +764,11 @@ services:
     container_name: edgex-kuiper
     depends_on:
     - database
+    - secretstore-setup
     environment:
       EDGEX__DEFAULT__PORT: 6379
       EDGEX__DEFAULT__PROTOCOL: redis
       EDGEX__DEFAULT__SERVER: edgex-redis
-      EDGEX__DEFAULT__SERVICESERVER: http://edgex-metadata-data:59881
       EDGEX__DEFAULT__TOPIC: rules-events
       EDGEX__DEFAULT__TYPE: redis
       KUIPER__BASIC__CONSOLELOG: "true"
@@ -785,6 +785,7 @@ services:
     user: kuiper:kuiper
     volumes:
     - kuiper-data:/kuiper/data:z
+    - kuiper-config:/kuiper/etc/sources:z
   scheduler:
     command: /support-scheduler -cp=consul.http://edgex-core-consul:8500 --registry
       --confdir=/res
@@ -858,6 +859,7 @@ services:
       PROXY_SETUP_HOST: edgex-proxy-setup
       SECRETSTORE_HOST: edgex-vault
       SECRETSTORE_PORT: '8200'
+      SECUREMESSAGEBUS_TYPE: redis
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
       STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
       STAGEGATE_DATABASE_HOST: edgex-redis
@@ -888,6 +890,7 @@ services:
     - edgex-init:/edgex-init:ro,z
     - /tmp/edgex/secrets:/tmp/edgex/secrets:z
     - kong:/tmp/kong:z
+    - kuiper-config:/tmp/kuiper:z
     - vault-config:/vault/config:z
   security-bootstrapper:
     container_name: edgex-security-bootstrapper
@@ -1034,6 +1037,7 @@ volumes:
   db-data: {}
   edgex-init: {}
   kong: {}
+  kuiper-config: {}
   kuiper-data: {}
   postgres-config: {}
   postgres-data: {}

--- a/taf/docker-compose-taf-perf-no-secty-arm64.yml
+++ b/taf/docker-compose-taf-perf-no-secty-arm64.yml
@@ -314,7 +314,6 @@ services:
       EDGEX__DEFAULT__PORT: 6379
       EDGEX__DEFAULT__PROTOCOL: redis
       EDGEX__DEFAULT__SERVER: edgex-redis
-      EDGEX__DEFAULT__SERVICESERVER: http://edgex-metadata-data:59881
       EDGEX__DEFAULT__TOPIC: rules-events
       EDGEX__DEFAULT__TYPE: redis
       KUIPER__BASIC__CONSOLELOG: "true"

--- a/taf/docker-compose-taf-perf-no-secty.yml
+++ b/taf/docker-compose-taf-perf-no-secty.yml
@@ -314,7 +314,6 @@ services:
       EDGEX__DEFAULT__PORT: 6379
       EDGEX__DEFAULT__PROTOCOL: redis
       EDGEX__DEFAULT__SERVER: edgex-redis
-      EDGEX__DEFAULT__SERVICESERVER: http://edgex-metadata-data:59881
       EDGEX__DEFAULT__TOPIC: rules-events
       EDGEX__DEFAULT__TYPE: redis
       KUIPER__BASIC__CONSOLELOG: "true"

--- a/taf/docker-compose-taf-perf.yml
+++ b/taf/docker-compose-taf-perf.yml
@@ -765,7 +765,12 @@ services:
     depends_on:
     - database
     - secretstore-setup
+    - security-bootstrapper
+    entrypoint:
+    - /edgex-init/kuiper_wait_install.sh
     environment:
+      API_GATEWAY_HOST: kong
+      API_GATEWAY_STATUS_PORT: '8100'
       EDGEX__DEFAULT__PORT: 6379
       EDGEX__DEFAULT__PROTOCOL: redis
       EDGEX__DEFAULT__SERVER: edgex-redis
@@ -773,6 +778,22 @@ services:
       EDGEX__DEFAULT__TYPE: redis
       KUIPER__BASIC__CONSOLELOG: "true"
       KUIPER__BASIC__RESTPORT: 59720
+      PROXY_SETUP_HOST: edgex-proxy-setup
+      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_DATABASE_HOST: edgex-redis
+      STAGEGATE_DATABASE_PORT: '6379'
+      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_KONGDB_HOST: kong-db
+      STAGEGATE_KONGDB_PORT: '5432'
+      STAGEGATE_KONGDB_READYPORT: '54325'
+      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_REGISTRY_HOST: edgex-core-consul
+      STAGEGATE_REGISTRY_PORT: '8500'
+      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_SECRETSTORESETUP_HOST: edgex-secretstore-setup
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-kuiper
     image: emqx/kuiper:1.2.1-beta.0-alpine
     networks:
@@ -784,6 +805,7 @@ services:
     - no-new-privileges:true
     user: kuiper:kuiper
     volumes:
+    - edgex-init:/edgex-init:ro,z
     - kuiper-data:/kuiper/data:z
     - kuiper-config:/kuiper/etc/sources:z
   scheduler:

--- a/taf/docker-compose-taf-perf.yml
+++ b/taf/docker-compose-taf-perf.yml
@@ -764,11 +764,11 @@ services:
     container_name: edgex-kuiper
     depends_on:
     - database
+    - secretstore-setup
     environment:
       EDGEX__DEFAULT__PORT: 6379
       EDGEX__DEFAULT__PROTOCOL: redis
       EDGEX__DEFAULT__SERVER: edgex-redis
-      EDGEX__DEFAULT__SERVICESERVER: http://edgex-metadata-data:59881
       EDGEX__DEFAULT__TOPIC: rules-events
       EDGEX__DEFAULT__TYPE: redis
       KUIPER__BASIC__CONSOLELOG: "true"
@@ -785,6 +785,7 @@ services:
     user: kuiper:kuiper
     volumes:
     - kuiper-data:/kuiper/data:z
+    - kuiper-config:/kuiper/etc/sources:z
   scheduler:
     command: /support-scheduler -cp=consul.http://edgex-core-consul:8500 --registry
       --confdir=/res
@@ -858,6 +859,7 @@ services:
       PROXY_SETUP_HOST: edgex-proxy-setup
       SECRETSTORE_HOST: edgex-vault
       SECRETSTORE_PORT: '8200'
+      SECUREMESSAGEBUS_TYPE: redis
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
       STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
       STAGEGATE_DATABASE_HOST: edgex-redis
@@ -888,6 +890,7 @@ services:
     - edgex-init:/edgex-init:ro,z
     - /tmp/edgex/secrets:/tmp/edgex/secrets:z
     - kong:/tmp/kong:z
+    - kuiper-config:/tmp/kuiper:z
     - vault-config:/vault/config:z
   security-bootstrapper:
     container_name: edgex-security-bootstrapper
@@ -1034,6 +1037,7 @@ volumes:
   db-data: {}
   edgex-init: {}
   kong: {}
+  kuiper-config: {}
   kuiper-data: {}
   postgres-config: {}
   postgres-data: {}

--- a/taf/docker-compose-taf.yml
+++ b/taf/docker-compose-taf.yml
@@ -950,11 +950,11 @@ services:
     container_name: edgex-kuiper
     depends_on:
     - database
+    - secretstore-setup
     environment:
       EDGEX__DEFAULT__PORT: 6379
       EDGEX__DEFAULT__PROTOCOL: redis
       EDGEX__DEFAULT__SERVER: edgex-redis
-      EDGEX__DEFAULT__SERVICESERVER: http://edgex-metadata-data:59881
       EDGEX__DEFAULT__TOPIC: rules-events
       EDGEX__DEFAULT__TYPE: redis
       KUIPER__BASIC__CONSOLELOG: "true"
@@ -971,6 +971,7 @@ services:
     user: kuiper:kuiper
     volumes:
     - kuiper-data:/kuiper/data:z
+    - kuiper-config:/kuiper/etc/sources:z
   scalability-test-mqtt-export:
     command: /app-service-configurable -cp=consul.http://edgex-core-consul:8500 --registry
       --confdir=/res
@@ -1109,6 +1110,7 @@ services:
       PROXY_SETUP_HOST: edgex-proxy-setup
       SECRETSTORE_HOST: edgex-vault
       SECRETSTORE_PORT: '8200'
+      SECUREMESSAGEBUS_TYPE: redis
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
       STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
       STAGEGATE_DATABASE_HOST: edgex-redis
@@ -1139,6 +1141,7 @@ services:
     - edgex-init:/edgex-init:ro,z
     - /tmp/edgex/secrets:/tmp/edgex/secrets:z
     - kong:/tmp/kong:z
+    - kuiper-config:/tmp/kuiper:z
     - vault-config:/vault/config:z
   security-bootstrapper:
     container_name: edgex-security-bootstrapper
@@ -1286,6 +1289,7 @@ volumes:
   db-data: {}
   edgex-init: {}
   kong: {}
+  kuiper-config: {}
   kuiper-data: {}
   postgres-config: {}
   postgres-data: {}

--- a/taf/docker-compose-taf.yml
+++ b/taf/docker-compose-taf.yml
@@ -951,7 +951,12 @@ services:
     depends_on:
     - database
     - secretstore-setup
+    - security-bootstrapper
+    entrypoint:
+    - /edgex-init/kuiper_wait_install.sh
     environment:
+      API_GATEWAY_HOST: kong
+      API_GATEWAY_STATUS_PORT: '8100'
       EDGEX__DEFAULT__PORT: 6379
       EDGEX__DEFAULT__PROTOCOL: redis
       EDGEX__DEFAULT__SERVER: edgex-redis
@@ -959,6 +964,22 @@ services:
       EDGEX__DEFAULT__TYPE: redis
       KUIPER__BASIC__CONSOLELOG: "true"
       KUIPER__BASIC__RESTPORT: 59720
+      PROXY_SETUP_HOST: edgex-proxy-setup
+      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_DATABASE_HOST: edgex-redis
+      STAGEGATE_DATABASE_PORT: '6379'
+      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_KONGDB_HOST: kong-db
+      STAGEGATE_KONGDB_PORT: '5432'
+      STAGEGATE_KONGDB_READYPORT: '54325'
+      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_REGISTRY_HOST: edgex-core-consul
+      STAGEGATE_REGISTRY_PORT: '8500'
+      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_SECRETSTORESETUP_HOST: edgex-secretstore-setup
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-kuiper
     image: emqx/kuiper:1.2.1-beta.0-alpine
     networks:
@@ -970,6 +991,7 @@ services:
     - no-new-privileges:true
     user: kuiper:kuiper
     volumes:
+    - edgex-init:/edgex-init:ro,z
     - kuiper-data:/kuiper/data:z
     - kuiper-config:/kuiper/etc/sources:z
   scalability-test-mqtt-export:


### PR DESCRIPTION
**This PR is dependent on https://github.com/edgexfoundry/edgex-go/pull/3537 merged and images built**

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-examples/blob/master/.github/CONTRIBUTING.md.

## What is the current behavior?
Kuiper has no knowledge of the credentials when using Secure MessageBus

## Issue Number: #110

## What is the new behavior?
Volume mount the Kuiper Edgex config file with credentials that is created by Secret Store Setup

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information