### PR TITLE
fix: Set KONG_DNS_VALID_TTL: '1' so Kong caches IP for only 1 sec

### DIFF
--- a/compose-builder/add-security.yml
+++ b/compose-builder/add-security.yml
@@ -209,6 +209,7 @@ services:
       KONG_ADMIN_LISTEN: "127.0.0.1:8001, 127.0.0.1:8444 ssl"
       KONG_STATUS_LISTEN: "0.0.0.0:8100"
       KONG_DNS_ORDER: "LAST,A,CNAME"
+      KONG_DNS_VALID_TTL: '1'
     restart: on-failure
     tmpfs:
       - /run

--- a/docker-compose-arm64.yml
+++ b/docker-compose-arm64.yml
@@ -427,6 +427,7 @@ services:
       KONG_ADMIN_LISTEN: 127.0.0.1:8001, 127.0.0.1:8444 ssl
       KONG_DATABASE: postgres
       KONG_DNS_ORDER: LAST,A,CNAME
+      KONG_DNS_VALID_TTL: '1'
       KONG_PG_HOST: kong-db
       KONG_PG_PASSWORD_FILE: /tmp/postgres-config/.pgpassword
       KONG_PROXY_ACCESS_LOG: /dev/stdout

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -427,6 +427,7 @@ services:
       KONG_ADMIN_LISTEN: 127.0.0.1:8001, 127.0.0.1:8444 ssl
       KONG_DATABASE: postgres
       KONG_DNS_ORDER: LAST,A,CNAME
+      KONG_DNS_VALID_TTL: '1'
       KONG_PG_HOST: kong-db
       KONG_PG_PASSWORD_FILE: /tmp/postgres-config/.pgpassword
       KONG_PROXY_ACCESS_LOG: /dev/stdout

--- a/taf/docker-compose-taf-arm64.yml
+++ b/taf/docker-compose-taf-arm64.yml
@@ -665,6 +665,7 @@ services:
       KONG_ADMIN_LISTEN: 127.0.0.1:8001, 127.0.0.1:8444 ssl
       KONG_DATABASE: postgres
       KONG_DNS_ORDER: LAST,A,CNAME
+      KONG_DNS_VALID_TTL: '1'
       KONG_PG_HOST: kong-db
       KONG_PG_PASSWORD_FILE: /tmp/postgres-config/.pgpassword
       KONG_PROXY_ACCESS_LOG: /dev/stdout

--- a/taf/docker-compose-taf-perf-arm64.yml
+++ b/taf/docker-compose-taf-perf-arm64.yml
@@ -491,6 +491,7 @@ services:
       KONG_ADMIN_LISTEN: 127.0.0.1:8001, 127.0.0.1:8444 ssl
       KONG_DATABASE: postgres
       KONG_DNS_ORDER: LAST,A,CNAME
+      KONG_DNS_VALID_TTL: '1'
       KONG_PG_HOST: kong-db
       KONG_PG_PASSWORD_FILE: /tmp/postgres-config/.pgpassword
       KONG_PROXY_ACCESS_LOG: /dev/stdout

--- a/taf/docker-compose-taf-perf.yml
+++ b/taf/docker-compose-taf-perf.yml
@@ -491,6 +491,7 @@ services:
       KONG_ADMIN_LISTEN: 127.0.0.1:8001, 127.0.0.1:8444 ssl
       KONG_DATABASE: postgres
       KONG_DNS_ORDER: LAST,A,CNAME
+      KONG_DNS_VALID_TTL: '1'
       KONG_PG_HOST: kong-db
       KONG_PG_PASSWORD_FILE: /tmp/postgres-config/.pgpassword
       KONG_PROXY_ACCESS_LOG: /dev/stdout

--- a/taf/docker-compose-taf.yml
+++ b/taf/docker-compose-taf.yml
@@ -665,6 +665,7 @@ services:
       KONG_ADMIN_LISTEN: 127.0.0.1:8001, 127.0.0.1:8444 ssl
       KONG_DATABASE: postgres
       KONG_DNS_ORDER: LAST,A,CNAME
+      KONG_DNS_VALID_TTL: '1'
       KONG_PG_HOST: kong-db
       KONG_PG_PASSWORD_FILE: /tmp/postgres-config/.pgpassword
       KONG_PROXY_ACCESS_LOG: /dev/stdout


### PR DESCRIPTION
closes 

Signed-off-by: lenny <leonard.goodell@intel.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-examples/blob/master/.github/CONTRIBUTING.md.

## What is the current behavior?
Kong caches IP address for ~5 mins before the cache is invalidated
When service IP changes, the service is not accessible via Kong for ~5 mins

## Issue Number: #116


## What is the new behavior?
Kong now configured cache IP address for only 1 second before the cache is invalidated

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [ ] No

## New Imports
Are there any new imports or modules? If so, what are they used for and why?
Now when service IP changes, the service is accessible via Kong after only 1 sec.

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information