### PR TITLE
feat: Add asc-sample option and include in no-secty-with-ui built compose files

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,14 +59,14 @@ This folder contains the following compose files:
 
 
 - **docker-compose-no-secty-with-ui.yml**
-  Contains just the services needed to run in non-secure configuration with the EdgeX UI.  Includes the Device Virtual & Device REST device services.
+  Contains just the services needed to run in non-secure configuration with the EdgeX UI.  Includes the Device Virtual, Device REST & App Sample services.
   **Make Commands**
 
   - Use `make run no-secty ui` and `make down` to start and stop the services using this compose file.
   - Use `make pull no-secty ui <service(s)>` to pull all or some images for the services in this compose file.
 
 - **docker-compose-no-secty-with-ui-arm64.yml**
-  Contains just the services needed to run in non-secure configuration with the EdgeX UI on `ARM64` system .  Includes the Device Virtual & Device REST device services.
+  Contains just the services needed to run in non-secure configuration with the EdgeX UI on `ARM64` system .  Includes the Device Virtual, Device REST & App Sample services.
 
   **Make Commands**
 

--- a/compose-builder/Makefile
+++ b/compose-builder/Makefile
@@ -36,7 +36,7 @@ define OPTIONS
  - zmq-bus mqtt-bus mqtt-broker -
  - taf-secty taf-no-secty taf-perf taf-perf-no-secty -
  - ds-bacnet ds-camera ds-grove ds-modbus ds-mqtt ds-rest ds-snmp ds-virtual ds-llrp ds-coap ds-gpio -
- - asc-http asc-mqtt as-llrp -
+ - asc-http asc-mqtt asc-sample as-llrp -
  - modbus-sim ui -
 endef
 export OPTIONS
@@ -289,6 +289,26 @@ ifeq (asc-mqtt, $(filter asc-mqtt,$(ARGS)))
 		COMPOSE_FILES:=$(COMPOSE_FILES) -f $(extension_file)
 	endif
 endif
+ifeq (asc-sample, $(filter asc-sample,$(ARGS)))
+	COMPOSE_FILES:=$(COMPOSE_FILES) -f add-asc-sample.yml
+	ifneq (no-secty, $(filter no-secty,$(ARGS)))
+		ifeq ($(TOKEN_LIST),"")
+			TOKEN_LIST:=app-sample
+		else
+			TOKEN_LIST:=$(TOKEN_LIST),app-sample
+		endif
+		ifeq ($(KNOWN_SECRETS_LIST),"")
+			KNOWN_SECRETS_LIST:=redisdb[app-sample]
+		else
+			KNOWN_SECRETS_LIST:=$(KNOWN_SECRETS_LIST),redisdb[app-sample]
+		endif
+		# when no security mode (no-secty) not explicitly specified,
+		# then we also need to add the secure version on top of base yml by default.
+		extension_file:= $(shell GEN_EXT_DIR="$(GEN_EXT_DIR)" ./gen_secure_compose_ext.sh app-service-sample \
+			app-sample app-service-configurable)
+		COMPOSE_FILES:=$(COMPOSE_FILES) -f $(extension_file)
+	endif
+endif
 ifeq (as-llrp, $(filter as-llrp,$(ARGS)))
 	COMPOSE_FILES:=$(COMPOSE_FILES) -f add-app-rfid-llrp-inventory.yml
 	ifneq (no-secty, $(filter no-secty,$(ARGS)))
@@ -458,8 +478,8 @@ build:
 	make compose ds-rest ds-virtual arm64
 	make compose ds-rest ds-virtual no-secty
 	make compose ds-rest ds-virtual no-secty arm64
-	make compose ds-rest ds-virtual no-secty ui
-	make compose ds-rest ds-virtual no-secty arm64 ui
+	make compose ds-rest ds-virtual asc-sample no-secty ui
+	make compose ds-rest ds-virtual asc-sample no-secty arm64 ui
 	make taf-compose taf-secty
 	make taf-compose taf-no-secty
 	make taf-compose taf-secty arm64
@@ -537,6 +557,8 @@ down:
 		-f add-device-virtual.yml \
 		-f add-asc-http-export.yml \
 		-f add-asc-mqtt-export.yml \
+		-f add-asc-sample.yml \
+		-f add-app-rfid-llrp-inventory.yml \
 		-f add-modbus-simulator.yml \
 		-f add-mqtt-broker.yml \
 		-f add-mqtt-messagebus.yml \

--- a/compose-builder/README.md
+++ b/compose-builder/README.md
@@ -70,13 +70,15 @@ This folder contains the following compose files:
     Device Service **extending** compose file, which adds the **Device RFID LLRP**  service.
 - **add-asc-http-export.yml**
     Application Service Configurable **extending** compose file, which adds the **App Service Http Export**  service.
-- **add-service-secure-template.yml**
-    A template for a single service **extending** compose file from its base service for security mode,
-    and the service is enabled with secret store by default.
+- **add-asc-sample.yml**
+    Application Service Configurable **extending** compose file, which adds the **App Service Sample**  service.
 - **add-asc-mqtt-export.yml**
     Application Service Configurable **extending** compose file, which adds the **App Service MQTT Export**  service.
 - **add-app-rfid-llrp-inventory.yml**
-    Application Service **extending** compose file, which adds the **App RFID LLRP Inventory**  service.
+    Application Service Configurable **extending** compose file, which adds the **App RFID LLRP Inventory**  service.
+- **add-service-secure-template.yml**
+    A template for a single service **extending** compose file from its base service for security mode,
+    and the service is enabled with secret store by default.
 - **add-modbus-simulator.yml**
     ModBus Simulator **extending** compose file. Adds the MQTT ModBus Simulator service. Must be used in conjunction with  **add-device-modbus.yml**
 - **add-mqtt-broker.yml**
@@ -174,6 +176,7 @@ Options:
     modbus-sim:  Runs with ModBus simulator included
     asc-http:    Runs with App Service HTTP Export included
     asc-mqtt:    Runs with App Service MQTT Export included
+    asc-sample:  Runs with App Service Sample included
     as-llrp:     Runs with App RFID LLRP Inventory included
     mqtt-broker: Runs with a MQTT Broker service included 
     mqtt-bus:    Runs with services configure for MQTT Message Bus 
@@ -212,6 +215,7 @@ Options:
     modbus-sim:  Pull includes ModBus simulator
     asc-http:    Pull includes App Service HTTP Export
     asc-mqtt:    Pull includes App Service MQTT Export
+    asc-sample:  Pull includes App Service Sample
     as-llrp:     Pull includes App RFID LLRP Inventory
     mqtt-broker: Pull includes MQTT Broker service
     mqtt-bus:    Pull includes additional services for MQTT Message Bus
@@ -247,6 +251,7 @@ Options:
     modbus-sim:  Generates compose file with ModBus simulator included
     asc-http:    Generates compose file with App Service HTTP Export included
     asc-mqtt:    Generates compose file with App Service MQTT Export included
+    asc-sample:  Generates compose file with App Service Sample included
     as-llrp:     Generates compose file with App RFID LLRP Inventory included
     mqtt-broker: Generates compose file with a MQTT Broker service included 
     mqtt-bus:    Generates compose file with services configured for MQTT Message Bus 
@@ -324,6 +329,7 @@ Options:
     modbus-sim:  Generates compose file with ModBus simulator included
     asc-http:    Generates compose file with App Service HTTP Export included
     asc-mqtt:    Generates compose file with App Service MQTT Export included
+    asc-sample:  Generates compose file with App Service S included
     as-llrp:     Generates compose file with App RFID LLRP Inventory included
     mqtt-broker: Generates compose file with a MQTT Broker service included 
     mqtt-bus:    Generates compose file with services configure for MQTT Message Bus 

--- a/compose-builder/add-asc-sample.yml
+++ b/compose-builder/add-asc-sample.yml
@@ -1,0 +1,39 @@
+# /*******************************************************************************
+#  * Copyright 2021 Intel Corporation.
+#  *
+#  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+#  * in compliance with the License. You may obtain a copy of the License at
+#  *
+#  * http://www.apache.org/licenses/LICENSE-2.0
+#  *
+#  * Unless required by applicable law or agreed to in writing, software distributed under the License
+#  * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  * or implied. See the License for the specific language governing permissions and limitations under
+#  * the License.
+#  *
+#  *******************************************************************************/
+
+version: '3.7'
+
+services:
+  app-service-sample:
+    image: ${APP_SVC_REPOSITORY}/app-service-configurable${ARCH}:${APP_SERVICE_CONFIG_VERSION}${APP_SVC_DEV}
+    ports:
+      - 127.0.0.1:59700:59700/tcp
+    container_name: edgex-app-sample
+    hostname: edgex-app-sample
+    env_file:
+      - common.env
+      - asc-common.env
+    environment:
+      EDGEX_PROFILE: sample
+      SERVICE_HOST: edgex-app-sample
+    depends_on:
+      - consul
+      - data
+    read_only: true
+    networks:
+      - edgex-network
+    security_opt:
+      - no-new-privileges:true
+    user: "${EDGEX_USER}:${EDGEX_GROUP}"

--- a/docker-compose-no-secty-with-ui-arm64.yml
+++ b/docker-compose-no-secty-with-ui-arm64.yml
@@ -57,6 +57,36 @@ services:
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
+  app-service-sample:
+    container_name: edgex-app-sample
+    depends_on:
+    - consul
+    - data
+    environment:
+      CLIENTS_CORE_COMMAND_HOST: edgex-core-command
+      CLIENTS_CORE_DATA_HOST: edgex-core-data
+      CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
+      CLIENTS_SUPPORT_NOTIFICATIONS_HOST: edgex-support-notifications
+      CLIENTS_SUPPORT_SCHEDULER_HOST: edgex-support-scheduler
+      DATABASES_PRIMARY_HOST: edgex-redis
+      DATABASE_HOST: edgex-redis
+      EDGEX_PROFILE: sample
+      EDGEX_SECURITY_SECRET_STORE: "false"
+      MESSAGEQUEUE_HOST: edgex-redis
+      REGISTRY_HOST: edgex-core-consul
+      SERVICE_HOST: edgex-app-sample
+      TRIGGER_EDGEXMESSAGEBUS_PUBLISHHOST_HOST: edgex-redis
+      TRIGGER_EDGEXMESSAGEBUS_SUBSCRIBEHOST_HOST: edgex-redis
+    hostname: edgex-app-sample
+    image: nexus3.edgexfoundry.org:10004/app-service-configurable-arm64:latest
+    networks:
+      edgex-network: {}
+    ports:
+    - 127.0.0.1:59700:59700/tcp
+    read_only: true
+    security_opt:
+    - no-new-privileges:true
+    user: 2002:2001
   command:
     container_name: edgex-core-command
     depends_on:

--- a/docker-compose-no-secty-with-ui.yml
+++ b/docker-compose-no-secty-with-ui.yml
@@ -57,6 +57,36 @@ services:
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
+  app-service-sample:
+    container_name: edgex-app-sample
+    depends_on:
+    - consul
+    - data
+    environment:
+      CLIENTS_CORE_COMMAND_HOST: edgex-core-command
+      CLIENTS_CORE_DATA_HOST: edgex-core-data
+      CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
+      CLIENTS_SUPPORT_NOTIFICATIONS_HOST: edgex-support-notifications
+      CLIENTS_SUPPORT_SCHEDULER_HOST: edgex-support-scheduler
+      DATABASES_PRIMARY_HOST: edgex-redis
+      DATABASE_HOST: edgex-redis
+      EDGEX_PROFILE: sample
+      EDGEX_SECURITY_SECRET_STORE: "false"
+      MESSAGEQUEUE_HOST: edgex-redis
+      REGISTRY_HOST: edgex-core-consul
+      SERVICE_HOST: edgex-app-sample
+      TRIGGER_EDGEXMESSAGEBUS_PUBLISHHOST_HOST: edgex-redis
+      TRIGGER_EDGEXMESSAGEBUS_SUBSCRIBEHOST_HOST: edgex-redis
+    hostname: edgex-app-sample
+    image: nexus3.edgexfoundry.org:10004/app-service-configurable:latest
+    networks:
+      edgex-network: {}
+    ports:
+    - 127.0.0.1:59700:59700/tcp
+    read_only: true
+    security_opt:
+    - no-new-privileges:true
+    user: 2002:2001
   command:
     container_name: edgex-core-command
     depends_on:


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-examples/blob/master/.github/CONTRIBUTING.md.

## What is the current behavior?
asc-sample is not an option 

## Issue Number: #154


## What is the new behavior?
asc-sample is now an option and is included in the non-secure with UI compose files  so the UI can use it to allow users to manipulate the configurable pipeline.


## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No


## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information