### PR TITLE
fix(security)!: Revert exposing Consul port externally

### DIFF
--- a/compose-builder/docker-compose-base.yml
+++ b/compose-builder/docker-compose-base.yml
@@ -33,7 +33,7 @@ services:
     command: "agent -ui -bootstrap -server -client 0.0.0.0"
     user: "root:root" # Note that Consul is run under the 'consul' user, but entry point scripts need to first run as root
     ports:
-      - "8500:8500"
+      - "127.0.0.1:8500:8500"
     container_name: edgex-core-consul
     hostname: edgex-core-consul
     read_only: true

--- a/docker-compose-arm64.yml
+++ b/docker-compose-arm64.yml
@@ -180,7 +180,7 @@ services:
     networks:
       edgex-network: {}
     ports:
-    - 8500:8500/tcp
+    - 127.0.0.1:8500:8500/tcp
     read_only: true
     restart: always
     security_opt:

--- a/docker-compose-no-secty-arm64.yml
+++ b/docker-compose-no-secty-arm64.yml
@@ -92,7 +92,7 @@ services:
     networks:
       edgex-network: {}
     ports:
-    - 8500:8500/tcp
+    - 127.0.0.1:8500:8500/tcp
     read_only: true
     restart: always
     security_opt:

--- a/docker-compose-no-secty-with-app-sample-arm64.yml
+++ b/docker-compose-no-secty-with-app-sample-arm64.yml
@@ -122,7 +122,7 @@ services:
     networks:
       edgex-network: {}
     ports:
-    - 8500:8500/tcp
+    - 127.0.0.1:8500:8500/tcp
     read_only: true
     restart: always
     security_opt:

--- a/docker-compose-no-secty-with-app-sample.yml
+++ b/docker-compose-no-secty-with-app-sample.yml
@@ -122,7 +122,7 @@ services:
     networks:
       edgex-network: {}
     ports:
-    - 8500:8500/tcp
+    - 127.0.0.1:8500:8500/tcp
     read_only: true
     restart: always
     security_opt:

--- a/docker-compose-no-secty.yml
+++ b/docker-compose-no-secty.yml
@@ -92,7 +92,7 @@ services:
     networks:
       edgex-network: {}
     ports:
-    - 8500:8500/tcp
+    - 127.0.0.1:8500:8500/tcp
     read_only: true
     restart: always
     security_opt:

--- a/docker-compose-with-app-sample-arm64.yml
+++ b/docker-compose-with-app-sample-arm64.yml
@@ -238,7 +238,7 @@ services:
     networks:
       edgex-network: {}
     ports:
-    - 8500:8500/tcp
+    - 127.0.0.1:8500:8500/tcp
     read_only: true
     restart: always
     security_opt:

--- a/docker-compose-with-app-sample.yml
+++ b/docker-compose-with-app-sample.yml
@@ -238,7 +238,7 @@ services:
     networks:
       edgex-network: {}
     ports:
-    - 8500:8500/tcp
+    - 127.0.0.1:8500:8500/tcp
     read_only: true
     restart: always
     security_opt:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -180,7 +180,7 @@ services:
     networks:
       edgex-network: {}
     ports:
-    - 8500:8500/tcp
+    - 127.0.0.1:8500:8500/tcp
     read_only: true
     restart: always
     security_opt:

--- a/taf/docker-compose-taf-arm64.yml
+++ b/taf/docker-compose-taf-arm64.yml
@@ -423,7 +423,7 @@ services:
     networks:
       edgex-network: {}
     ports:
-    - 8500:8500/tcp
+    - 127.0.0.1:8500:8500/tcp
     read_only: true
     restart: always
     security_opt:

--- a/taf/docker-compose-taf-mqtt-bus-arm64.yml
+++ b/taf/docker-compose-taf-mqtt-bus-arm64.yml
@@ -444,7 +444,7 @@ services:
     networks:
       edgex-network: {}
     ports:
-    - 8500:8500/tcp
+    - 127.0.0.1:8500:8500/tcp
     read_only: true
     restart: always
     security_opt:

--- a/taf/docker-compose-taf-mqtt-bus.yml
+++ b/taf/docker-compose-taf-mqtt-bus.yml
@@ -444,7 +444,7 @@ services:
     networks:
       edgex-network: {}
     ports:
-    - 8500:8500/tcp
+    - 127.0.0.1:8500:8500/tcp
     read_only: true
     restart: always
     security_opt:

--- a/taf/docker-compose-taf-no-secty-arm64.yml
+++ b/taf/docker-compose-taf-no-secty-arm64.yml
@@ -220,7 +220,7 @@ services:
     networks:
       edgex-network: {}
     ports:
-    - 8500:8500/tcp
+    - 127.0.0.1:8500:8500/tcp
     read_only: true
     restart: always
     security_opt:

--- a/taf/docker-compose-taf-no-secty-mqtt-bus-arm64.yml
+++ b/taf/docker-compose-taf-no-secty-mqtt-bus-arm64.yml
@@ -241,7 +241,7 @@ services:
     networks:
       edgex-network: {}
     ports:
-    - 8500:8500/tcp
+    - 127.0.0.1:8500:8500/tcp
     read_only: true
     restart: always
     security_opt:

--- a/taf/docker-compose-taf-no-secty-mqtt-bus.yml
+++ b/taf/docker-compose-taf-no-secty-mqtt-bus.yml
@@ -241,7 +241,7 @@ services:
     networks:
       edgex-network: {}
     ports:
-    - 8500:8500/tcp
+    - 127.0.0.1:8500:8500/tcp
     read_only: true
     restart: always
     security_opt:

--- a/taf/docker-compose-taf-no-secty.yml
+++ b/taf/docker-compose-taf-no-secty.yml
@@ -220,7 +220,7 @@ services:
     networks:
       edgex-network: {}
     ports:
-    - 8500:8500/tcp
+    - 127.0.0.1:8500:8500/tcp
     read_only: true
     restart: always
     security_opt:

--- a/taf/docker-compose-taf-perf-arm64.yml
+++ b/taf/docker-compose-taf-perf-arm64.yml
@@ -244,7 +244,7 @@ services:
     networks:
       edgex-network: {}
     ports:
-    - 8500:8500/tcp
+    - 127.0.0.1:8500:8500/tcp
     read_only: true
     restart: always
     security_opt:

--- a/taf/docker-compose-taf-perf-no-secty-arm64.yml
+++ b/taf/docker-compose-taf-perf-no-secty-arm64.yml
@@ -125,7 +125,7 @@ services:
     networks:
       edgex-network: {}
     ports:
-    - 8500:8500/tcp
+    - 127.0.0.1:8500:8500/tcp
     read_only: true
     restart: always
     security_opt:

--- a/taf/docker-compose-taf-perf-no-secty.yml
+++ b/taf/docker-compose-taf-perf-no-secty.yml
@@ -125,7 +125,7 @@ services:
     networks:
       edgex-network: {}
     ports:
-    - 8500:8500/tcp
+    - 127.0.0.1:8500:8500/tcp
     read_only: true
     restart: always
     security_opt:

--- a/taf/docker-compose-taf-perf.yml
+++ b/taf/docker-compose-taf-perf.yml
@@ -244,7 +244,7 @@ services:
     networks:
       edgex-network: {}
     ports:
-    - 8500:8500/tcp
+    - 127.0.0.1:8500:8500/tcp
     read_only: true
     restart: always
     security_opt:

--- a/taf/docker-compose-taf.yml
+++ b/taf/docker-compose-taf.yml
@@ -423,7 +423,7 @@ services:
     networks:
       edgex-network: {}
     ports:
-    - 8500:8500/tcp
+    - 127.0.0.1:8500:8500/tcp
     read_only: true
     restart: always
     security_opt:


### PR DESCRIPTION
It has been determined that exposing the Consul port externally is unsafe,
despite Consul authentication, because the Consul access token
is exposed over the wire.

Refs: 685de56a36267c0adb07867b2eda848eadd86500
Closes #190
Closes https://github.com/edgexfoundry/edgex-go/issues/3744

Signed-off-by: Bryon Nevis <bryon.nevis@intel.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [X] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>


## Testing Instructions
`make run` ensure everything comes up.