### PR TITLE
fix: [Ireland] remove device-random from down target

### DIFF
--- a/compose-builder/Makefile
+++ b/compose-builder/Makefile
@@ -529,7 +529,6 @@ down:
 		-f add-device-grove.yml \
 		-f add-device-modbus.yml \
 		-f add-device-mqtt.yml \
-		-f add-device-random.yml \
 		-f add-device-rest.yml \
 		-f add-device-snmp.yml \
 		-f add-device-coap.yml \


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-examples/blob/master/.github/CONTRIBUTING.md.

## What is the current behavior?
running make down fails due to add-device-random.yml file previously removed, but not removed from down target


## Issue Number: #149


## What is the new behavior?
make down no longer fails


## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information