### PR TITLE
fix: Correct description for app-rfid-llrp-inventory compose file

### DIFF
--- a/compose-builder/README.md
+++ b/compose-builder/README.md
@@ -76,7 +76,7 @@ This folder contains the following compose files:
 - **add-asc-mqtt-export.yml**
     Application Service Configurable **extending** compose file, which adds the **App Service MQTT Export**  service.
 - **add-app-rfid-llrp-inventory.yml**
-    Application Service Configurable **extending** compose file, which adds the **App RFID LLRP Inventory**  service.
+    Application Service **extending** compose file, which adds the **App RFID LLRP Inventory**  service.
 - **add-modbus-simulator.yml**
     ModBus Simulator **extending** compose file. Adds the MQTT ModBus Simulator service. Must be used in conjunction with  **add-device-modbus.yml**
 - **add-mqtt-broker.yml**


### PR DESCRIPTION
Signed-off-by: lenny <leonard.goodell@intel.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-examples/blob/master/.github/CONTRIBUTING.md.

## What is the current behavior?
Description for app-rfid-llrp-inventory compose file is slightly wrong as it starts with `Application Service Configurable **extending**` rather than `Application Service **extending**`

## Issue Number: n/a


## What is the new behavior?
Description for app-rfid-llrp-inventory compose file corrected.

## New Imports
Are there any new imports or modules? If so, what are they used for and why?

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information