### PR TITLE
feat: Open Consul port for off system access

### DIFF
--- a/compose-builder/docker-compose-base.yml
+++ b/compose-builder/docker-compose-base.yml
@@ -33,7 +33,7 @@ services:
     command: "agent -ui -bootstrap -server -client 0.0.0.0"
     user: "root:root" # Note that Consul is run under the 'consul' user, but entry point scripts need to first run as root
     ports:
-      - "127.0.0.1:8500:8500"
+      - "8500:8500"
     container_name: edgex-core-consul
     hostname: edgex-core-consul
     read_only: true

--- a/docker-compose-arm64.yml
+++ b/docker-compose-arm64.yml
@@ -180,7 +180,7 @@ services:
     networks:
       edgex-network: {}
     ports:
-    - 127.0.0.1:8500:8500/tcp
+    - 8500:8500/tcp
     read_only: true
     restart: always
     security_opt:

--- a/docker-compose-no-secty-arm64.yml
+++ b/docker-compose-no-secty-arm64.yml
@@ -92,7 +92,7 @@ services:
     networks:
       edgex-network: {}
     ports:
-    - 127.0.0.1:8500:8500/tcp
+    - 8500:8500/tcp
     read_only: true
     restart: always
     security_opt:

--- a/docker-compose-no-secty-with-ui-arm64.yml
+++ b/docker-compose-no-secty-with-ui-arm64.yml
@@ -122,7 +122,7 @@ services:
     networks:
       edgex-network: {}
     ports:
-    - 127.0.0.1:8500:8500/tcp
+    - 8500:8500/tcp
     read_only: true
     restart: always
     security_opt:

--- a/docker-compose-no-secty-with-ui.yml
+++ b/docker-compose-no-secty-with-ui.yml
@@ -122,7 +122,7 @@ services:
     networks:
       edgex-network: {}
     ports:
-    - 127.0.0.1:8500:8500/tcp
+    - 8500:8500/tcp
     read_only: true
     restart: always
     security_opt:

--- a/docker-compose-no-secty.yml
+++ b/docker-compose-no-secty.yml
@@ -92,7 +92,7 @@ services:
     networks:
       edgex-network: {}
     ports:
-    - 127.0.0.1:8500:8500/tcp
+    - 8500:8500/tcp
     read_only: true
     restart: always
     security_opt:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -180,7 +180,7 @@ services:
     networks:
       edgex-network: {}
     ports:
-    - 127.0.0.1:8500:8500/tcp
+    - 8500:8500/tcp
     read_only: true
     restart: always
     security_opt:

--- a/taf/docker-compose-taf-arm64.yml
+++ b/taf/docker-compose-taf-arm64.yml
@@ -361,7 +361,7 @@ services:
     networks:
       edgex-network: {}
     ports:
-    - 127.0.0.1:8500:8500/tcp
+    - 8500:8500/tcp
     read_only: true
     restart: always
     security_opt:

--- a/taf/docker-compose-taf-mqtt-bus-arm64.yml
+++ b/taf/docker-compose-taf-mqtt-bus-arm64.yml
@@ -382,7 +382,7 @@ services:
     networks:
       edgex-network: {}
     ports:
-    - 127.0.0.1:8500:8500/tcp
+    - 8500:8500/tcp
     read_only: true
     restart: always
     security_opt:

--- a/taf/docker-compose-taf-mqtt-bus.yml
+++ b/taf/docker-compose-taf-mqtt-bus.yml
@@ -382,7 +382,7 @@ services:
     networks:
       edgex-network: {}
     ports:
-    - 127.0.0.1:8500:8500/tcp
+    - 8500:8500/tcp
     read_only: true
     restart: always
     security_opt:

--- a/taf/docker-compose-taf-no-secty-arm64.yml
+++ b/taf/docker-compose-taf-no-secty-arm64.yml
@@ -186,7 +186,7 @@ services:
     networks:
       edgex-network: {}
     ports:
-    - 127.0.0.1:8500:8500/tcp
+    - 8500:8500/tcp
     read_only: true
     restart: always
     security_opt:

--- a/taf/docker-compose-taf-no-secty-mqtt-bus-arm64.yml
+++ b/taf/docker-compose-taf-no-secty-mqtt-bus-arm64.yml
@@ -207,7 +207,7 @@ services:
     networks:
       edgex-network: {}
     ports:
-    - 127.0.0.1:8500:8500/tcp
+    - 8500:8500/tcp
     read_only: true
     restart: always
     security_opt:

--- a/taf/docker-compose-taf-no-secty-mqtt-bus.yml
+++ b/taf/docker-compose-taf-no-secty-mqtt-bus.yml
@@ -207,7 +207,7 @@ services:
     networks:
       edgex-network: {}
     ports:
-    - 127.0.0.1:8500:8500/tcp
+    - 8500:8500/tcp
     read_only: true
     restart: always
     security_opt:

--- a/taf/docker-compose-taf-no-secty.yml
+++ b/taf/docker-compose-taf-no-secty.yml
@@ -186,7 +186,7 @@ services:
     networks:
       edgex-network: {}
     ports:
-    - 127.0.0.1:8500:8500/tcp
+    - 8500:8500/tcp
     read_only: true
     restart: always
     security_opt:

--- a/taf/docker-compose-taf-perf-arm64.yml
+++ b/taf/docker-compose-taf-perf-arm64.yml
@@ -244,7 +244,7 @@ services:
     networks:
       edgex-network: {}
     ports:
-    - 127.0.0.1:8500:8500/tcp
+    - 8500:8500/tcp
     read_only: true
     restart: always
     security_opt:

--- a/taf/docker-compose-taf-perf-no-secty-arm64.yml
+++ b/taf/docker-compose-taf-perf-no-secty-arm64.yml
@@ -125,7 +125,7 @@ services:
     networks:
       edgex-network: {}
     ports:
-    - 127.0.0.1:8500:8500/tcp
+    - 8500:8500/tcp
     read_only: true
     restart: always
     security_opt:

--- a/taf/docker-compose-taf-perf-no-secty.yml
+++ b/taf/docker-compose-taf-perf-no-secty.yml
@@ -125,7 +125,7 @@ services:
     networks:
       edgex-network: {}
     ports:
-    - 127.0.0.1:8500:8500/tcp
+    - 8500:8500/tcp
     read_only: true
     restart: always
     security_opt:

--- a/taf/docker-compose-taf-perf.yml
+++ b/taf/docker-compose-taf-perf.yml
@@ -244,7 +244,7 @@ services:
     networks:
       edgex-network: {}
     ports:
-    - 127.0.0.1:8500:8500/tcp
+    - 8500:8500/tcp
     read_only: true
     restart: always
     security_opt:

--- a/taf/docker-compose-taf.yml
+++ b/taf/docker-compose-taf.yml
@@ -361,7 +361,7 @@ services:
     networks:
       edgex-network: {}
     ports:
-    - 127.0.0.1:8500:8500/tcp
+    - 8500:8500/tcp
     read_only: true
     restart: always
     security_opt:


### PR DESCRIPTION
When in secure mode, Consul UI will require access token to login.

closes #190

Signed-off-by: Leonard Goodell <leonard.goodell@intel.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-compose/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-compose/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?) **N/A to docs**


## Testing Instructions
run both secure and non-secure
from off box browse to <ip>:8500
if secure mode Consul will request token
if non-secure mode Consul Ui will be usable w/o token
