### PR TITLE
ci: add stage to archive 3rd party images from compose file

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,16 +8,36 @@ pipeline {
         durabilityHint 'PERFORMANCE_OPTIMIZED'
         timeout(360)
     }
+    parameters {
+        booleanParam defaultValue: false, description: 'Archive 3rd Party Images', name: 'ARCHIVE'
+    }
     triggers {
         issueCommentTrigger('.*^recheck$.*')
     }
     stages {
         stage('Smoke Tests') {
             when {
-                expression { !edgex.isReleaseStream() }
+                expression { !edgex.isReleaseStream() && env.ARCHIVE == 'false' }
             }
             steps {
                 build job: '/edgexfoundry/edgex-taf-pipelines/smoke-test', parameters: [string(name: 'SHA1', value: env.GIT_COMMIT), string(name: 'TEST_ARCH', value: 'All'), string(name: 'WITH_SECURITY', value: 'All')]
+            }
+        }
+
+        stage('Archive 3rd Party Images') {
+            when {
+                expression { env.ARCHIVE == 'true' }
+            }
+            steps {
+                edgeXDockerLogin(settingsFile: 'ci-build-images-settings')
+                bootstrapBuildX()
+
+                script {
+                    def images = sh(script: "grep image docker-compose.yml | grep -v edgexfoundry | awk '{print \$2}'", returnStdout: true).trim()
+                    images.split('\n').each { image ->
+                        sh "echo -e 'FROM ${image}' | docker buildx build --platform 'linux/amd64,linux/arm64' -t nexus3.edgexfoundry.org:10002/archive/${image} --push -"
+                    }
+                }
             }
         }
     }
@@ -29,4 +49,11 @@ pipeline {
             cleanWs()
         }
     }
+}
+
+def bootstrapBuildX() {
+    sh 'docker buildx ls'
+    sh 'docker buildx create --name edgex-builder --platform linux/amd64,linux/arm64 --use'
+    sh 'docker buildx inspect --bootstrap'
+    sh 'docker buildx ls'
 }


### PR DESCRIPTION
This PR implements new functionality to archive any 3rd party docker images to nexus release (10002) repository. The new stage added will only run when the `ARCHIVE` jenkins build parameter is passed in. This stage will only need to be triggered on LTS releases and can be done with anyone with Jenkins build permission.

Signed-off-by: Ernesto Ojeda <ernesto.ojeda@intel.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-compose/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-compose/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [ ] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>


## Testing Instructions
<!-- How can the reviewers test your change? -->
