### PR TITLE
fix: Add label:disable to security_opt for SysMgmtAgent

### DIFF
--- a/compose-builder/docker-compose-base.yml
+++ b/compose-builder/docker-compose-base.yml
@@ -88,6 +88,7 @@ services:
       - command
     security_opt: 
       - no-new-privileges:true
+      - label:disable # needed for CentOS to provide docker access
 
   notifications:
     image: ${CORE_EDGEX_REPOSITORY}/support-notifications${ARCH}:${CORE_EDGEX_VERSION}${DEV}

--- a/docker-compose-arm64.yml
+++ b/docker-compose-arm64.yml
@@ -925,6 +925,7 @@ services:
     - 127.0.0.1:58890:58890/tcp
     read_only: true
     security_opt:
+    - label:disable
     - no-new-privileges:true
     user: root:root
     volumes:

--- a/docker-compose-no-secty-arm64.yml
+++ b/docker-compose-no-secty-arm64.yml
@@ -342,6 +342,7 @@ services:
     - 127.0.0.1:58890:58890/tcp
     read_only: true
     security_opt:
+    - label:disable
     - no-new-privileges:true
     user: root:root
     volumes:

--- a/docker-compose-no-secty.yml
+++ b/docker-compose-no-secty.yml
@@ -342,6 +342,7 @@ services:
     - 127.0.0.1:58890:58890/tcp
     read_only: true
     security_opt:
+    - label:disable
     - no-new-privileges:true
     user: root:root
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -925,6 +925,7 @@ services:
     - 127.0.0.1:58890:58890/tcp
     read_only: true
     security_opt:
+    - label:disable
     - no-new-privileges:true
     user: root:root
     volumes:

--- a/taf/docker-compose-taf-arm64.yml
+++ b/taf/docker-compose-taf-arm64.yml
@@ -1253,6 +1253,7 @@ services:
     - 127.0.0.1:58890:58890/tcp
     read_only: true
     security_opt:
+    - label:disable
     - no-new-privileges:true
     user: root:root
     volumes:

--- a/taf/docker-compose-taf-no-secty-arm64.yml
+++ b/taf/docker-compose-taf-no-secty-arm64.yml
@@ -530,6 +530,7 @@ services:
     - 127.0.0.1:58890:58890/tcp
     read_only: true
     security_opt:
+    - label:disable
     - no-new-privileges:true
     user: root:root
     volumes:

--- a/taf/docker-compose-taf-no-secty.yml
+++ b/taf/docker-compose-taf-no-secty.yml
@@ -530,6 +530,7 @@ services:
     - 127.0.0.1:58890:58890/tcp
     read_only: true
     security_opt:
+    - label:disable
     - no-new-privileges:true
     user: root:root
     volumes:

--- a/taf/docker-compose-taf-perf-arm64.yml
+++ b/taf/docker-compose-taf-perf-arm64.yml
@@ -1002,6 +1002,7 @@ services:
     - 127.0.0.1:58890:58890/tcp
     read_only: true
     security_opt:
+    - label:disable
     - no-new-privileges:true
     user: root:root
     volumes:

--- a/taf/docker-compose-taf-perf-no-secty-arm64.yml
+++ b/taf/docker-compose-taf-perf-no-secty-arm64.yml
@@ -388,6 +388,7 @@ services:
     - 127.0.0.1:58890:58890/tcp
     read_only: true
     security_opt:
+    - label:disable
     - no-new-privileges:true
     user: root:root
     volumes:

--- a/taf/docker-compose-taf-perf-no-secty.yml
+++ b/taf/docker-compose-taf-perf-no-secty.yml
@@ -388,6 +388,7 @@ services:
     - 127.0.0.1:58890:58890/tcp
     read_only: true
     security_opt:
+    - label:disable
     - no-new-privileges:true
     user: root:root
     volumes:

--- a/taf/docker-compose-taf-perf.yml
+++ b/taf/docker-compose-taf-perf.yml
@@ -1002,6 +1002,7 @@ services:
     - 127.0.0.1:58890:58890/tcp
     read_only: true
     security_opt:
+    - label:disable
     - no-new-privileges:true
     user: root:root
     volumes:

--- a/taf/docker-compose-taf.yml
+++ b/taf/docker-compose-taf.yml
@@ -1253,6 +1253,7 @@ services:
     - 127.0.0.1:58890:58890/tcp
     read_only: true
     security_opt:
+    - label:disable
     - no-new-privileges:true
     user: root:root
     volumes:


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-examples/blob/master/.github/CONTRIBUTING.md.

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->
SysMgmtAgent gets `permission denied` on CentOS for access to docker

## Issue Number: #124

## What is the new behavior?
This resolves permissions issue on CentOS for SysMgmtAgent access to docker


## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information