### PR TITLE
ci: fix issue with ARCHIVE param

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,7 +17,7 @@ pipeline {
     stages {
         stage('Smoke Tests') {
             when {
-                expression { !edgex.isReleaseStream() && env.ARCHIVE == 'false' }
+                expression { !edgex.isReleaseStream() && !params.ARCHIVE }
             }
             steps {
                 build job: '/edgexfoundry/edgex-taf-pipelines/smoke-test', parameters: [string(name: 'SHA1', value: env.GIT_COMMIT), string(name: 'TEST_ARCH', value: 'All'), string(name: 'WITH_SECURITY', value: 'All')]
@@ -26,7 +26,7 @@ pipeline {
 
         stage('Archive 3rd Party Images') {
             when {
-                expression { env.ARCHIVE == 'true' }
+                expression { params.ARCHIVE }
             }
             steps {
                 edgeXDockerLogin(settingsFile: 'ci-build-images-settings')


### PR DESCRIPTION
Fix issue with new Jenkins update where builds triggered by webhooks no longer have parameters set in the environment.

Signed-off-by: Ernesto Ojeda <ernesto.ojeda@intel.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-compose/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-compose/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [ ] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>


## Testing Instructions
<!-- How can the reviewers test your change? -->
