### PR TITLE
feat: add terminal UI to generate compose files

### DIFF
--- a/compose-builder/tui-generator.sh
+++ b/compose-builder/tui-generator.sh
@@ -1,0 +1,258 @@
+#!/usr/bin/env bash
+
+# /*******************************************************************************
+#  * Copyright 2022 
+#  *
+#  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+#  * in compliance with the License. You may obtain a copy of the License at
+#  *
+#  * http://www.apache.org/licenses/LICENSE-2.0
+#  *
+#  * Unless required by applicable law or agreed to in writing, software distributed under the License
+#  * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  * or implied. See the License for the specific language governing permissions and limitations under
+#  * the License.
+#  *
+#  *******************************************************************************/
+
+# generator.sh - provide a Terminal User Interface to make generation of different EdgeX Foundry
+# services more comprehensible.
+# Author: Shantanoo (Shan) Desai <shantanoo.desai@gmail.com>
+
+# Map the available options in `make compose` either as standalone strings or array of strings
+
+# Individual Compose Descriptions that may not fall into EdgeX-Foundry Architecture Components
+# Or may be an initial "out-of-the-box" configuration
+
+MAKE=/usr/bin/make
+
+SELECTED_DEVSERVICES=()
+SELECTED_APPSERVICES=()
+SELECTED_BUS=()
+SELECTED_OTHERS=()
+
+## Additional Options
+additionalOpts=(
+    "mqtt-broker"
+    "modbus-sim"
+)
+
+## General Options Description
+declare -A additionalOptsDesc=(
+    [modbus-sim]="Include ModBus Simulator"
+    [mqtt-broker]="Include MQTT Broker"
+)
+
+
+## Available App Services in EdgeX-Foundry
+appServices=(
+    "asc-http"
+    "asc-mqtt"
+    "asc-sample"
+    "as-llrp"
+    "asc-ex-mqtt"
+)
+
+## App Service Descriptions
+declare -A appServiceDesc=(
+    [asc-http]="Include HTTP Export App Service"
+    [asc-mqtt]="Include MQTT Export App Service"
+    [asc-sample]="Include Sample App Service"
+    [as-llrp]="Include RFID LLRP Inventory"
+    [asc-ex-mqtt]="Include External MQTT Trigger App Service"
+)
+
+
+## Available Device Services in EdgeX-Foundry
+deviceServices=(
+    "ds-bacnet"
+    "ds-camera"
+    "ds-grove"
+    "ds-modbus"
+    "ds-mqtt"
+    "ds-rest"
+    "ds-snmp"
+    "ds-virtual"
+    "ds-coap"
+    "ds-gpio"
+    "ds-llrp"
+)
+
+## Device Service Descriptions
+declare -A deviceServiceDesc=(
+    [ds-bacnet]="Include BACnet Device Service"
+    [ds-camera]="Include Camera Device Service"
+    [ds-grove]="Include Grove Device Service (valid only: arm64)"
+    [ds-modbus]="Include ModBus Device Service"
+    [ds-mqtt]="Include MQTT Device Service"
+    [ds-rest]="Include REST Device Service"
+    [ds-snmp]="Include SNMP Device Service"
+    [ds-virtual]="Include Virtual Device Service"
+    [ds-coap]="Include CoAP Device Service"
+    [ds-gpio]="Include GPIO Device Service"
+    [ds-llrp]="Include RFID LLRP Device Service"
+
+)
+
+
+## Available Message Bus Services in EdgeX-Foundry
+messageBus=(
+    "mqtt-bus"
+    "zmq-bus"
+)
+
+
+## Message Bus Descriptions
+declare -A msgBusDesc=(
+    [mqtt-bus]="Configure MQTT Message Bus"
+    [zmq-bus]="Configure ZMQ Message Bus"
+)
+
+
+####################################################################
+#    Additional Services Options Display Function                  #
+####################################################################
+function additionalServiceOption() {
+    message="Some Additional Services are available that can also be included."
+
+    # Generate a Specific form of Array required by whiptail checklist
+    # FORMAT: "<INDEX> <DESCRIPTION> <OFF>"
+    arglist=()
+    for index in "${additionalOpts[@]}";
+    do
+        arglist+=("$index")
+        arglist+=("${additionalOptsDesc[$index]}")
+        arglist+=("OFF") # Nothing is selected by-default
+    done
+    SELECTED_OTHERS+=$(/usr/bin/whiptail --title "App Services" \
+                --notags --separate-output \
+                --nocancel \
+                --checklist "$message" 20 75 5 \
+                -- "${arglist[@]})" \
+                3>&1 1>&2 2>&3)
+}
+
+
+####################################################################
+#    App Services Options Display Function                         #
+####################################################################
+function appServiceOption() {
+    message="Available App Services to include in your compose file."
+
+    # Generate a Specific form of Array required by whiptail checklist
+    # FORMAT: "<INDEX> <DESCRIPTION> <OFF>"
+    arglist=()
+    for index in "${appServices[@]}";
+    do
+        arglist+=("$index")
+        arglist+=("${appServiceDesc[$index]}")
+        arglist+=("OFF") # Nothing is selected by-default
+    done
+    SELECTED_APPSERVICES+=$(/usr/bin/whiptail --title "App Services" \
+                --nocancel \
+                --notags --separate-output \
+                --checklist "$message" 20 75 7 \
+                -- "${arglist[@]}" \
+                3>&1 1>&2 2>&3)
+}
+
+
+
+####################################################################
+#    ARM64 Question Display Function                               #
+####################################################################
+function displayArm64() {
+    message="Would you like to use ARM64 Images to generate the Compose file?"
+
+    /usr/bin/whiptail --title "Images Architecture" --yesno "$message" 8 78
+}
+
+
+####################################################################
+#    No-Security Question Display Function                         #
+####################################################################
+function displayNoSecty() {
+    message="Would you like to generate a non-secure configuration of the Compose file?"
+    
+    /usr/bin/whiptail --title "Non-Secure Configuration" --yesno "$message" 8 78
+}
+
+
+####################################################################
+#    Device Services Options Display Function                      #
+####################################################################
+function devServiceOption() {
+    message="Available Device Services to include in your compose file."
+
+    # Generate a Specific form of Array required by whiptail checklist
+    # FORMAT: "<INDEX> <DESCRIPTION> <OFF>"
+    arglist=()
+    for index in "${deviceServices[@]}";
+    do
+        arglist+=("$index")
+        arglist+=("${deviceServiceDesc[$index]}")
+        arglist+=("OFF") # Nothing is selected by-default
+    done
+    SELECTED_DEVSERVICES=$(/usr/bin/whiptail --title "Device Services" \
+                --nocancel \
+                --notags --separate-output \
+                --checklist "$message" 20 75 13 \
+                -- "${arglist[@]})" \
+                3>&1 1>&2 2>&3)
+}
+
+####################################################################
+#    Message Bus Options Display Function                          #
+####################################################################
+function msgBusOption() {
+    message="Available Message Buses to replace the default one."
+
+    # Generate a Specific form of Array required by whiptail checklist
+    # FORMAT: "<INDEX> <DESCRIPTION> <OFF>"
+    arglist=()
+    for index in "${messageBus[@]}";
+    do
+        arglist+=("$index")
+        arglist+=("${msgBusDesc[$index]}")
+        arglist+=("OFF") # Nothing is selected by-default
+    done
+    SELECTED_BUS=$(/usr/bin/whiptail --title "App Services" \
+                --nocancel \
+                --notags --separate-output \
+                --radiolist "$message" 20 75 4 \
+                -- "${arglist[@]})" \
+                3>&1 1>&2 2>&3)
+}
+
+
+## Step - 1: Start by Asking about whether Images should be pulled for ARM64?
+displayArm64
+if [[ $? == 0 ]]; then
+    SELECTED_OTHERS+=("arm64 ")
+fi
+
+## Step - 2: Ask whether a non-secure Configuration is needed
+displayNoSecty
+if [[ $? == 0 ]]; then
+    SELECTED_OTHERS+=("no-secty ")
+fi  
+
+## Step - 3: Add Device Services Option
+devServiceOption
+
+## Step - 4: App Services Option
+appServiceOption
+
+## Step - 5: Configure Message Bus
+msgBusOption
+
+## Step -6: Ask for Additional Options
+additionalServiceOption
+
+# echo "additional services selected: ${SELECTED_OTHERS}" ## DEBUG
+# echo "device services selected: ${SELECTED_DEVSERVICES}" ## DEBUG
+# echo "app services selected: ${SELECTED_APPSERVICES}" ## DEBUG
+# echo "selected message bus: ${SELECTED_BUS}" ## DEBUG
+
+echo "Generating necessary Compose file:....."
+$MAKE compose $SELECTED_OTHERS $SELECTED_DEVSERVICES $SELECTED_APPSERVICES $SELECTED_BUS

--- a/compose-builder/tui-generator.sh
+++ b/compose-builder/tui-generator.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # /*******************************************************************************
-#  * Copyright 2022 
+#  * Copyright 2022 Shantanoo Desai <shantanoo.desai@gmail.com>
 #  *
 #  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 #  * in compliance with the License. You may obtain a copy of the License at
@@ -113,7 +113,10 @@ declare -A msgBusDesc=(
 #    Additional Services Options Display Function                  #
 ####################################################################
 function additionalServiceOption() {
-    message="Some Additional Services are available that can also be included."
+    message="Some Additional Services are available that can also be included. \n
+            Press <SPACEBAR> to Select \n
+            Press <ENTER> to Skip \n
+            "
 
     # Generate a Specific form of Array required by whiptail checklist
     # FORMAT: "<INDEX> <DESCRIPTION> <OFF>"
@@ -126,6 +129,7 @@ function additionalServiceOption() {
     done
     SELECTED_OTHERS+=$(/usr/bin/whiptail --title "App Services" \
                 --notags --separate-output \
+                --ok-button Next \
                 --nocancel \
                 --checklist "$message" 20 75 5 \
                 -- "${arglist[@]})" \
@@ -137,7 +141,10 @@ function additionalServiceOption() {
 #    App Services Options Display Function                         #
 ####################################################################
 function appServiceOption() {
-    message="Available App Services to include in your compose file."
+    message="Available App Services to include in your compose file. \n
+            Press <SPACEBAR> to Select \n
+            Press <ENTER> to Skip \n
+            "
 
     # Generate a Specific form of Array required by whiptail checklist
     # FORMAT: "<INDEX> <DESCRIPTION> <OFF>"
@@ -149,6 +156,7 @@ function appServiceOption() {
         arglist+=("OFF") # Nothing is selected by-default
     done
     SELECTED_APPSERVICES+=$(/usr/bin/whiptail --title "App Services" \
+                --ok-button Next \
                 --nocancel \
                 --notags --separate-output \
                 --checklist "$message" 20 75 7 \
@@ -182,7 +190,10 @@ function displayNoSecty() {
 #    Device Services Options Display Function                      #
 ####################################################################
 function devServiceOption() {
-    message="Available Device Services to include in your compose file."
+    message="Available Device Services to include in your compose file.\n
+            Press <SPACEBAR> to Select \n
+            Press <ENTER> to Skip \n
+            "
 
     # Generate a Specific form of Array required by whiptail checklist
     # FORMAT: "<INDEX> <DESCRIPTION> <OFF>"
@@ -194,6 +205,7 @@ function devServiceOption() {
         arglist+=("OFF") # Nothing is selected by-default
     done
     SELECTED_DEVSERVICES=$(/usr/bin/whiptail --title "Device Services" \
+                --ok-button Next \
                 --nocancel \
                 --notags --separate-output \
                 --checklist "$message" 20 75 13 \
@@ -205,7 +217,10 @@ function devServiceOption() {
 #    Message Bus Options Display Function                          #
 ####################################################################
 function msgBusOption() {
-    message="Available Message Buses to replace the default one."
+    message="Available Message Buses to replace the default one.\n
+            Press <SPACEBAR> to Select \n
+            Press <ENTER> to Skip \n
+            "
 
     # Generate a Specific form of Array required by whiptail checklist
     # FORMAT: "<INDEX> <DESCRIPTION> <OFF>"
@@ -217,6 +232,7 @@ function msgBusOption() {
         arglist+=("OFF") # Nothing is selected by-default
     done
     SELECTED_BUS=$(/usr/bin/whiptail --title "App Services" \
+                --ok-button Next \
                 --nocancel \
                 --notags --separate-output \
                 --radiolist "$message" 20 75 4 \
@@ -224,6 +240,17 @@ function msgBusOption() {
                 3>&1 1>&2 2>&3)
 }
 
+####################################################################
+#    Generate / Generate & Run Option Display Function             #
+####################################################################
+function finalStep() {
+    message="What would you like to do?"
+
+    /usr/bin/whiptail --title "Non-Secure Configuration" \
+        --yes-button "Generate File" \
+        --no-button "Generate File and Run" \
+         --yesno "$message" 8 78
+}
 
 ## Step - 1: Start by Asking about whether Images should be pulled for ARM64?
 displayArm64
@@ -254,5 +281,13 @@ additionalServiceOption
 # echo "app services selected: ${SELECTED_APPSERVICES}" ## DEBUG
 # echo "selected message bus: ${SELECTED_BUS}" ## DEBUG
 
-echo "Generating necessary Compose file:....."
-$MAKE compose $SELECTED_OTHERS $SELECTED_DEVSERVICES $SELECTED_APPSERVICES $SELECTED_BUS
+finalStep
+
+if [[ $? == 0 ]]; then
+    echo "Generating Compose file...\n"
+    $MAKE gen $SELECTED_OTHERS $SELECTED_DEVSERVICES $SELECTED_APPSERVICES $SELECTED_BUS
+else
+    echo "Generating Compose file and Running the Stack....\n"
+    $MAKE gen $SELECTED_OTHERS $SELECTED_DEVSERVICES $SELECTED_APPSERVICES $SELECTED_BUS
+    $MAKE run
+fi

--- a/compose-builder/tui-generator.sh
+++ b/compose-builder/tui-generator.sh
@@ -24,6 +24,15 @@
 # Individual Compose Descriptions that may not fall into EdgeX-Foundry Architecture Components
 # Or may be an initial "out-of-the-box" configuration
 
+# Check if whiptail exists to render the UI, if not, exit script
+WHIPTAIL=$(which whiptail)
+
+if [ -z $WHIPTAIL ]
+then
+    echo "This script requires whiptail to render the UI."
+    exit 1;
+fi
+
 MAKE=/usr/bin/make
 
 SELECTED_DEVSERVICES=()
@@ -115,7 +124,7 @@ declare -A msgBusDesc=(
 function additionalServiceOption() {
     message="Some Additional Services are available that can also be included. \n
             Press <SPACEBAR> to Select \n
-            Press <ENTER> to Skip \n
+            Press <ENTER> to Skip
             "
 
     # Generate a Specific form of Array required by whiptail checklist
@@ -127,11 +136,11 @@ function additionalServiceOption() {
         arglist+=("${additionalOptsDesc[$index]}")
         arglist+=("OFF") # Nothing is selected by-default
     done
-    SELECTED_OTHERS+=$(/usr/bin/whiptail --title "App Services" \
+    SELECTED_OTHERS+=$($WHIPTAIL --title "App Services" \
                 --notags --separate-output \
                 --ok-button Next \
                 --nocancel \
-                --checklist "$message" 20 75 5 \
+                --checklist "$message" $LINES $COLUMNS $(( $LINES - 12 )) \
                 -- "${arglist[@]})" \
                 3>&1 1>&2 2>&3)
 }
@@ -143,7 +152,7 @@ function additionalServiceOption() {
 function appServiceOption() {
     message="Available App Services to include in your compose file. \n
             Press <SPACEBAR> to Select \n
-            Press <ENTER> to Skip \n
+            Press <ENTER> to Skip
             "
 
     # Generate a Specific form of Array required by whiptail checklist
@@ -155,11 +164,11 @@ function appServiceOption() {
         arglist+=("${appServiceDesc[$index]}")
         arglist+=("OFF") # Nothing is selected by-default
     done
-    SELECTED_APPSERVICES+=$(/usr/bin/whiptail --title "App Services" \
+    SELECTED_APPSERVICES+=$($WHIPTAIL --title "App Services" \
                 --ok-button Next \
                 --nocancel \
                 --notags --separate-output \
-                --checklist "$message" 20 75 7 \
+                --checklist "$message" $LINES $COLUMNS $(( $LINES - 12 )) \
                 -- "${arglist[@]}" \
                 3>&1 1>&2 2>&3)
 }
@@ -171,8 +180,7 @@ function appServiceOption() {
 ####################################################################
 function displayArm64() {
     message="Would you like to use ARM64 Images to generate the Compose file?"
-
-    /usr/bin/whiptail --title "Images Architecture" --yesno "$message" 8 78
+    $WHIPTAIL --title "Images Architecture" --yesno --defaultno "$message" $LINES $COLUMNS
 }
 
 
@@ -181,8 +189,7 @@ function displayArm64() {
 ####################################################################
 function displayNoSecty() {
     message="Would you like to generate a non-secure configuration of the Compose file?"
-    
-    /usr/bin/whiptail --title "Non-Secure Configuration" --yesno "$message" 8 78
+    $WHIPTAIL --title "Non-Secure Configuration" --yesno "$message" $LINES $COLUMNS
 }
 
 
@@ -192,7 +199,7 @@ function displayNoSecty() {
 function devServiceOption() {
     message="Available Device Services to include in your compose file.\n
             Press <SPACEBAR> to Select \n
-            Press <ENTER> to Skip \n
+            Press <ENTER> to Skip
             "
 
     # Generate a Specific form of Array required by whiptail checklist
@@ -204,11 +211,11 @@ function devServiceOption() {
         arglist+=("${deviceServiceDesc[$index]}")
         arglist+=("OFF") # Nothing is selected by-default
     done
-    SELECTED_DEVSERVICES=$(/usr/bin/whiptail --title "Device Services" \
+    SELECTED_DEVSERVICES=$($WHIPTAIL --title "Device Services" \
                 --ok-button Next \
                 --nocancel \
                 --notags --separate-output \
-                --checklist "$message" 20 75 13 \
+                --checklist "$message" $LINES $COLUMNS $(( $LINES - 12 )) \
                 -- "${arglist[@]})" \
                 3>&1 1>&2 2>&3)
 }
@@ -219,7 +226,7 @@ function devServiceOption() {
 function msgBusOption() {
     message="Available Message Buses to replace the default one.\n
             Press <SPACEBAR> to Select \n
-            Press <ENTER> to Skip \n
+            Press <ENTER> to Skip
             "
 
     # Generate a Specific form of Array required by whiptail checklist
@@ -231,11 +238,11 @@ function msgBusOption() {
         arglist+=("${msgBusDesc[$index]}")
         arglist+=("OFF") # Nothing is selected by-default
     done
-    SELECTED_BUS=$(/usr/bin/whiptail --title "App Services" \
+    SELECTED_BUS=$($WHIPTAIL --title "App Services" \
                 --ok-button Next \
                 --nocancel \
                 --notags --separate-output \
-                --radiolist "$message" 20 75 4 \
+                --radiolist "$message" $LINES $COLUMNS $(( $LINES - 12 )) \
                 -- "${arglist[@]})" \
                 3>&1 1>&2 2>&3)
 }
@@ -245,11 +252,10 @@ function msgBusOption() {
 ####################################################################
 function finalStep() {
     message="What would you like to do?"
-
-    /usr/bin/whiptail --title "Non-Secure Configuration" \
+    $WHIPTAIL --title "Non-Secure Configuration" \
         --yes-button "Generate File" \
         --no-button "Generate File and Run" \
-         --yesno "$message" 8 78
+         --yesno "$message" $LINES $COLUMNS
 }
 
 ## Step - 1: Start by Asking about whether Images should be pulled for ARM64?


### PR DESCRIPTION
provide a terminal based UI using whiptail to generate a
custom `docker-compose.yml` file. The bash script collects the
necessary selections from a defined Usage Flow and generates the
compose file by calling the `make compose <selection>` command.
Aforementioned Usage Flow is documented in #225 

Signed-off-by: Shantanoo 'Shan' Desai <shantanoo.desai@gmail.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-compose/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-compose/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>


## Testing Instructions
<!-- How can the reviewers test your change? -->
```bash
cd compose-builder/
chmod +x tui-generator.sh
./tui-generator.sh
```
### Tested with:
__OS/Distro__: GNU/Linux Manjaro Rolling
__whiptail version__: `whiptail (newt): 0.52.21`
__GNU make__: 4.3
__docker version__: Docker version 20.10.12, build e91ed5707e
__docker-compose version__: docker-compose version 1.29.2

## Docs
Current PR under review and documentation follows once the team decides upon a fixed flow of UI and whether the code needs refactoring. For actual discussion refer to #225 