### PR TITLE
fix: Remove hard-coding of MESSAGEQUEUE_HOST

### DIFF
--- a/compose-builder/common.env
+++ b/compose-builder/common.env
@@ -24,3 +24,4 @@ CLIENTS_CORE_COMMAND_HOST=edgex-core-command
 CLIENTS_SUPPORT_NOTIFICATIONS_HOST=edgex-support-notifications
 CLIENTS_SUPPORT_SCHEDULER_HOST=edgex-support-scheduler
 DATABASES_PRIMARY_HOST=edgex-redis
+MESSAGEQUEUE_HOST=edgex-redis

--- a/compose-builder/docker-compose-base.yml
+++ b/compose-builder/docker-compose-base.yml
@@ -154,7 +154,6 @@ services:
       - common.env
     environment:
       SERVICE_HOST: edgex-core-data
-      MESSAGEQUEUE_HOST: edgex-redis
     depends_on:
       - consul
       - database


### PR DESCRIPTION
core-data service currently hard-codes edgex-redis
as the message-queue host.  This fix moves it to
an environment variable where it can be more
easily overridden for all services

Signed-off-by: Bryon Nevis <bryon.nevis@intel.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [ ] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>


## Testing Instructions
This change has not yet been fully regressed.
