### PR TITLE
refactor: Remove Core Data override for MESSAGEQUEUE_SUBSCRIBEENABLED

### DIFF
--- a/compose-builder/docker-compose-base.yml
+++ b/compose-builder/docker-compose-base.yml
@@ -147,7 +147,6 @@ services:
       - common.env
     environment:
       SERVICE_HOST: edgex-core-data
-      MESSAGEQUEUE_SUBSCRIBEENABLED: "false"
     depends_on:
       - consul
       - database

--- a/docker-compose-arm64.yml
+++ b/docker-compose-arm64.yml
@@ -212,7 +212,6 @@ services:
       DATABASES_PRIMARY_HOST: edgex-redis
       EDGEX_SECURITY_SECRET_STORE: "true"
       MESSAGEQUEUE_HOST: edgex-redis
-      MESSAGEQUEUE_SUBSCRIBEENABLED: "false"
       PROXY_SETUP_HOST: edgex-proxy-setup
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault

--- a/docker-compose-no-secty-arm64.yml
+++ b/docker-compose-no-secty-arm64.yml
@@ -114,7 +114,6 @@ services:
       DATABASES_PRIMARY_HOST: edgex-redis
       EDGEX_SECURITY_SECRET_STORE: "false"
       MESSAGEQUEUE_HOST: edgex-redis
-      MESSAGEQUEUE_SUBSCRIBEENABLED: "false"
       REGISTRY_HOST: edgex-core-consul
       SERVICE_HOST: edgex-core-data
     hostname: edgex-core-data

--- a/docker-compose-no-secty.yml
+++ b/docker-compose-no-secty.yml
@@ -114,7 +114,6 @@ services:
       DATABASES_PRIMARY_HOST: edgex-redis
       EDGEX_SECURITY_SECRET_STORE: "false"
       MESSAGEQUEUE_HOST: edgex-redis
-      MESSAGEQUEUE_SUBSCRIBEENABLED: "false"
       REGISTRY_HOST: edgex-core-consul
       SERVICE_HOST: edgex-core-data
     hostname: edgex-core-data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -212,7 +212,6 @@ services:
       DATABASES_PRIMARY_HOST: edgex-redis
       EDGEX_SECURITY_SECRET_STORE: "true"
       MESSAGEQUEUE_HOST: edgex-redis
-      MESSAGEQUEUE_SUBSCRIBEENABLED: "false"
       PROXY_SETUP_HOST: edgex-proxy-setup
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault

--- a/taf/docker-compose-taf-arm64.yml
+++ b/taf/docker-compose-taf-arm64.yml
@@ -394,7 +394,6 @@ services:
       DATABASES_PRIMARY_HOST: edgex-redis
       EDGEX_SECURITY_SECRET_STORE: "true"
       MESSAGEQUEUE_HOST: edgex-redis
-      MESSAGEQUEUE_SUBSCRIBEENABLED: "false"
       PROXY_SETUP_HOST: edgex-proxy-setup
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault

--- a/taf/docker-compose-taf-no-secty-arm64.yml
+++ b/taf/docker-compose-taf-no-secty-arm64.yml
@@ -209,7 +209,6 @@ services:
       DATABASES_PRIMARY_HOST: edgex-redis
       EDGEX_SECURITY_SECRET_STORE: "false"
       MESSAGEQUEUE_HOST: edgex-redis
-      MESSAGEQUEUE_SUBSCRIBEENABLED: "false"
       REGISTRY_HOST: edgex-core-consul
       SERVICE_HOST: edgex-core-data
     hostname: edgex-core-data

--- a/taf/docker-compose-taf-no-secty.yml
+++ b/taf/docker-compose-taf-no-secty.yml
@@ -209,7 +209,6 @@ services:
       DATABASES_PRIMARY_HOST: edgex-redis
       EDGEX_SECURITY_SECRET_STORE: "false"
       MESSAGEQUEUE_HOST: edgex-redis
-      MESSAGEQUEUE_SUBSCRIBEENABLED: "false"
       REGISTRY_HOST: edgex-core-consul
       SERVICE_HOST: edgex-core-data
     hostname: edgex-core-data

--- a/taf/docker-compose-taf-perf-arm64.yml
+++ b/taf/docker-compose-taf-perf-arm64.yml
@@ -276,7 +276,6 @@ services:
       DATABASES_PRIMARY_HOST: edgex-redis
       EDGEX_SECURITY_SECRET_STORE: "true"
       MESSAGEQUEUE_HOST: edgex-redis
-      MESSAGEQUEUE_SUBSCRIBEENABLED: "false"
       PROXY_SETUP_HOST: edgex-proxy-setup
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault

--- a/taf/docker-compose-taf-perf-no-secty-arm64.yml
+++ b/taf/docker-compose-taf-perf-no-secty-arm64.yml
@@ -147,7 +147,6 @@ services:
       DATABASES_PRIMARY_HOST: edgex-redis
       EDGEX_SECURITY_SECRET_STORE: "false"
       MESSAGEQUEUE_HOST: edgex-redis
-      MESSAGEQUEUE_SUBSCRIBEENABLED: "false"
       REGISTRY_HOST: edgex-core-consul
       SERVICE_HOST: edgex-core-data
     hostname: edgex-core-data

--- a/taf/docker-compose-taf-perf-no-secty.yml
+++ b/taf/docker-compose-taf-perf-no-secty.yml
@@ -147,7 +147,6 @@ services:
       DATABASES_PRIMARY_HOST: edgex-redis
       EDGEX_SECURITY_SECRET_STORE: "false"
       MESSAGEQUEUE_HOST: edgex-redis
-      MESSAGEQUEUE_SUBSCRIBEENABLED: "false"
       REGISTRY_HOST: edgex-core-consul
       SERVICE_HOST: edgex-core-data
     hostname: edgex-core-data

--- a/taf/docker-compose-taf-perf.yml
+++ b/taf/docker-compose-taf-perf.yml
@@ -276,7 +276,6 @@ services:
       DATABASES_PRIMARY_HOST: edgex-redis
       EDGEX_SECURITY_SECRET_STORE: "true"
       MESSAGEQUEUE_HOST: edgex-redis
-      MESSAGEQUEUE_SUBSCRIBEENABLED: "false"
       PROXY_SETUP_HOST: edgex-proxy-setup
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault

--- a/taf/docker-compose-taf.yml
+++ b/taf/docker-compose-taf.yml
@@ -394,7 +394,6 @@ services:
       DATABASES_PRIMARY_HOST: edgex-redis
       EDGEX_SECURITY_SECRET_STORE: "true"
       MESSAGEQUEUE_HOST: edgex-redis
-      MESSAGEQUEUE_SUBSCRIBEENABLED: "false"
       PROXY_SETUP_HOST: edgex-proxy-setup
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-examples/blob/master/.github/CONTRIBUTING.md.

## What is the current behavior?
Core Data subscribe is disable with env override

## Issue Number: #129

## What is the new behavior?
Core Data subscribe no longer disable with env override

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information