### PR TITLE
feat(make): add tab-completion for all custom options

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,10 @@ endif
 
 SERVICES:=$(filter-out $(OPTIONS),$(ARGS))
 
+# Define additional phony targets for all options to enable support for tab-completion in shell
+# Note: This must be defined after the options are parsed otherwise it will interfere with them
+.PHONY: $(OPTIONS)
+
 portainer:
 	docker-compose -p portainer -f docker-compose-portainer.yml up -d
 

--- a/compose-builder/Makefile
+++ b/compose-builder/Makefile
@@ -392,6 +392,10 @@ ifeq (true, $(DS_GROVE))
  endif
 endif
 
+# Define additional phony targets for all options to enable support for tab-completion in shell
+# Note: This must be defined after the options are parsed otherwise it will interfere with them
+.PHONY: $(OPTIONS)
+
 help:
 	echo "See README.md in this folder"
 


### PR DESCRIPTION
Signed-off-by: Anthony Casagrande <anthony.j.casagrande@intel.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- **[N/A]** Tests for the changes have been added (for bug fixes / features)
- **[N/A]** Docs have been added / updated (for bug fixes / features)

## What is the current behavior?
Options such as `arm64` and `no-secty` are not available for tab-completion.

> _Note: `<TAB>` indicates the user pressing the Tab key on their keyboard._

```shell
user@machine:projects/edgex-compose$ make <TAB>
clean                 get-consul-acl-token  portainer             pull-ui               
down                  get-token             portainer-down        run                   
down-ui               help                  pull                  run-ui  
```
```shell
user@machine:projects/edgex-compose/compose-builder$ make <TAB>
build                 down                  help                  run                   upload-tls-cert
build-taf             gen                   portainer             taf-compose           
clean                 get-consul-acl-token  portainer-down        taf-compose-perf      
compose               get-token             pull                  ui-down               
```

## What is the new behavior?
This adds tab-completion support for all custom options defined in `$(OPTIONS)` such as `no-secty` and `arm64`, as well as various others within the `compose-builder`.

Now if you start typing `make run no<TAB>`, it will auto-complete to `make run no-secty`

```shell
user@machine:projects/edgex-compose$ make <TAB>
arm64                 down-ui               help                  portainer-down        run
clean                 get-consul-acl-token  no-secty              pull                  run-ui
down                  get-token             portainer             pull-ui             
```
```shell
user@machine:projects/edgex-compose/compose-builder$ make <TAB>
app-dev               down                  ds-virtual            portainer             taf-secty
arm64                 ds-bacnet             gen                   portainer-down        ui
asc-http              ds-camera             get-consul-acl-token  pull                  ui-down
asc-mqtt              ds-grove              get-token             run                   ui-only
build                 ds-modbus             help                  taf-compose           upload-tls-cert
build-taf             ds-mqtt               modbus-sim            taf-compose-perf      zmq-bus
clean                 ds-random             mqtt-broker           taf-no-secty          
compose               ds-rest               mqtt-bus              taf-perf              
dev                   ds-snmp               no-secty              taf-perf-no-secty     
```

## Does this PR introduce a breaking change?
- [X] No

## Other information