### PR TITLE
fix: Use correct service key for Device Camera

### DIFF
--- a/compose-builder/Makefile
+++ b/compose-builder/Makefile
@@ -93,16 +93,16 @@ ifeq (ds-camera, $(filter ds-camera,$(ARGS)))
 	endif
 	ifneq (no-secty, $(filter no-secty,$(ARGS)))
 		ifeq ($(TOKEN_LIST),"")
-			TOKEN_LIST:=device-camera-go
+			TOKEN_LIST:=device-camera
 		else
-			TOKEN_LIST:=$(TOKEN_LIST),device-camera-go
+			TOKEN_LIST:=$(TOKEN_LIST),device-camera
 		endif
 		ifeq ($(KNOWN_SECRETS_LIST),"")
-			KNOWN_SECRETS_LIST:=redisdb[device-camera-go]
+			KNOWN_SECRETS_LIST:=redisdb[device-camera]
 		else
-			KNOWN_SECRETS_LIST:=$(KNOWN_SECRETS_LIST),redisdb[device-camera-go]
+			KNOWN_SECRETS_LIST:=$(KNOWN_SECRETS_LIST),redisdb[device-camera]
 		endif
-		extension_file:= $(shell GEN_EXT_DIR="$(GEN_EXT_DIR)" ./gen_secure_compose_ext.sh device-camera device-camera-go)
+		extension_file:= $(shell GEN_EXT_DIR="$(GEN_EXT_DIR)" ./gen_secure_compose_ext.sh device-camera)
 		COMPOSE_FILES:=$(COMPOSE_FILES) -f $(extension_file)
 	endif
 endif


### PR DESCRIPTION
Now the security services are configured properly when the `ds-camera` option is used.

fixes #181

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-compose/blob/main/.github/CONTRIBUTING.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

<!-- If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-compose/blob/main/.github/CONTRIBUTING.md -->

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?) **N/A** 
      

## Testing Instructions
run `make run ds-camera` 
Check Device Camera logs to verify it successfully created the secrets client. i.e didn't fail to startup due to not finding it's Vault token
