### PR TITLE
docs: Update builder README with note on using docker-compose 1.27.2

### DIFF
--- a/compose-builder/README.md
+++ b/compose-builder/README.md
@@ -4,6 +4,8 @@ This folder contains the `Compose Builder` which is made up of **source** compos
 
 > **Note to Developers**: 
 > *Once you have edited and tested your changes to these source files you **MUST** regenerate the standard `pre-release` compose files using the `make build` command.*
+>
+> **You must use *docker-compose version 1.27.2* due to bug in later versions that generates the `depends_on` sections incorrectly for compose version 3.x**
 
 ### Generate next release compose files
 


### PR DESCRIPTION
README update to let devs know they must use docker-compose 1.27.2

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [ ] I have fully tested (add details below) this the new feature or bug fix (if not, why?) **N/A**
- [ ] I have opened a PR for the related docs change (if not, why?) **N/A**


## Testing Instructions
**N/A**