### PR TITLE
fix: [Kamakura] Add missing volume for LLRP Inventory app service's data

### DIFF
--- a/compose-builder/add-app-rfid-llrp-inventory.yml
+++ b/compose-builder/add-app-rfid-llrp-inventory.yml
@@ -15,6 +15,9 @@
 
 version: '3.7'
 
+volumes:
+  llrp-inventory-data:
+
 services:
   app-rfid-llrp-inventory:
     image: ${APP_SVC_REPOSITORY}/app-rfid-llrp-inventory${ARCH}:${APP_LLRP_VERSION}
@@ -37,3 +40,6 @@ services:
     security_opt:
       - no-new-privileges:true
     user: "${EDGEX_USER}:${EDGEX_GROUP}"
+    volumes:
+      - llrp-inventory-data:/cache:z
+


### PR DESCRIPTION
closes #210

Signed-off-by: Leonard Goodell <leonard.goodell@intel.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-compose/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-compose/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?) **N/A**



## Testing Instructions
**N/A**