### PR TITLE
feat: Ensure all services, that should, restart after reboot.

### DIFF
--- a/compose-builder/add-app-rfid-llrp-inventory.yml
+++ b/compose-builder/add-app-rfid-llrp-inventory.yml
@@ -30,6 +30,7 @@ services:
       - consul
       - data
     read_only: true
+    restart: always
     networks:
       - edgex-network
     security_opt:

--- a/compose-builder/add-asc-http-export.yml
+++ b/compose-builder/add-asc-http-export.yml
@@ -32,6 +32,7 @@ services:
       - consul
       - data
     read_only: true
+    restart: always
     networks:
       - edgex-network
     security_opt:

--- a/compose-builder/add-asc-mqtt-export.yml
+++ b/compose-builder/add-asc-mqtt-export.yml
@@ -32,6 +32,7 @@ services:
       - consul
       - data
     read_only: true
+    restart: always
     networks:
       - edgex-network
     security_opt:

--- a/compose-builder/add-asc-sample.yml
+++ b/compose-builder/add-asc-sample.yml
@@ -32,6 +32,7 @@ services:
       - consul
       - data
     read_only: true
+    restart: always
     networks:
       - edgex-network
     security_opt:

--- a/compose-builder/add-device-bacnet.yml
+++ b/compose-builder/add-device-bacnet.yml
@@ -35,4 +35,6 @@ services:
       - metadata
     security_opt: 
       - no-new-privileges:true
+    read_only: true
+    restart: always
     user: "${EDGEX_USER}:${EDGEX_GROUP}"

--- a/compose-builder/add-device-camera.yml
+++ b/compose-builder/add-device-camera.yml
@@ -23,6 +23,7 @@ services:
     container_name: edgex-device-camera
     hostname: edgex-device-camera
     read_only: true
+    restart: always
     networks:
       - edgex-network
     env_file:

--- a/compose-builder/add-device-coap.yml
+++ b/compose-builder/add-device-coap.yml
@@ -23,6 +23,7 @@ services:
     container_name: edgex-device-coap
     hostname: edgex-device-coap
     read_only: true
+    restart: always
     networks:
       - edgex-network
     env_file:

--- a/compose-builder/add-device-gpio.yml
+++ b/compose-builder/add-device-gpio.yml
@@ -23,6 +23,7 @@ services:
     container_name: edgex-device-gpio
     hostname: edgex-device-gpio
     read_only: true
+    restart: always
     networks:
       - edgex-network
     env_file:

--- a/compose-builder/add-device-grove.yml
+++ b/compose-builder/add-device-grove.yml
@@ -37,4 +37,6 @@ services:
       - metadata
     security_opt: 
       - no-new-privileges:true
+    read_only: true
+    restart: always
     user: "${EDGEX_USER}:${EDGEX_GROUP}"

--- a/compose-builder/add-device-modbus.yml
+++ b/compose-builder/add-device-modbus.yml
@@ -35,4 +35,6 @@ services:
       - metadata
     security_opt: 
       - no-new-privileges:true
+    read_only: true
+    restart: always
     user: "${EDGEX_USER}:${EDGEX_GROUP}"

--- a/compose-builder/add-device-mqtt.yml
+++ b/compose-builder/add-device-mqtt.yml
@@ -23,6 +23,7 @@ services:
     container_name: edgex-device-mqtt
     hostname: edgex-device-mqtt
     read_only: true
+    restart: always
     networks:
       - edgex-network
     env_file:

--- a/compose-builder/add-device-rest.yml
+++ b/compose-builder/add-device-rest.yml
@@ -23,6 +23,7 @@ services:
     container_name: edgex-device-rest
     hostname: edgex-device-rest
     read_only: true
+    restart: always
     networks:
       - edgex-network
     env_file:

--- a/compose-builder/add-device-rfid-llrp.yml
+++ b/compose-builder/add-device-rfid-llrp.yml
@@ -23,6 +23,7 @@ services:
     container_name: edgex-device-rfid-llrp
     hostname: edgex-device-rfid-llrp
     read_only: true
+    restart: always
     networks:
       - edgex-network
     env_file:

--- a/compose-builder/add-device-snmp.yml
+++ b/compose-builder/add-device-snmp.yml
@@ -35,4 +35,6 @@ services:
       - metadata
     security_opt: 
       - no-new-privileges:true
+    read_only: true
+    restart: always
     user: "${EDGEX_USER}:${EDGEX_GROUP}"

--- a/compose-builder/add-device-virtual.yml
+++ b/compose-builder/add-device-virtual.yml
@@ -23,6 +23,7 @@ services:
     container_name: edgex-device-virtual
     hostname: edgex-device-virtual
     read_only: true
+    restart: always
     networks:
       - edgex-network
     env_file:

--- a/compose-builder/add-modbus-simulator.yml
+++ b/compose-builder/add-modbus-simulator.yml
@@ -25,6 +25,7 @@ services:
     networks:
       - edgex-network
     read_only: true
+    restart: always
     security_opt:
       - no-new-privileges:true
     user: "${EDGEX_USER}:${EDGEX_GROUP}"

--- a/compose-builder/add-mqtt-broker.yml
+++ b/compose-builder/add-mqtt-broker.yml
@@ -24,6 +24,7 @@ services:
     container_name: edgex-mqtt-broker
     hostname: edgex-mqtt-broker
     read_only: true
+    restart: always
     networks:
       - edgex-network
     security_opt:

--- a/compose-builder/add-security.yml
+++ b/compose-builder/add-security.yml
@@ -36,6 +36,7 @@ services:
     networks:
       - edgex-network
     read_only: true
+    restart: always
     env_file:
       - common-sec-stage-gate.env
     environment:
@@ -81,6 +82,7 @@ services:
       # in service "consul".
       #ADD_SECRETSTORE_TOKENS: app-sample,app-rules-engine-redis, app-rules-engine-mqtt, app-push-to-core
     read_only: true
+    restart: always
     networks:
       - edgex-network
     tmpfs:
@@ -148,6 +150,7 @@ services:
       - vault-logs:/vault/logs:z
     depends_on:
       - security-bootstrapper
+    restart: always
 
 # containers for reverse proxy
   kong-db:
@@ -156,6 +159,7 @@ services:
     container_name: edgex-kong-db
     hostname: edgex-kong-db
     read_only: true
+    restart: always
     networks:
       - edgex-network
     ports:
@@ -188,6 +192,7 @@ services:
     container_name: edgex-kong
     hostname: edgex-kong
     read_only: true
+    restart: always
     networks:
       - edgex-network
     ports:
@@ -212,7 +217,6 @@ services:
       KONG_DNS_VALID_TTL: '1'
       KONG_SSL_CIPHER_SUITE: modern
       KONG_NGINX_WORKER_PROCESSES: '1'
-    restart: on-failure
     tmpfs:
       - /run
       - /tmp

--- a/compose-builder/add-ui.yml
+++ b/compose-builder/add-ui.yml
@@ -23,6 +23,7 @@ services:
     container_name: edgex-ui-go
     hostname: edgex-ui-go
     read_only: true
+    restart: always
     networks:
       - edgex-network
     security_opt:

--- a/compose-builder/docker-compose-base.yml
+++ b/compose-builder/docker-compose-base.yml
@@ -37,6 +37,7 @@ services:
     container_name: edgex-core-consul
     hostname: edgex-core-consul
     read_only: true
+    restart: always
     networks:
       edgex-network:
     volumes:
@@ -53,6 +54,7 @@ services:
     container_name: edgex-redis
     hostname: edgex-redis
     read_only: true
+    restart: always
     networks:
       - edgex-network
     env_file:
@@ -70,6 +72,7 @@ services:
     container_name: edgex-sys-mgmt-agent
     hostname: edgex-sys-mgmt-agent
     read_only: true
+    restart: always
     networks:
       - edgex-network
     env_file:
@@ -99,6 +102,7 @@ services:
     container_name: edgex-support-notifications
     hostname: edgex-support-notifications
     read_only: true
+    restart: always
     networks:
       - edgex-network
     env_file:
@@ -119,6 +123,7 @@ services:
     container_name: edgex-core-metadata
     hostname: edgex-core-metadata
     read_only: true
+    restart: always
     networks:
       - edgex-network
     env_file:
@@ -142,6 +147,7 @@ services:
     container_name: edgex-core-data
     hostname: edgex-core-data
     read_only: true
+    restart: always
     networks:
       - edgex-network
     env_file:
@@ -164,6 +170,7 @@ services:
     container_name: edgex-core-command
     hostname: edgex-core-command
     read_only: true
+    restart: always
     networks:
       - edgex-network
     env_file:
@@ -185,6 +192,7 @@ services:
     container_name: edgex-support-scheduler
     hostname: edgex-support-scheduler
     read_only: true
+    restart: always
     networks:
       - edgex-network
     env_file:
@@ -207,6 +215,7 @@ services:
     container_name: edgex-app-rules-engine
     hostname: edgex-app-rules-engine
     read_only: true
+    restart: always
     networks:
       - edgex-network
     env_file:
@@ -230,6 +239,7 @@ services:
     container_name: edgex-kuiper
     hostname: edgex-kuiper
     read_only: true
+    restart: always
     networks:
       - edgex-network
     volumes:

--- a/docker-compose-arm64.yml
+++ b/docker-compose-arm64.yml
@@ -78,6 +78,7 @@ services:
     ports:
     - 127.0.0.1:59701:59701/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -132,6 +133,7 @@ services:
     ports:
     - 127.0.0.1:59882:59882/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -180,6 +182,7 @@ services:
     ports:
     - 127.0.0.1:8500:8500/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: root:root
@@ -240,6 +243,7 @@ services:
     - 127.0.0.1:5563:5563/tcp
     - 127.0.0.1:59880:59880/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -291,6 +295,7 @@ services:
     ports:
     - 127.0.0.1:6379:6379/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     tmpfs:
@@ -349,6 +354,7 @@ services:
     ports:
     - 127.0.0.1:59986:59986/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -403,6 +409,7 @@ services:
     ports:
     - 127.0.0.1:59900:59900/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -457,7 +464,7 @@ services:
     - 127.0.0.1:8100:8100/tcp
     - 8443:8443/tcp
     read_only: true
-    restart: on-failure
+    restart: always
     security_opt:
     - no-new-privileges:true
     tmpfs:
@@ -508,6 +515,7 @@ services:
     ports:
     - 127.0.0.1:5432:5432/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     tmpfs:
@@ -568,6 +576,7 @@ services:
     ports:
     - 127.0.0.1:59881:59881/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -622,6 +631,7 @@ services:
     ports:
     - 127.0.0.1:59860:59860/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -722,6 +732,7 @@ services:
     ports:
     - 127.0.0.1:59720:59720/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: kuiper:kuiper
@@ -779,6 +790,7 @@ services:
     ports:
     - 127.0.0.1:59861:59861/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -822,6 +834,7 @@ services:
     networks:
       edgex-network: {}
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     tmpfs:
@@ -862,6 +875,7 @@ services:
     networks:
       edgex-network: {}
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: root:root
@@ -919,6 +933,7 @@ services:
     ports:
     - 127.0.0.1:58890:58890/tcp
     read_only: true
+    restart: always
     security_opt:
     - label:disable
     - no-new-privileges:true
@@ -964,6 +979,7 @@ services:
       edgex-network: {}
     ports:
     - 127.0.0.1:8200:8200/tcp
+    restart: always
     tmpfs:
     - /vault/config
     user: root:root

--- a/docker-compose-no-secty-arm64.yml
+++ b/docker-compose-no-secty-arm64.yml
@@ -53,6 +53,7 @@ services:
     ports:
     - 127.0.0.1:59701:59701/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -79,6 +80,7 @@ services:
     ports:
     - 127.0.0.1:59882:59882/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -92,6 +94,7 @@ services:
     ports:
     - 127.0.0.1:8500:8500/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: root:root
@@ -123,6 +126,7 @@ services:
     - 127.0.0.1:5563:5563/tcp
     - 127.0.0.1:59880:59880/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -144,6 +148,7 @@ services:
     ports:
     - 127.0.0.1:6379:6379/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: root:root
@@ -173,6 +178,7 @@ services:
     ports:
     - 127.0.0.1:59986:59986/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -200,6 +206,7 @@ services:
     ports:
     - 127.0.0.1:59900:59900/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -227,6 +234,7 @@ services:
     ports:
     - 127.0.0.1:59881:59881/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -252,6 +260,7 @@ services:
     ports:
     - 127.0.0.1:59860:59860/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -274,6 +283,7 @@ services:
     ports:
     - 127.0.0.1:59720:59720/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: kuiper:kuiper
@@ -303,6 +313,7 @@ services:
     ports:
     - 127.0.0.1:59861:59861/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -334,6 +345,7 @@ services:
     ports:
     - 127.0.0.1:58890:58890/tcp
     read_only: true
+    restart: always
     security_opt:
     - label:disable
     - no-new-privileges:true

--- a/docker-compose-no-secty-with-ui-arm64.yml
+++ b/docker-compose-no-secty-with-ui-arm64.yml
@@ -53,6 +53,7 @@ services:
     ports:
     - 127.0.0.1:59701:59701/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -82,6 +83,7 @@ services:
     ports:
     - 127.0.0.1:59700:59700/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -108,6 +110,7 @@ services:
     ports:
     - 127.0.0.1:59882:59882/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -121,6 +124,7 @@ services:
     ports:
     - 127.0.0.1:8500:8500/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: root:root
@@ -152,6 +156,7 @@ services:
     - 127.0.0.1:5563:5563/tcp
     - 127.0.0.1:59880:59880/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -173,6 +178,7 @@ services:
     ports:
     - 127.0.0.1:6379:6379/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: root:root
@@ -202,6 +208,7 @@ services:
     ports:
     - 127.0.0.1:59986:59986/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -229,6 +236,7 @@ services:
     ports:
     - 127.0.0.1:59900:59900/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -256,6 +264,7 @@ services:
     ports:
     - 127.0.0.1:59881:59881/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -281,6 +290,7 @@ services:
     ports:
     - 127.0.0.1:59860:59860/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -303,6 +313,7 @@ services:
     ports:
     - 127.0.0.1:59720:59720/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: kuiper:kuiper
@@ -332,6 +343,7 @@ services:
     ports:
     - 127.0.0.1:59861:59861/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -363,6 +375,7 @@ services:
     ports:
     - 127.0.0.1:58890:58890/tcp
     read_only: true
+    restart: always
     security_opt:
     - label:disable
     - no-new-privileges:true
@@ -378,6 +391,7 @@ services:
     ports:
     - 127.0.0.1:4000:4000/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001

--- a/docker-compose-no-secty-with-ui.yml
+++ b/docker-compose-no-secty-with-ui.yml
@@ -53,6 +53,7 @@ services:
     ports:
     - 127.0.0.1:59701:59701/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -82,6 +83,7 @@ services:
     ports:
     - 127.0.0.1:59700:59700/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -108,6 +110,7 @@ services:
     ports:
     - 127.0.0.1:59882:59882/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -121,6 +124,7 @@ services:
     ports:
     - 127.0.0.1:8500:8500/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: root:root
@@ -152,6 +156,7 @@ services:
     - 127.0.0.1:5563:5563/tcp
     - 127.0.0.1:59880:59880/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -173,6 +178,7 @@ services:
     ports:
     - 127.0.0.1:6379:6379/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: root:root
@@ -202,6 +208,7 @@ services:
     ports:
     - 127.0.0.1:59986:59986/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -229,6 +236,7 @@ services:
     ports:
     - 127.0.0.1:59900:59900/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -256,6 +264,7 @@ services:
     ports:
     - 127.0.0.1:59881:59881/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -281,6 +290,7 @@ services:
     ports:
     - 127.0.0.1:59860:59860/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -303,6 +313,7 @@ services:
     ports:
     - 127.0.0.1:59720:59720/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: kuiper:kuiper
@@ -332,6 +343,7 @@ services:
     ports:
     - 127.0.0.1:59861:59861/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -363,6 +375,7 @@ services:
     ports:
     - 127.0.0.1:58890:58890/tcp
     read_only: true
+    restart: always
     security_opt:
     - label:disable
     - no-new-privileges:true
@@ -378,6 +391,7 @@ services:
     ports:
     - 127.0.0.1:4000:4000/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001

--- a/docker-compose-no-secty.yml
+++ b/docker-compose-no-secty.yml
@@ -53,6 +53,7 @@ services:
     ports:
     - 127.0.0.1:59701:59701/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -79,6 +80,7 @@ services:
     ports:
     - 127.0.0.1:59882:59882/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -92,6 +94,7 @@ services:
     ports:
     - 127.0.0.1:8500:8500/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: root:root
@@ -123,6 +126,7 @@ services:
     - 127.0.0.1:5563:5563/tcp
     - 127.0.0.1:59880:59880/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -144,6 +148,7 @@ services:
     ports:
     - 127.0.0.1:6379:6379/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: root:root
@@ -173,6 +178,7 @@ services:
     ports:
     - 127.0.0.1:59986:59986/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -200,6 +206,7 @@ services:
     ports:
     - 127.0.0.1:59900:59900/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -227,6 +234,7 @@ services:
     ports:
     - 127.0.0.1:59881:59881/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -252,6 +260,7 @@ services:
     ports:
     - 127.0.0.1:59860:59860/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -274,6 +283,7 @@ services:
     ports:
     - 127.0.0.1:59720:59720/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: kuiper:kuiper
@@ -303,6 +313,7 @@ services:
     ports:
     - 127.0.0.1:59861:59861/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -334,6 +345,7 @@ services:
     ports:
     - 127.0.0.1:58890:58890/tcp
     read_only: true
+    restart: always
     security_opt:
     - label:disable
     - no-new-privileges:true

--- a/docker-compose-portainer.yml
+++ b/docker-compose-portainer.yml
@@ -24,6 +24,7 @@ services:
     ports:
       - "127.0.0.1:9000:9000"
     container_name: portainer
+    restart: always
     command: -H unix:///var/run/docker.sock
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:z

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -78,6 +78,7 @@ services:
     ports:
     - 127.0.0.1:59701:59701/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -132,6 +133,7 @@ services:
     ports:
     - 127.0.0.1:59882:59882/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -180,6 +182,7 @@ services:
     ports:
     - 127.0.0.1:8500:8500/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: root:root
@@ -240,6 +243,7 @@ services:
     - 127.0.0.1:5563:5563/tcp
     - 127.0.0.1:59880:59880/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -291,6 +295,7 @@ services:
     ports:
     - 127.0.0.1:6379:6379/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     tmpfs:
@@ -349,6 +354,7 @@ services:
     ports:
     - 127.0.0.1:59986:59986/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -403,6 +409,7 @@ services:
     ports:
     - 127.0.0.1:59900:59900/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -457,7 +464,7 @@ services:
     - 127.0.0.1:8100:8100/tcp
     - 8443:8443/tcp
     read_only: true
-    restart: on-failure
+    restart: always
     security_opt:
     - no-new-privileges:true
     tmpfs:
@@ -508,6 +515,7 @@ services:
     ports:
     - 127.0.0.1:5432:5432/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     tmpfs:
@@ -568,6 +576,7 @@ services:
     ports:
     - 127.0.0.1:59881:59881/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -622,6 +631,7 @@ services:
     ports:
     - 127.0.0.1:59860:59860/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -722,6 +732,7 @@ services:
     ports:
     - 127.0.0.1:59720:59720/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: kuiper:kuiper
@@ -779,6 +790,7 @@ services:
     ports:
     - 127.0.0.1:59861:59861/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -822,6 +834,7 @@ services:
     networks:
       edgex-network: {}
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     tmpfs:
@@ -862,6 +875,7 @@ services:
     networks:
       edgex-network: {}
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: root:root
@@ -919,6 +933,7 @@ services:
     ports:
     - 127.0.0.1:58890:58890/tcp
     read_only: true
+    restart: always
     security_opt:
     - label:disable
     - no-new-privileges:true
@@ -964,6 +979,7 @@ services:
       edgex-network: {}
     ports:
     - 127.0.0.1:8200:8200/tcp
+    restart: always
     tmpfs:
     - /vault/config
     user: root:root

--- a/taf/docker-compose-taf-arm64.yml
+++ b/taf/docker-compose-taf-arm64.yml
@@ -138,6 +138,7 @@ services:
     ports:
     - 127.0.0.1:59704:59704/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -201,6 +202,7 @@ services:
     ports:
     - 127.0.0.1:59703:59703/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -257,6 +259,7 @@ services:
     ports:
     - 127.0.0.1:59701:59701/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -311,6 +314,7 @@ services:
     ports:
     - 127.0.0.1:59882:59882/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -359,6 +363,7 @@ services:
     ports:
     - 127.0.0.1:8500:8500/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: root:root
@@ -419,6 +424,7 @@ services:
     - 127.0.0.1:5563:5563/tcp
     - 127.0.0.1:59880:59880/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -470,6 +476,7 @@ services:
     ports:
     - 127.0.0.1:6379:6379/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     tmpfs:
@@ -528,6 +535,8 @@ services:
       edgex-network: {}
     ports:
     - 127.0.0.1:59901:59901/tcp
+    read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -583,6 +592,7 @@ services:
     ports:
     - 127.0.0.1:59986:59986/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -637,6 +647,7 @@ services:
     ports:
     - 127.0.0.1:59900:59900/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -692,7 +703,7 @@ services:
     - 127.0.0.1:8100:8100/tcp
     - 8443:8443/tcp
     read_only: true
-    restart: on-failure
+    restart: always
     security_opt:
     - no-new-privileges:true
     tmpfs:
@@ -743,6 +754,7 @@ services:
     ports:
     - 127.0.0.1:5432:5432/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     tmpfs:
@@ -803,6 +815,7 @@ services:
     ports:
     - 127.0.0.1:59881:59881/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -818,6 +831,7 @@ services:
     ports:
     - 127.0.0.1:1502:1502/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -831,6 +845,7 @@ services:
     ports:
     - 1883:1883/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -882,6 +897,7 @@ services:
     ports:
     - 127.0.0.1:59860:59860/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -982,6 +998,7 @@ services:
     ports:
     - 127.0.0.1:59720:59720/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: kuiper:kuiper
@@ -1103,6 +1120,7 @@ services:
     ports:
     - 127.0.0.1:59861:59861/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -1146,6 +1164,7 @@ services:
     networks:
       edgex-network: {}
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     tmpfs:
@@ -1186,6 +1205,7 @@ services:
     networks:
       edgex-network: {}
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: root:root
@@ -1243,6 +1263,7 @@ services:
     ports:
     - 127.0.0.1:58890:58890/tcp
     read_only: true
+    restart: always
     security_opt:
     - label:disable
     - no-new-privileges:true
@@ -1288,6 +1309,7 @@ services:
       edgex-network: {}
     ports:
     - 127.0.0.1:8200:8200/tcp
+    restart: always
     tmpfs:
     - /vault/config
     user: root:root

--- a/taf/docker-compose-taf-mqtt-bus-arm64.yml
+++ b/taf/docker-compose-taf-mqtt-bus-arm64.yml
@@ -145,6 +145,7 @@ services:
     ports:
     - 127.0.0.1:59704:59704/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -215,6 +216,7 @@ services:
     ports:
     - 127.0.0.1:59703:59703/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -278,6 +280,7 @@ services:
     ports:
     - 127.0.0.1:59701:59701/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -332,6 +335,7 @@ services:
     ports:
     - 127.0.0.1:59882:59882/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -380,6 +384,7 @@ services:
     ports:
     - 127.0.0.1:8500:8500/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: root:root
@@ -446,6 +451,7 @@ services:
     - 127.0.0.1:5563:5563/tcp
     - 127.0.0.1:59880:59880/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -497,6 +503,7 @@ services:
     ports:
     - 127.0.0.1:6379:6379/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     tmpfs:
@@ -560,6 +567,8 @@ services:
       edgex-network: {}
     ports:
     - 127.0.0.1:59901:59901/tcp
+    read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -620,6 +629,7 @@ services:
     ports:
     - 127.0.0.1:59986:59986/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -679,6 +689,7 @@ services:
     ports:
     - 127.0.0.1:59900:59900/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -734,7 +745,7 @@ services:
     - 127.0.0.1:8100:8100/tcp
     - 8443:8443/tcp
     read_only: true
-    restart: on-failure
+    restart: always
     security_opt:
     - no-new-privileges:true
     tmpfs:
@@ -785,6 +796,7 @@ services:
     ports:
     - 127.0.0.1:5432:5432/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     tmpfs:
@@ -845,6 +857,7 @@ services:
     ports:
     - 127.0.0.1:59881:59881/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -860,6 +873,7 @@ services:
     ports:
     - 127.0.0.1:1502:1502/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -873,6 +887,7 @@ services:
     ports:
     - 1883:1883/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -924,6 +939,7 @@ services:
     ports:
     - 127.0.0.1:59860:59860/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -1004,6 +1020,7 @@ services:
     ports:
     - 127.0.0.1:59720:59720/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: kuiper:kuiper
@@ -1130,6 +1147,7 @@ services:
     ports:
     - 127.0.0.1:59861:59861/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -1172,6 +1190,7 @@ services:
     networks:
       edgex-network: {}
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     tmpfs:
@@ -1211,6 +1230,7 @@ services:
     networks:
       edgex-network: {}
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: root:root
@@ -1268,6 +1288,7 @@ services:
     ports:
     - 127.0.0.1:58890:58890/tcp
     read_only: true
+    restart: always
     security_opt:
     - label:disable
     - no-new-privileges:true
@@ -1313,6 +1334,7 @@ services:
       edgex-network: {}
     ports:
     - 127.0.0.1:8200:8200/tcp
+    restart: always
     tmpfs:
     - /vault/config
     user: root:root

--- a/taf/docker-compose-taf-mqtt-bus.yml
+++ b/taf/docker-compose-taf-mqtt-bus.yml
@@ -145,6 +145,7 @@ services:
     ports:
     - 127.0.0.1:59704:59704/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -215,6 +216,7 @@ services:
     ports:
     - 127.0.0.1:59703:59703/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -278,6 +280,7 @@ services:
     ports:
     - 127.0.0.1:59701:59701/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -332,6 +335,7 @@ services:
     ports:
     - 127.0.0.1:59882:59882/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -380,6 +384,7 @@ services:
     ports:
     - 127.0.0.1:8500:8500/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: root:root
@@ -446,6 +451,7 @@ services:
     - 127.0.0.1:5563:5563/tcp
     - 127.0.0.1:59880:59880/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -497,6 +503,7 @@ services:
     ports:
     - 127.0.0.1:6379:6379/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     tmpfs:
@@ -560,6 +567,8 @@ services:
       edgex-network: {}
     ports:
     - 127.0.0.1:59901:59901/tcp
+    read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -620,6 +629,7 @@ services:
     ports:
     - 127.0.0.1:59986:59986/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -679,6 +689,7 @@ services:
     ports:
     - 127.0.0.1:59900:59900/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -734,7 +745,7 @@ services:
     - 127.0.0.1:8100:8100/tcp
     - 8443:8443/tcp
     read_only: true
-    restart: on-failure
+    restart: always
     security_opt:
     - no-new-privileges:true
     tmpfs:
@@ -785,6 +796,7 @@ services:
     ports:
     - 127.0.0.1:5432:5432/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     tmpfs:
@@ -845,6 +857,7 @@ services:
     ports:
     - 127.0.0.1:59881:59881/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -860,6 +873,7 @@ services:
     ports:
     - 127.0.0.1:1502:1502/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -873,6 +887,7 @@ services:
     ports:
     - 1883:1883/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -924,6 +939,7 @@ services:
     ports:
     - 127.0.0.1:59860:59860/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -1004,6 +1020,7 @@ services:
     ports:
     - 127.0.0.1:59720:59720/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: kuiper:kuiper
@@ -1130,6 +1147,7 @@ services:
     ports:
     - 127.0.0.1:59861:59861/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -1172,6 +1190,7 @@ services:
     networks:
       edgex-network: {}
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     tmpfs:
@@ -1211,6 +1230,7 @@ services:
     networks:
       edgex-network: {}
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: root:root
@@ -1268,6 +1288,7 @@ services:
     ports:
     - 127.0.0.1:58890:58890/tcp
     read_only: true
+    restart: always
     security_opt:
     - label:disable
     - no-new-privileges:true
@@ -1313,6 +1334,7 @@ services:
       edgex-network: {}
     ports:
     - 127.0.0.1:8200:8200/tcp
+    restart: always
     tmpfs:
     - /vault/config
     user: root:root

--- a/taf/docker-compose-taf-no-secty-arm64.yml
+++ b/taf/docker-compose-taf-no-secty-arm64.yml
@@ -85,6 +85,7 @@ services:
     ports:
     - 127.0.0.1:59704:59704/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -117,6 +118,7 @@ services:
     ports:
     - 127.0.0.1:59703:59703/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -145,6 +147,7 @@ services:
     ports:
     - 127.0.0.1:59701:59701/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -171,6 +174,7 @@ services:
     ports:
     - 127.0.0.1:59882:59882/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -184,6 +188,7 @@ services:
     ports:
     - 127.0.0.1:8500:8500/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: root:root
@@ -215,6 +220,7 @@ services:
     - 127.0.0.1:5563:5563/tcp
     - 127.0.0.1:59880:59880/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -236,6 +242,7 @@ services:
     ports:
     - 127.0.0.1:6379:6379/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: root:root
@@ -266,6 +273,8 @@ services:
       edgex-network: {}
     ports:
     - 127.0.0.1:59901:59901/tcp
+    read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -295,6 +304,7 @@ services:
     ports:
     - 127.0.0.1:59986:59986/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -323,6 +333,7 @@ services:
     ports:
     - 127.0.0.1:59900:59900/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -352,6 +363,7 @@ services:
     ports:
     - 127.0.0.1:59881:59881/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -364,6 +376,7 @@ services:
     ports:
     - 127.0.0.1:1502:1502/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -377,6 +390,7 @@ services:
     ports:
     - 1883:1883/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -402,6 +416,7 @@ services:
     ports:
     - 127.0.0.1:59860:59860/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -424,6 +439,7 @@ services:
     ports:
     - 127.0.0.1:59720:59720/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: kuiper:kuiper
@@ -487,6 +503,7 @@ services:
     ports:
     - 127.0.0.1:59861:59861/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -518,6 +535,7 @@ services:
     ports:
     - 127.0.0.1:58890:58890/tcp
     read_only: true
+    restart: always
     security_opt:
     - label:disable
     - no-new-privileges:true

--- a/taf/docker-compose-taf-no-secty-mqtt-bus-arm64.yml
+++ b/taf/docker-compose-taf-no-secty-mqtt-bus-arm64.yml
@@ -92,6 +92,7 @@ services:
     ports:
     - 127.0.0.1:59704:59704/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -131,6 +132,7 @@ services:
     ports:
     - 127.0.0.1:59703:59703/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -166,6 +168,7 @@ services:
     ports:
     - 127.0.0.1:59701:59701/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -192,6 +195,7 @@ services:
     ports:
     - 127.0.0.1:59882:59882/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -205,6 +209,7 @@ services:
     ports:
     - 127.0.0.1:8500:8500/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: root:root
@@ -242,6 +247,7 @@ services:
     - 127.0.0.1:5563:5563/tcp
     - 127.0.0.1:59880:59880/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -263,6 +269,7 @@ services:
     ports:
     - 127.0.0.1:6379:6379/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: root:root
@@ -298,6 +305,8 @@ services:
       edgex-network: {}
     ports:
     - 127.0.0.1:59901:59901/tcp
+    read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -332,6 +341,7 @@ services:
     ports:
     - 127.0.0.1:59986:59986/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -365,6 +375,7 @@ services:
     ports:
     - 127.0.0.1:59900:59900/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -394,6 +405,7 @@ services:
     ports:
     - 127.0.0.1:59881:59881/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -406,6 +418,7 @@ services:
     ports:
     - 127.0.0.1:1502:1502/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -419,6 +432,7 @@ services:
     ports:
     - 1883:1883/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -444,6 +458,7 @@ services:
     ports:
     - 127.0.0.1:59860:59860/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -468,6 +483,7 @@ services:
     ports:
     - 127.0.0.1:59720:59720/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: kuiper:kuiper
@@ -538,6 +554,7 @@ services:
     ports:
     - 127.0.0.1:59861:59861/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -569,6 +586,7 @@ services:
     ports:
     - 127.0.0.1:58890:58890/tcp
     read_only: true
+    restart: always
     security_opt:
     - label:disable
     - no-new-privileges:true

--- a/taf/docker-compose-taf-no-secty-mqtt-bus.yml
+++ b/taf/docker-compose-taf-no-secty-mqtt-bus.yml
@@ -92,6 +92,7 @@ services:
     ports:
     - 127.0.0.1:59704:59704/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -131,6 +132,7 @@ services:
     ports:
     - 127.0.0.1:59703:59703/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -166,6 +168,7 @@ services:
     ports:
     - 127.0.0.1:59701:59701/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -192,6 +195,7 @@ services:
     ports:
     - 127.0.0.1:59882:59882/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -205,6 +209,7 @@ services:
     ports:
     - 127.0.0.1:8500:8500/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: root:root
@@ -242,6 +247,7 @@ services:
     - 127.0.0.1:5563:5563/tcp
     - 127.0.0.1:59880:59880/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -263,6 +269,7 @@ services:
     ports:
     - 127.0.0.1:6379:6379/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: root:root
@@ -298,6 +305,8 @@ services:
       edgex-network: {}
     ports:
     - 127.0.0.1:59901:59901/tcp
+    read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -332,6 +341,7 @@ services:
     ports:
     - 127.0.0.1:59986:59986/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -365,6 +375,7 @@ services:
     ports:
     - 127.0.0.1:59900:59900/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -394,6 +405,7 @@ services:
     ports:
     - 127.0.0.1:59881:59881/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -406,6 +418,7 @@ services:
     ports:
     - 127.0.0.1:1502:1502/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -419,6 +432,7 @@ services:
     ports:
     - 1883:1883/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -444,6 +458,7 @@ services:
     ports:
     - 127.0.0.1:59860:59860/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -468,6 +483,7 @@ services:
     ports:
     - 127.0.0.1:59720:59720/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: kuiper:kuiper
@@ -538,6 +554,7 @@ services:
     ports:
     - 127.0.0.1:59861:59861/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -569,6 +586,7 @@ services:
     ports:
     - 127.0.0.1:58890:58890/tcp
     read_only: true
+    restart: always
     security_opt:
     - label:disable
     - no-new-privileges:true

--- a/taf/docker-compose-taf-no-secty.yml
+++ b/taf/docker-compose-taf-no-secty.yml
@@ -85,6 +85,7 @@ services:
     ports:
     - 127.0.0.1:59704:59704/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -117,6 +118,7 @@ services:
     ports:
     - 127.0.0.1:59703:59703/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -145,6 +147,7 @@ services:
     ports:
     - 127.0.0.1:59701:59701/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -171,6 +174,7 @@ services:
     ports:
     - 127.0.0.1:59882:59882/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -184,6 +188,7 @@ services:
     ports:
     - 127.0.0.1:8500:8500/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: root:root
@@ -215,6 +220,7 @@ services:
     - 127.0.0.1:5563:5563/tcp
     - 127.0.0.1:59880:59880/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -236,6 +242,7 @@ services:
     ports:
     - 127.0.0.1:6379:6379/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: root:root
@@ -266,6 +273,8 @@ services:
       edgex-network: {}
     ports:
     - 127.0.0.1:59901:59901/tcp
+    read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -295,6 +304,7 @@ services:
     ports:
     - 127.0.0.1:59986:59986/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -323,6 +333,7 @@ services:
     ports:
     - 127.0.0.1:59900:59900/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -352,6 +363,7 @@ services:
     ports:
     - 127.0.0.1:59881:59881/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -364,6 +376,7 @@ services:
     ports:
     - 127.0.0.1:1502:1502/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -377,6 +390,7 @@ services:
     ports:
     - 1883:1883/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -402,6 +416,7 @@ services:
     ports:
     - 127.0.0.1:59860:59860/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -424,6 +439,7 @@ services:
     ports:
     - 127.0.0.1:59720:59720/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: kuiper:kuiper
@@ -487,6 +503,7 @@ services:
     ports:
     - 127.0.0.1:59861:59861/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -518,6 +535,7 @@ services:
     ports:
     - 127.0.0.1:58890:58890/tcp
     read_only: true
+    restart: always
     security_opt:
     - label:disable
     - no-new-privileges:true

--- a/taf/docker-compose-taf-perf-arm64.yml
+++ b/taf/docker-compose-taf-perf-arm64.yml
@@ -85,6 +85,7 @@ services:
     ports:
     - 127.0.0.1:59703:59703/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -141,6 +142,7 @@ services:
     ports:
     - 127.0.0.1:59701:59701/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -195,6 +197,7 @@ services:
     ports:
     - 127.0.0.1:59882:59882/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -243,6 +246,7 @@ services:
     ports:
     - 127.0.0.1:8500:8500/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: root:root
@@ -303,6 +307,7 @@ services:
     - 127.0.0.1:5563:5563/tcp
     - 127.0.0.1:59880:59880/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -354,6 +359,7 @@ services:
     ports:
     - 127.0.0.1:6379:6379/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     tmpfs:
@@ -412,6 +418,7 @@ services:
     ports:
     - 127.0.0.1:59986:59986/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -466,6 +473,7 @@ services:
     ports:
     - 127.0.0.1:59900:59900/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -520,7 +528,7 @@ services:
     - 127.0.0.1:8100:8100/tcp
     - 8443:8443/tcp
     read_only: true
-    restart: on-failure
+    restart: always
     security_opt:
     - no-new-privileges:true
     tmpfs:
@@ -571,6 +579,7 @@ services:
     ports:
     - 127.0.0.1:5432:5432/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     tmpfs:
@@ -631,6 +640,7 @@ services:
     ports:
     - 127.0.0.1:59881:59881/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -647,6 +657,7 @@ services:
     ports:
     - 1883:1883/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -698,6 +709,7 @@ services:
     ports:
     - 127.0.0.1:59860:59860/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -798,6 +810,7 @@ services:
     ports:
     - 127.0.0.1:59720:59720/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: kuiper:kuiper
@@ -855,6 +868,7 @@ services:
     ports:
     - 127.0.0.1:59861:59861/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -898,6 +912,7 @@ services:
     networks:
       edgex-network: {}
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     tmpfs:
@@ -938,6 +953,7 @@ services:
     networks:
       edgex-network: {}
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: root:root
@@ -995,6 +1011,7 @@ services:
     ports:
     - 127.0.0.1:58890:58890/tcp
     read_only: true
+    restart: always
     security_opt:
     - label:disable
     - no-new-privileges:true
@@ -1040,6 +1057,7 @@ services:
       edgex-network: {}
     ports:
     - 127.0.0.1:8200:8200/tcp
+    restart: always
     tmpfs:
     - /vault/config
     user: root:root

--- a/taf/docker-compose-taf-perf-no-secty-arm64.yml
+++ b/taf/docker-compose-taf-perf-no-secty-arm64.yml
@@ -57,6 +57,7 @@ services:
     ports:
     - 127.0.0.1:59703:59703/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -85,6 +86,7 @@ services:
     ports:
     - 127.0.0.1:59701:59701/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -111,6 +113,7 @@ services:
     ports:
     - 127.0.0.1:59882:59882/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -124,6 +127,7 @@ services:
     ports:
     - 127.0.0.1:8500:8500/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: root:root
@@ -155,6 +159,7 @@ services:
     - 127.0.0.1:5563:5563/tcp
     - 127.0.0.1:59880:59880/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -176,6 +181,7 @@ services:
     ports:
     - 127.0.0.1:6379:6379/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: root:root
@@ -205,6 +211,7 @@ services:
     ports:
     - 127.0.0.1:59986:59986/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -232,6 +239,7 @@ services:
     ports:
     - 127.0.0.1:59900:59900/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -259,6 +267,7 @@ services:
     ports:
     - 127.0.0.1:59881:59881/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -272,6 +281,7 @@ services:
     ports:
     - 1883:1883/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -297,6 +307,7 @@ services:
     ports:
     - 127.0.0.1:59860:59860/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -319,6 +330,7 @@ services:
     ports:
     - 127.0.0.1:59720:59720/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: kuiper:kuiper
@@ -348,6 +360,7 @@ services:
     ports:
     - 127.0.0.1:59861:59861/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -379,6 +392,7 @@ services:
     ports:
     - 127.0.0.1:58890:58890/tcp
     read_only: true
+    restart: always
     security_opt:
     - label:disable
     - no-new-privileges:true

--- a/taf/docker-compose-taf-perf-no-secty.yml
+++ b/taf/docker-compose-taf-perf-no-secty.yml
@@ -57,6 +57,7 @@ services:
     ports:
     - 127.0.0.1:59703:59703/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -85,6 +86,7 @@ services:
     ports:
     - 127.0.0.1:59701:59701/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -111,6 +113,7 @@ services:
     ports:
     - 127.0.0.1:59882:59882/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -124,6 +127,7 @@ services:
     ports:
     - 127.0.0.1:8500:8500/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: root:root
@@ -155,6 +159,7 @@ services:
     - 127.0.0.1:5563:5563/tcp
     - 127.0.0.1:59880:59880/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -176,6 +181,7 @@ services:
     ports:
     - 127.0.0.1:6379:6379/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: root:root
@@ -205,6 +211,7 @@ services:
     ports:
     - 127.0.0.1:59986:59986/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -232,6 +239,7 @@ services:
     ports:
     - 127.0.0.1:59900:59900/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -259,6 +267,7 @@ services:
     ports:
     - 127.0.0.1:59881:59881/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -272,6 +281,7 @@ services:
     ports:
     - 1883:1883/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -297,6 +307,7 @@ services:
     ports:
     - 127.0.0.1:59860:59860/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -319,6 +330,7 @@ services:
     ports:
     - 127.0.0.1:59720:59720/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: kuiper:kuiper
@@ -348,6 +360,7 @@ services:
     ports:
     - 127.0.0.1:59861:59861/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -379,6 +392,7 @@ services:
     ports:
     - 127.0.0.1:58890:58890/tcp
     read_only: true
+    restart: always
     security_opt:
     - label:disable
     - no-new-privileges:true

--- a/taf/docker-compose-taf-perf.yml
+++ b/taf/docker-compose-taf-perf.yml
@@ -85,6 +85,7 @@ services:
     ports:
     - 127.0.0.1:59703:59703/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -141,6 +142,7 @@ services:
     ports:
     - 127.0.0.1:59701:59701/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -195,6 +197,7 @@ services:
     ports:
     - 127.0.0.1:59882:59882/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -243,6 +246,7 @@ services:
     ports:
     - 127.0.0.1:8500:8500/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: root:root
@@ -303,6 +307,7 @@ services:
     - 127.0.0.1:5563:5563/tcp
     - 127.0.0.1:59880:59880/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -354,6 +359,7 @@ services:
     ports:
     - 127.0.0.1:6379:6379/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     tmpfs:
@@ -412,6 +418,7 @@ services:
     ports:
     - 127.0.0.1:59986:59986/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -466,6 +473,7 @@ services:
     ports:
     - 127.0.0.1:59900:59900/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -520,7 +528,7 @@ services:
     - 127.0.0.1:8100:8100/tcp
     - 8443:8443/tcp
     read_only: true
-    restart: on-failure
+    restart: always
     security_opt:
     - no-new-privileges:true
     tmpfs:
@@ -571,6 +579,7 @@ services:
     ports:
     - 127.0.0.1:5432:5432/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     tmpfs:
@@ -631,6 +640,7 @@ services:
     ports:
     - 127.0.0.1:59881:59881/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -647,6 +657,7 @@ services:
     ports:
     - 1883:1883/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -698,6 +709,7 @@ services:
     ports:
     - 127.0.0.1:59860:59860/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -798,6 +810,7 @@ services:
     ports:
     - 127.0.0.1:59720:59720/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: kuiper:kuiper
@@ -855,6 +868,7 @@ services:
     ports:
     - 127.0.0.1:59861:59861/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -898,6 +912,7 @@ services:
     networks:
       edgex-network: {}
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     tmpfs:
@@ -938,6 +953,7 @@ services:
     networks:
       edgex-network: {}
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: root:root
@@ -995,6 +1011,7 @@ services:
     ports:
     - 127.0.0.1:58890:58890/tcp
     read_only: true
+    restart: always
     security_opt:
     - label:disable
     - no-new-privileges:true
@@ -1040,6 +1057,7 @@ services:
       edgex-network: {}
     ports:
     - 127.0.0.1:8200:8200/tcp
+    restart: always
     tmpfs:
     - /vault/config
     user: root:root

--- a/taf/docker-compose-taf.yml
+++ b/taf/docker-compose-taf.yml
@@ -138,6 +138,7 @@ services:
     ports:
     - 127.0.0.1:59704:59704/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -201,6 +202,7 @@ services:
     ports:
     - 127.0.0.1:59703:59703/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -257,6 +259,7 @@ services:
     ports:
     - 127.0.0.1:59701:59701/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -311,6 +314,7 @@ services:
     ports:
     - 127.0.0.1:59882:59882/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -359,6 +363,7 @@ services:
     ports:
     - 127.0.0.1:8500:8500/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: root:root
@@ -419,6 +424,7 @@ services:
     - 127.0.0.1:5563:5563/tcp
     - 127.0.0.1:59880:59880/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -470,6 +476,7 @@ services:
     ports:
     - 127.0.0.1:6379:6379/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     tmpfs:
@@ -528,6 +535,8 @@ services:
       edgex-network: {}
     ports:
     - 127.0.0.1:59901:59901/tcp
+    read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -583,6 +592,7 @@ services:
     ports:
     - 127.0.0.1:59986:59986/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -637,6 +647,7 @@ services:
     ports:
     - 127.0.0.1:59900:59900/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -692,7 +703,7 @@ services:
     - 127.0.0.1:8100:8100/tcp
     - 8443:8443/tcp
     read_only: true
-    restart: on-failure
+    restart: always
     security_opt:
     - no-new-privileges:true
     tmpfs:
@@ -743,6 +754,7 @@ services:
     ports:
     - 127.0.0.1:5432:5432/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     tmpfs:
@@ -803,6 +815,7 @@ services:
     ports:
     - 127.0.0.1:59881:59881/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -818,6 +831,7 @@ services:
     ports:
     - 127.0.0.1:1502:1502/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -831,6 +845,7 @@ services:
     ports:
     - 1883:1883/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -882,6 +897,7 @@ services:
     ports:
     - 127.0.0.1:59860:59860/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -982,6 +998,7 @@ services:
     ports:
     - 127.0.0.1:59720:59720/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: kuiper:kuiper
@@ -1103,6 +1120,7 @@ services:
     ports:
     - 127.0.0.1:59861:59861/tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -1146,6 +1164,7 @@ services:
     networks:
       edgex-network: {}
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     tmpfs:
@@ -1186,6 +1205,7 @@ services:
     networks:
       edgex-network: {}
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: root:root
@@ -1243,6 +1263,7 @@ services:
     ports:
     - 127.0.0.1:58890:58890/tcp
     read_only: true
+    restart: always
     security_opt:
     - label:disable
     - no-new-privileges:true
@@ -1288,6 +1309,7 @@ services:
       edgex-network: {}
     ports:
     - 127.0.0.1:8200:8200/tcp
+    restart: always
     tmpfs:
     - /vault/config
     user: root:root


### PR DESCRIPTION
closes #184

Have to use `restart: always` to ensure container restart after reboot. 

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-compose/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-compose/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  **Docs not impacted**


## Testing Instructions
1. run the default secure compose file, i.e. `make run` from repo root folder
2. run `make get-token` and use token to to do GET to https://localhost:8443/core-metadata/api/v2/ping
   - Verify 200 response code.
   - Save token for use later
3. run `make get-consul-acl-token` and use token to login to Consul at localhost:8500 in browser
4. Navigate to `http://localhost:8500/ui/dc1/kv/edgex/appservices/2.0/app-rules-engine/Writable/LogLevel/edit`
5. Change value to `DEBUG`
6. run `make portainer`
7. Open localhost:9000 in browser and set password if prompted.
8. Navigate to viewing containers and then display logs for ` edgex-app-rules-engine`
   - Verify data is flowing, i.e. logs show events being processed
9. Reboot the system
10. Open localhost:9000 in browser and verify all containers have started.
11. Open Consul at localhost:8500 in browser and navigate to `http://localhost:8500/ui/dc1/kv/edgex/appservices/2.0/app-rules-engine/Writable/LogLevel/edit`
   - Note you are still logged in. i.e. didn't have to use access token
12. Use API Token from above to to do GET to https://localhost:8443/core-metadata/api/v2/ping
   - Verify 200 response code.
