### PR TITLE
feat: Change clean commands to just clean EdgeX volumes, containers and networks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,8 @@ endif
 
 SERVICES:=$(filter-out $(OPTIONS),$(ARGS))
 
+COMPOSE_DOWN:= docker-compose -p edgex -f docker-compose.yml -f docker-compose-no-secty-with-ui.yml down $1
+
 # Define additional phony targets for all options to enable support for tab-completion in shell
 # Note: This must be defined after the options are parsed otherwise it will interfere with them
 .PHONY: $(OPTIONS)
@@ -54,10 +56,10 @@ run:
 	docker-compose -p edgex -f docker-compose${NO_SECURITY}${UI}${ARM64}.yml up -d ${SERVICES}
 
 down:
-	docker-compose -p edgex -f docker-compose.yml -f docker-compose-no-secty-with-ui.yml down ${CLEAN}
+	$(COMPOSE_DOWN)
 
 clean:
-	CLEAN=-v make down
+	$(call COMPOSE_DOWN,-v)
 
 get-token:
 	DEV=$(DEV) \

--- a/Makefile
+++ b/Makefile
@@ -54,12 +54,10 @@ run:
 	docker-compose -p edgex -f docker-compose${NO_SECURITY}${UI}${ARM64}.yml up -d ${SERVICES}
 
 down:
-	docker-compose -p edgex -f docker-compose.yml -f docker-compose-no-secty-with-ui.yml down
+	docker-compose -p edgex -f docker-compose.yml -f docker-compose-no-secty-with-ui.yml down ${CLEAN}
 
-clean: down
-	-docker rm $$(docker ps --filter "network=edgex_edgex-network" --filter "network=edgex_default" -aq) 2> /dev/null
-	docker volume prune -f && \
-	docker network prune -f
+clean:
+	CLEAN=-v make down
 
 get-token:
 	DEV=$(DEV) \

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,9 @@ endif
 
 SERVICES:=$(filter-out $(OPTIONS),$(ARGS))
 
-COMPOSE_DOWN:= docker-compose -p edgex -f docker-compose.yml -f docker-compose-no-secty-with-ui.yml down $1
+define COMPOSE_DOWN
+	docker-compose -p edgex -f docker-compose.yml -f docker-compose-no-secty-with-ui.yml down $1
+endef
 
 # Define additional phony targets for all options to enable support for tab-completion in shell
 # Note: This must be defined after the options are parsed otherwise it will interfere with them

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ The compose files under the `taf` subfolder are used for the automated TAF tests
 
 - `make clean`
 
-    Runs `down` commands, removes all stopped container and prunes all unused volumes and networks. Use this command when needing to do a fresh restart.
+    Runs `down` command and removes all stopped containers, all volumes and all networks used by the EdgeX stack. Use this command when needing to do a fresh restart.
     
 - `make get-token`
     For secure mode only. Runs commands via docker to generate a new API Gateway token.

--- a/compose-builder/Makefile
+++ b/compose-builder/Makefile
@@ -520,36 +520,38 @@ ifeq (true, $(DS_GROVE))
  endif
 endif
 
-COMPOSE_DOWN:=  DEV= \
-               	APP_SVC_DEV= \
-               	ARCH= \
-               	TOKEN_LIST= \
-               	KNOWN_SECRETS_LIST= \
-               	EXTRA_PROXY_ROUTE_LIST= \
-               	docker-compose -p edgex \
-               		-f docker-compose-base.yml \
-               		-f add-device-bacnet.yml \
-               		-f add-device-camera.yml \
-               		-f add-device-grove.yml \
-               		-f add-device-modbus.yml \
-               		-f add-device-mqtt.yml \
-               		-f add-device-rest.yml \
-               		-f add-device-snmp.yml \
-               		-f add-device-coap.yml \
-               		-f add-device-gpio.yml \
-               		-f add-device-rfid-llrp.yml \
-               		-f add-device-virtual.yml \
-               		-f add-asc-http-export.yml \
-               		-f add-asc-mqtt-export.yml \
-               		-f add-asc-sample.yml \
-               		-f add-app-rfid-llrp-inventory.yml \
-               		-f add-modbus-simulator.yml \
-               		-f add-mqtt-broker.yml \
-               		-f add-mqtt-messagebus.yml \
-               		-f add-security.yml \
-               		-f add-secure-redis-messagebus.yml \
-               		-f add-ui.yml \
-               		down $1
+define COMPOSE_DOWN
+	DEV= \
+	APP_SVC_DEV= \
+	ARCH= \
+	TOKEN_LIST= \
+	KNOWN_SECRETS_LIST= \
+	EXTRA_PROXY_ROUTE_LIST= \
+	docker-compose -p edgex \
+		-f docker-compose-base.yml \
+		-f add-device-bacnet.yml \
+		-f add-device-camera.yml \
+		-f add-device-grove.yml \
+		-f add-device-modbus.yml \
+		-f add-device-mqtt.yml \
+		-f add-device-rest.yml \
+		-f add-device-snmp.yml \
+		-f add-device-coap.yml \
+		-f add-device-gpio.yml \
+		-f add-device-rfid-llrp.yml \
+		-f add-device-virtual.yml \
+		-f add-asc-http-export.yml \
+		-f add-asc-mqtt-export.yml \
+		-f add-asc-sample.yml \
+		-f add-app-rfid-llrp-inventory.yml \
+		-f add-modbus-simulator.yml \
+		-f add-mqtt-broker.yml \
+		-f add-mqtt-messagebus.yml \
+		-f add-security.yml \
+		-f add-secure-redis-messagebus.yml \
+		-f add-ui.yml \
+		down $1
+endef
 
 # Define additional phony targets for all options to enable support for tab-completion in shell
 # Note: This must be defined after the options are parsed otherwise it will interfere with them

--- a/compose-builder/Makefile
+++ b/compose-builder/Makefile
@@ -520,6 +520,37 @@ ifeq (true, $(DS_GROVE))
  endif
 endif
 
+COMPOSE_DOWN:=  DEV= \
+               	APP_SVC_DEV= \
+               	ARCH= \
+               	TOKEN_LIST= \
+               	KNOWN_SECRETS_LIST= \
+               	EXTRA_PROXY_ROUTE_LIST= \
+               	docker-compose -p edgex \
+               		-f docker-compose-base.yml \
+               		-f add-device-bacnet.yml \
+               		-f add-device-camera.yml \
+               		-f add-device-grove.yml \
+               		-f add-device-modbus.yml \
+               		-f add-device-mqtt.yml \
+               		-f add-device-rest.yml \
+               		-f add-device-snmp.yml \
+               		-f add-device-coap.yml \
+               		-f add-device-gpio.yml \
+               		-f add-device-rfid-llrp.yml \
+               		-f add-device-virtual.yml \
+               		-f add-asc-http-export.yml \
+               		-f add-asc-mqtt-export.yml \
+               		-f add-asc-sample.yml \
+               		-f add-app-rfid-llrp-inventory.yml \
+               		-f add-modbus-simulator.yml \
+               		-f add-mqtt-broker.yml \
+               		-f add-mqtt-messagebus.yml \
+               		-f add-security.yml \
+               		-f add-secure-redis-messagebus.yml \
+               		-f add-ui.yml \
+               		down $1
+
 # Define additional phony targets for all options to enable support for tab-completion in shell
 # Note: This must be defined after the options are parsed otherwise it will interfere with them
 .PHONY: $(OPTIONS)
@@ -596,36 +627,7 @@ get-consul-acl-token:
 	sh ./get-consul-acl-token.sh
 
 down:
-	DEV= \
-	APP_SVC_DEV= \
-	ARCH= \
-	TOKEN_LIST= \
-	KNOWN_SECRETS_LIST= \
-	EXTRA_PROXY_ROUTE_LIST= \
-	docker-compose -p edgex \
-		-f docker-compose-base.yml \
-		-f add-device-bacnet.yml \
-		-f add-device-camera.yml \
-		-f add-device-grove.yml \
-		-f add-device-modbus.yml \
-		-f add-device-mqtt.yml \
-		-f add-device-rest.yml \
-		-f add-device-snmp.yml \
-		-f add-device-coap.yml \
-		-f add-device-gpio.yml \
-		-f add-device-rfid-llrp.yml \
-		-f add-device-virtual.yml \
-		-f add-asc-http-export.yml \
-		-f add-asc-mqtt-export.yml \
-		-f add-asc-sample.yml \
-		-f add-app-rfid-llrp-inventory.yml \
-		-f add-modbus-simulator.yml \
-		-f add-mqtt-broker.yml \
-		-f add-mqtt-messagebus.yml \
-		-f add-security.yml \
-		-f add-secure-redis-messagebus.yml \
-		-f add-ui.yml \
-		down ${CLEAN}
+	$(COMPOSE_DOWN)
 
 clean:
-	CLEAN=-v make down
+	$(call COMPOSE_DOWN,-v)

--- a/compose-builder/Makefile
+++ b/compose-builder/Makefile
@@ -623,10 +623,9 @@ down:
 		-f add-mqtt-broker.yml \
 		-f add-mqtt-messagebus.yml \
 		-f add-security.yml \
+		-f add-secure-redis-messagebus.yml \
 		-f add-ui.yml \
-		down
+		down ${CLEAN}
 
-clean: down
-	-docker rm $$(docker ps --filter "network=edgex_edgex-network" --filter "network=edgex_default" -aq) 2> /dev/null
-	docker volume prune -f && \
-	docker network prune -f
+clean:
+	CLEAN=-v make down

--- a/compose-builder/README.md
+++ b/compose-builder/README.md
@@ -267,7 +267,7 @@ Options:
 
 ```
 clean
-Runs 'down' , then removes any stopped containers and then prunes unused volumes and networks
+Runs 'down' and removes all stopped containers, all volumes and all networks used by the EdgeX stack. Use this command when needing to do a fresh restart.
 ```
 
 #### Get-token


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-examples/blob/master/.github/CONTRIBUTING.md.

## What is the current behavior?
Clean commands remove ALL un-used volumes, containers and networks even if not part of the Edgex stack

## Issue Number: #156


## What is the new behavior?
Clean commands now only remove un-used volumes, containers and networks that are part of the Edgex stack


## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No


## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information