### PR TITLE
fix: Missing backtick to retrieve unique id from uuidgen

### DIFF
--- a/compose-builder/get-api-gateway-token.sh
+++ b/compose-builder/get-api-gateway-token.sh
@@ -38,7 +38,7 @@ openssl ec -in ${GW_KEY_DIR}/gateway.key -pubout -out ${GW_KEY_DIR}/gateway.pub 
 JWT_FILE=/tmp/edgex/secrets/security-proxy-setup/kong-admin-jwt
 JWT_VOLUME=/tmp/edgex/secrets/security-proxy-setup
 
-ID="uuidgen"
+ID=`uuidgen`
 
 docker run --rm -it -e KONGURL_SERVER=kong -e "ID=${ID}" -e "JWT_FILE=${JWT_FILE}" --network edgex_edgex-network --entrypoint "" -v ${GW_KEY_DIR}:/keys -v ${JWT_VOLUME}:${JWT_VOLUME} \
        ${CORE_EDGEX_REPOSITORY}/security-proxy-setup${ARCH}:${CORE_EDGEX_VERSION}${DEV} \


### PR DESCRIPTION
Signed-off-by: Bryon Nevis <bryon.nevis@intel.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-examples/blob/master/.github/CONTRIBUTING.md.

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->


## Issue Number:
Closes #114 

## What is the new behavior?
Fixes minor typo that sets the "unique" ID for new JWT's to the literal string "uuidgen"

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
Are there any new imports or modules? If so, what are they used for and why?

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information