### PR TITLE
feat(security): Enable modern cipher suite / TLSv1.3 only

### DIFF
--- a/compose-builder/add-security.yml
+++ b/compose-builder/add-security.yml
@@ -210,6 +210,7 @@ services:
       KONG_STATUS_LISTEN: "0.0.0.0:8100"
       KONG_DNS_ORDER: "LAST,A,CNAME"
       KONG_DNS_VALID_TTL: '1'
+      KONG_SSL_CIPHER_SUITE: modern
     restart: on-failure
     tmpfs:
       - /run

--- a/docker-compose-arm64.yml
+++ b/docker-compose-arm64.yml
@@ -428,6 +428,7 @@ services:
       KONG_PG_PASSWORD_FILE: /tmp/postgres-config/.pgpassword
       KONG_PROXY_ACCESS_LOG: /dev/stdout
       KONG_PROXY_ERROR_LOG: /dev/stderr
+      KONG_SSL_CIPHER_SUITE: modern
       KONG_STATUS_LISTEN: 0.0.0.0:8100
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -428,6 +428,7 @@ services:
       KONG_PG_PASSWORD_FILE: /tmp/postgres-config/.pgpassword
       KONG_PROXY_ACCESS_LOG: /dev/stdout
       KONG_PROXY_ERROR_LOG: /dev/stderr
+      KONG_SSL_CIPHER_SUITE: modern
       KONG_STATUS_LISTEN: 0.0.0.0:8100
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper

--- a/taf/docker-compose-taf-arm64.yml
+++ b/taf/docker-compose-taf-arm64.yml
@@ -663,6 +663,7 @@ services:
       KONG_PG_PASSWORD_FILE: /tmp/postgres-config/.pgpassword
       KONG_PROXY_ACCESS_LOG: /dev/stdout
       KONG_PROXY_ERROR_LOG: /dev/stderr
+      KONG_SSL_CIPHER_SUITE: modern
       KONG_STATUS_LISTEN: 0.0.0.0:8100
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper

--- a/taf/docker-compose-taf-mqtt-bus-arm64.yml
+++ b/taf/docker-compose-taf-mqtt-bus-arm64.yml
@@ -705,6 +705,7 @@ services:
       KONG_PG_PASSWORD_FILE: /tmp/postgres-config/.pgpassword
       KONG_PROXY_ACCESS_LOG: /dev/stdout
       KONG_PROXY_ERROR_LOG: /dev/stderr
+      KONG_SSL_CIPHER_SUITE: modern
       KONG_STATUS_LISTEN: 0.0.0.0:8100
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper

--- a/taf/docker-compose-taf-mqtt-bus.yml
+++ b/taf/docker-compose-taf-mqtt-bus.yml
@@ -705,6 +705,7 @@ services:
       KONG_PG_PASSWORD_FILE: /tmp/postgres-config/.pgpassword
       KONG_PROXY_ACCESS_LOG: /dev/stdout
       KONG_PROXY_ERROR_LOG: /dev/stderr
+      KONG_SSL_CIPHER_SUITE: modern
       KONG_STATUS_LISTEN: 0.0.0.0:8100
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper

--- a/taf/docker-compose-taf-perf-arm64.yml
+++ b/taf/docker-compose-taf-perf-arm64.yml
@@ -491,6 +491,7 @@ services:
       KONG_PG_PASSWORD_FILE: /tmp/postgres-config/.pgpassword
       KONG_PROXY_ACCESS_LOG: /dev/stdout
       KONG_PROXY_ERROR_LOG: /dev/stderr
+      KONG_SSL_CIPHER_SUITE: modern
       KONG_STATUS_LISTEN: 0.0.0.0:8100
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper

--- a/taf/docker-compose-taf-perf.yml
+++ b/taf/docker-compose-taf-perf.yml
@@ -491,6 +491,7 @@ services:
       KONG_PG_PASSWORD_FILE: /tmp/postgres-config/.pgpassword
       KONG_PROXY_ACCESS_LOG: /dev/stdout
       KONG_PROXY_ERROR_LOG: /dev/stderr
+      KONG_SSL_CIPHER_SUITE: modern
       KONG_STATUS_LISTEN: 0.0.0.0:8100
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper

--- a/taf/docker-compose-taf.yml
+++ b/taf/docker-compose-taf.yml
@@ -663,6 +663,7 @@ services:
       KONG_PG_PASSWORD_FILE: /tmp/postgres-config/.pgpassword
       KONG_PROXY_ACCESS_LOG: /dev/stdout
       KONG_PROXY_ERROR_LOG: /dev/stderr
+      KONG_SSL_CIPHER_SUITE: modern
       KONG_STATUS_LISTEN: 0.0.0.0:8100
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper


### PR DESCRIPTION
Closes #3680

Signed-off-by: Bryon Nevis <bryon.nevis@intel.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features) https://github.com/edgexfoundry/edgex-docs/pull/560

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/master/.github/Contributing.md.

## What is the current behavior?
API gateway supports "intermediate" level of cipher suites.

## Issue Number:
- #3680

## What is the new behavior?
API gateway supports "modern" cipher suite and TLSv1.3 only.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [X] Yes, but can by changed by configuration alone.
- [ ] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [X] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information