### PR TITLE
fix: Enable Consul persistence in non-secure compose

### DIFF
--- a/compose-builder/docker-compose-base.yml
+++ b/compose-builder/docker-compose-base.yml
@@ -30,6 +30,7 @@ volumes:
 services:
   consul:
     image: consul:${CONSUL_VERSION}
+    command: "agent -ui -bootstrap -server -client 0.0.0.0"
     user: "root:root" # Note that Consul is run under the 'consul' user, but entry point scripts need to first run as root
     ports:
       - "127.0.0.1:8500:8500"

--- a/docker-compose-arm64.yml
+++ b/docker-compose-arm64.yml
@@ -139,6 +139,7 @@ services:
     - edgex-init:/edgex-init:ro,z
     - /tmp/edgex/secrets/core-command:/tmp/edgex/secrets/core-command:ro,z
   consul:
+    command: agent -ui -bootstrap -server -client 0.0.0.0
     container_name: edgex-core-consul
     depends_on:
     - security-bootstrapper
@@ -424,12 +425,12 @@ services:
       KONG_DATABASE: postgres
       KONG_DNS_ORDER: LAST,A,CNAME
       KONG_DNS_VALID_TTL: '1'
+      KONG_NGINX_WORKER_PROCESSES: '1'
       KONG_PG_HOST: edgex-kong-db
       KONG_PG_PASSWORD_FILE: /tmp/postgres-config/.pgpassword
       KONG_PROXY_ACCESS_LOG: /dev/stdout
       KONG_PROXY_ERROR_LOG: /dev/stderr
       KONG_SSL_CIPHER_SUITE: modern
-      KONG_NGINX_WORKER_PROCESSES: '1'
       KONG_STATUS_LISTEN: 0.0.0.0:8100
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper

--- a/docker-compose-no-secty-arm64.yml
+++ b/docker-compose-no-secty-arm64.yml
@@ -83,6 +83,7 @@ services:
     - no-new-privileges:true
     user: 2002:2001
   consul:
+    command: agent -ui -bootstrap -server -client 0.0.0.0
     container_name: edgex-core-consul
     hostname: edgex-core-consul
     image: consul:1.10

--- a/docker-compose-no-secty-with-ui-arm64.yml
+++ b/docker-compose-no-secty-with-ui-arm64.yml
@@ -112,6 +112,7 @@ services:
     - no-new-privileges:true
     user: 2002:2001
   consul:
+    command: agent -ui -bootstrap -server -client 0.0.0.0
     container_name: edgex-core-consul
     hostname: edgex-core-consul
     image: consul:1.10

--- a/docker-compose-no-secty-with-ui.yml
+++ b/docker-compose-no-secty-with-ui.yml
@@ -112,6 +112,7 @@ services:
     - no-new-privileges:true
     user: 2002:2001
   consul:
+    command: agent -ui -bootstrap -server -client 0.0.0.0
     container_name: edgex-core-consul
     hostname: edgex-core-consul
     image: consul:1.10

--- a/docker-compose-no-secty.yml
+++ b/docker-compose-no-secty.yml
@@ -83,6 +83,7 @@ services:
     - no-new-privileges:true
     user: 2002:2001
   consul:
+    command: agent -ui -bootstrap -server -client 0.0.0.0
     container_name: edgex-core-consul
     hostname: edgex-core-consul
     image: consul:1.10

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -139,6 +139,7 @@ services:
     - edgex-init:/edgex-init:ro,z
     - /tmp/edgex/secrets/core-command:/tmp/edgex/secrets/core-command:ro,z
   consul:
+    command: agent -ui -bootstrap -server -client 0.0.0.0
     container_name: edgex-core-consul
     depends_on:
     - security-bootstrapper
@@ -424,12 +425,12 @@ services:
       KONG_DATABASE: postgres
       KONG_DNS_ORDER: LAST,A,CNAME
       KONG_DNS_VALID_TTL: '1'
+      KONG_NGINX_WORKER_PROCESSES: '1'
       KONG_PG_HOST: edgex-kong-db
       KONG_PG_PASSWORD_FILE: /tmp/postgres-config/.pgpassword
       KONG_PROXY_ACCESS_LOG: /dev/stdout
       KONG_PROXY_ERROR_LOG: /dev/stderr
       KONG_SSL_CIPHER_SUITE: modern
-      KONG_NGINX_WORKER_PROCESSES: '1'
       KONG_STATUS_LISTEN: 0.0.0.0:8100
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper

--- a/taf/docker-compose-taf-arm64.yml
+++ b/taf/docker-compose-taf-arm64.yml
@@ -318,6 +318,7 @@ services:
     - edgex-init:/edgex-init:ro,z
     - /tmp/edgex/secrets/core-command:/tmp/edgex/secrets/core-command:ro,z
   consul:
+    command: agent -ui -bootstrap -server -client 0.0.0.0
     container_name: edgex-core-consul
     depends_on:
     - security-bootstrapper
@@ -659,12 +660,12 @@ services:
       KONG_DATABASE: postgres
       KONG_DNS_ORDER: LAST,A,CNAME
       KONG_DNS_VALID_TTL: '1'
+      KONG_NGINX_WORKER_PROCESSES: '1'
       KONG_PG_HOST: edgex-kong-db
       KONG_PG_PASSWORD_FILE: /tmp/postgres-config/.pgpassword
       KONG_PROXY_ACCESS_LOG: /dev/stdout
       KONG_PROXY_ERROR_LOG: /dev/stderr
       KONG_SSL_CIPHER_SUITE: modern
-      KONG_NGINX_WORKER_PROCESSES: '1'
       KONG_STATUS_LISTEN: 0.0.0.0:8100
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper

--- a/taf/docker-compose-taf-mqtt-bus-arm64.yml
+++ b/taf/docker-compose-taf-mqtt-bus-arm64.yml
@@ -339,6 +339,7 @@ services:
     - edgex-init:/edgex-init:ro,z
     - /tmp/edgex/secrets/core-command:/tmp/edgex/secrets/core-command:ro,z
   consul:
+    command: agent -ui -bootstrap -server -client 0.0.0.0
     container_name: edgex-core-consul
     depends_on:
     - security-bootstrapper
@@ -701,12 +702,12 @@ services:
       KONG_DATABASE: postgres
       KONG_DNS_ORDER: LAST,A,CNAME
       KONG_DNS_VALID_TTL: '1'
+      KONG_NGINX_WORKER_PROCESSES: '1'
       KONG_PG_HOST: edgex-kong-db
       KONG_PG_PASSWORD_FILE: /tmp/postgres-config/.pgpassword
       KONG_PROXY_ACCESS_LOG: /dev/stdout
       KONG_PROXY_ERROR_LOG: /dev/stderr
       KONG_SSL_CIPHER_SUITE: modern
-      KONG_NGINX_WORKER_PROCESSES: '1'
       KONG_STATUS_LISTEN: 0.0.0.0:8100
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper

--- a/taf/docker-compose-taf-mqtt-bus.yml
+++ b/taf/docker-compose-taf-mqtt-bus.yml
@@ -339,6 +339,7 @@ services:
     - edgex-init:/edgex-init:ro,z
     - /tmp/edgex/secrets/core-command:/tmp/edgex/secrets/core-command:ro,z
   consul:
+    command: agent -ui -bootstrap -server -client 0.0.0.0
     container_name: edgex-core-consul
     depends_on:
     - security-bootstrapper
@@ -701,12 +702,12 @@ services:
       KONG_DATABASE: postgres
       KONG_DNS_ORDER: LAST,A,CNAME
       KONG_DNS_VALID_TTL: '1'
+      KONG_NGINX_WORKER_PROCESSES: '1'
       KONG_PG_HOST: edgex-kong-db
       KONG_PG_PASSWORD_FILE: /tmp/postgres-config/.pgpassword
       KONG_PROXY_ACCESS_LOG: /dev/stdout
       KONG_PROXY_ERROR_LOG: /dev/stderr
       KONG_SSL_CIPHER_SUITE: modern
-      KONG_NGINX_WORKER_PROCESSES: '1'
       KONG_STATUS_LISTEN: 0.0.0.0:8100
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper

--- a/taf/docker-compose-taf-no-secty-arm64.yml
+++ b/taf/docker-compose-taf-no-secty-arm64.yml
@@ -175,6 +175,7 @@ services:
     - no-new-privileges:true
     user: 2002:2001
   consul:
+    command: agent -ui -bootstrap -server -client 0.0.0.0
     container_name: edgex-core-consul
     hostname: edgex-core-consul
     image: consul:1.10

--- a/taf/docker-compose-taf-no-secty-mqtt-bus-arm64.yml
+++ b/taf/docker-compose-taf-no-secty-mqtt-bus-arm64.yml
@@ -196,6 +196,7 @@ services:
     - no-new-privileges:true
     user: 2002:2001
   consul:
+    command: agent -ui -bootstrap -server -client 0.0.0.0
     container_name: edgex-core-consul
     hostname: edgex-core-consul
     image: consul:1.10

--- a/taf/docker-compose-taf-no-secty-mqtt-bus.yml
+++ b/taf/docker-compose-taf-no-secty-mqtt-bus.yml
@@ -196,6 +196,7 @@ services:
     - no-new-privileges:true
     user: 2002:2001
   consul:
+    command: agent -ui -bootstrap -server -client 0.0.0.0
     container_name: edgex-core-consul
     hostname: edgex-core-consul
     image: consul:1.10

--- a/taf/docker-compose-taf-no-secty.yml
+++ b/taf/docker-compose-taf-no-secty.yml
@@ -175,6 +175,7 @@ services:
     - no-new-privileges:true
     user: 2002:2001
   consul:
+    command: agent -ui -bootstrap -server -client 0.0.0.0
     container_name: edgex-core-consul
     hostname: edgex-core-consul
     image: consul:1.10

--- a/taf/docker-compose-taf-perf-arm64.yml
+++ b/taf/docker-compose-taf-perf-arm64.yml
@@ -202,6 +202,7 @@ services:
     - edgex-init:/edgex-init:ro,z
     - /tmp/edgex/secrets/core-command:/tmp/edgex/secrets/core-command:ro,z
   consul:
+    command: agent -ui -bootstrap -server -client 0.0.0.0
     container_name: edgex-core-consul
     depends_on:
     - security-bootstrapper
@@ -487,12 +488,12 @@ services:
       KONG_DATABASE: postgres
       KONG_DNS_ORDER: LAST,A,CNAME
       KONG_DNS_VALID_TTL: '1'
+      KONG_NGINX_WORKER_PROCESSES: '1'
       KONG_PG_HOST: edgex-kong-db
       KONG_PG_PASSWORD_FILE: /tmp/postgres-config/.pgpassword
       KONG_PROXY_ACCESS_LOG: /dev/stdout
       KONG_PROXY_ERROR_LOG: /dev/stderr
       KONG_SSL_CIPHER_SUITE: modern
-      KONG_NGINX_WORKER_PROCESSES: '1'
       KONG_STATUS_LISTEN: 0.0.0.0:8100
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper

--- a/taf/docker-compose-taf-perf-no-secty-arm64.yml
+++ b/taf/docker-compose-taf-perf-no-secty-arm64.yml
@@ -115,6 +115,7 @@ services:
     - no-new-privileges:true
     user: 2002:2001
   consul:
+    command: agent -ui -bootstrap -server -client 0.0.0.0
     container_name: edgex-core-consul
     hostname: edgex-core-consul
     image: consul:1.10

--- a/taf/docker-compose-taf-perf-no-secty.yml
+++ b/taf/docker-compose-taf-perf-no-secty.yml
@@ -115,6 +115,7 @@ services:
     - no-new-privileges:true
     user: 2002:2001
   consul:
+    command: agent -ui -bootstrap -server -client 0.0.0.0
     container_name: edgex-core-consul
     hostname: edgex-core-consul
     image: consul:1.10

--- a/taf/docker-compose-taf-perf.yml
+++ b/taf/docker-compose-taf-perf.yml
@@ -202,6 +202,7 @@ services:
     - edgex-init:/edgex-init:ro,z
     - /tmp/edgex/secrets/core-command:/tmp/edgex/secrets/core-command:ro,z
   consul:
+    command: agent -ui -bootstrap -server -client 0.0.0.0
     container_name: edgex-core-consul
     depends_on:
     - security-bootstrapper
@@ -487,12 +488,12 @@ services:
       KONG_DATABASE: postgres
       KONG_DNS_ORDER: LAST,A,CNAME
       KONG_DNS_VALID_TTL: '1'
+      KONG_NGINX_WORKER_PROCESSES: '1'
       KONG_PG_HOST: edgex-kong-db
       KONG_PG_PASSWORD_FILE: /tmp/postgres-config/.pgpassword
       KONG_PROXY_ACCESS_LOG: /dev/stdout
       KONG_PROXY_ERROR_LOG: /dev/stderr
       KONG_SSL_CIPHER_SUITE: modern
-      KONG_NGINX_WORKER_PROCESSES: '1'
       KONG_STATUS_LISTEN: 0.0.0.0:8100
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper

--- a/taf/docker-compose-taf.yml
+++ b/taf/docker-compose-taf.yml
@@ -318,6 +318,7 @@ services:
     - edgex-init:/edgex-init:ro,z
     - /tmp/edgex/secrets/core-command:/tmp/edgex/secrets/core-command:ro,z
   consul:
+    command: agent -ui -bootstrap -server -client 0.0.0.0
     container_name: edgex-core-consul
     depends_on:
     - security-bootstrapper
@@ -659,12 +660,12 @@ services:
       KONG_DATABASE: postgres
       KONG_DNS_ORDER: LAST,A,CNAME
       KONG_DNS_VALID_TTL: '1'
+      KONG_NGINX_WORKER_PROCESSES: '1'
       KONG_PG_HOST: edgex-kong-db
       KONG_PG_PASSWORD_FILE: /tmp/postgres-config/.pgpassword
       KONG_PROXY_ACCESS_LOG: /dev/stdout
       KONG_PROXY_ERROR_LOG: /dev/stderr
       KONG_SSL_CIPHER_SUITE: modern
-      KONG_NGINX_WORKER_PROCESSES: '1'
       KONG_STATUS_LISTEN: 0.0.0.0:8100
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper


### PR DESCRIPTION
Note that secure compose does this via entry point script. Command
setting added will be overridden in secure mode by the entry point
script.

fixes #186

Signed-off-by: Leonard Goodell <leonard.goodell@intel.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-compose/blob/main/.github/CONTRIBUTING.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

<!-- If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-compose/blob/main/.github/CONTRIBUTING.md -->

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?) **None needed**


## Testing Instructions

1. run docker-compose up on non-secure compose file
2. Change setting for any service in Consul
3. run docker-compose down
4. run docker-compose up
5. verify the changed setting in Consul is still changed
6. run docker-compose down -v (cleans volumes)
6. repeat above steps with secure compose file