### PR TITLE
fix: Update eKuiper environment variables to not use Shared connection by default and fix MQTT issue

### DIFF
--- a/compose-builder/add-mqtt-messagebus.yml
+++ b/compose-builder/add-mqtt-messagebus.yml
@@ -48,10 +48,12 @@ services:
       CONNECTION__EDGEX__MQTTMSGBUS__SERVER: edgex-mqtt-broker
       CONNECTION__EDGEX__MQTTMSGBUS__TYPE: mqtt
       CONNECTION__EDGEX__MQTTMSGBUS__OPTIONAL__CLIENTID: kuiper-rules-engine
+      CONNECTION__EDGEX__MQTTMSGBUS__OPTIONAL__KEEPALIVE: 500
       EDGEX__DEFAULT__PORT: 1883
       EDGEX__DEFAULT__PROTOCOL: tcp
       EDGEX__DEFAULT__SERVER: edgex-mqtt-broker
       EDGEX__DEFAULT__TYPE: mqtt
       EDGEX__DEFAULT__OPTIONAL__CLIENTID: kuiper-rules-engine
+      EDGEX__DEFAULT__OPTIONAL__KEEPALIVE: 500
     depends_on:
       - mqtt-broker

--- a/compose-builder/add-mqtt-messagebus.yml
+++ b/compose-builder/add-mqtt-messagebus.yml
@@ -48,6 +48,10 @@ services:
       CONNECTION__EDGEX__MQTTMSGBUS__SERVER: edgex-mqtt-broker
       CONNECTION__EDGEX__MQTTMSGBUS__TYPE: mqtt
       CONNECTION__EDGEX__MQTTMSGBUS__OPTIONAL__CLIENTID: kuiper-rules-engine
-      EDGEX__DEFAULT__CONNECTIONSELECTOR: edgex.mqttMsgBus
+      EDGEX__DEFAULT__PORT: 1883
+      EDGEX__DEFAULT__PROTOCOL: tcp
+      EDGEX__DEFAULT__SERVER: edgex-mqtt-broker
+      EDGEX__DEFAULT__TYPE: mqtt
+      EDGEX__DEFAULT__OPTIONAL__CLIENTID: kuiper-rules-engine
     depends_on:
       - mqtt-broker

--- a/compose-builder/docker-compose-base.yml
+++ b/compose-builder/docker-compose-base.yml
@@ -245,7 +245,7 @@ services:
     volumes:
       - kuiper-data:/kuiper/data:z
     environment:
-      KUIPER__BASIC__DEBUG: "true"
+#      KUIPER__BASIC__DEBUG: "true"
       KUIPER__BASIC__CONSOLELOG: "true"
       KUIPER__BASIC__RESTPORT: 59720
       CONNECTION__EDGEX__REDISMSGBUS__PORT: 6379

--- a/compose-builder/docker-compose-base.yml
+++ b/compose-builder/docker-compose-base.yml
@@ -245,14 +245,17 @@ services:
     volumes:
       - kuiper-data:/kuiper/data:z
     environment:
-#      KUIPER__BASIC__DEBUG: "true"
+      KUIPER__BASIC__DEBUG: "true"
       KUIPER__BASIC__CONSOLELOG: "true"
       KUIPER__BASIC__RESTPORT: 59720
       CONNECTION__EDGEX__REDISMSGBUS__PORT: 6379
       CONNECTION__EDGEX__REDISMSGBUS__PROTOCOL: redis
       CONNECTION__EDGEX__REDISMSGBUS__SERVER: edgex-redis
       CONNECTION__EDGEX__REDISMSGBUS__TYPE: redis
-      EDGEX__DEFAULT__CONNECTIONSELECTOR: edgex.redisMsgBus
+      EDGEX__DEFAULT__PORT: 6379
+      EDGEX__DEFAULT__PROTOCOL: redis
+      EDGEX__DEFAULT__SERVER: edgex-redis
+      EDGEX__DEFAULT__TYPE: redis
       EDGEX__DEFAULT__TOPIC: rules-events
     depends_on:
       - database

--- a/docker-compose-arm64.yml
+++ b/docker-compose-arm64.yml
@@ -739,9 +739,13 @@ services:
       CONNECTION__EDGEX__REDISMSGBUS__PROTOCOL: redis
       CONNECTION__EDGEX__REDISMSGBUS__SERVER: edgex-redis
       CONNECTION__EDGEX__REDISMSGBUS__TYPE: redis
-      EDGEX__DEFAULT__CONNECTIONSELECTOR: edgex.redisMsgBus
+      EDGEX__DEFAULT__PORT: 6379
+      EDGEX__DEFAULT__PROTOCOL: redis
+      EDGEX__DEFAULT__SERVER: edgex-redis
       EDGEX__DEFAULT__TOPIC: rules-events
+      EDGEX__DEFAULT__TYPE: redis
       KUIPER__BASIC__CONSOLELOG: "true"
+      KUIPER__BASIC__DEBUG: "true"
       KUIPER__BASIC__RESTPORT: 59720
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper

--- a/docker-compose-arm64.yml
+++ b/docker-compose-arm64.yml
@@ -745,7 +745,6 @@ services:
       EDGEX__DEFAULT__TOPIC: rules-events
       EDGEX__DEFAULT__TYPE: redis
       KUIPER__BASIC__CONSOLELOG: "true"
-      KUIPER__BASIC__DEBUG: "true"
       KUIPER__BASIC__RESTPORT: 59720
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper

--- a/docker-compose-no-secty-arm64.yml
+++ b/docker-compose-no-secty-arm64.yml
@@ -279,7 +279,6 @@ services:
       EDGEX__DEFAULT__TOPIC: rules-events
       EDGEX__DEFAULT__TYPE: redis
       KUIPER__BASIC__CONSOLELOG: "true"
-      KUIPER__BASIC__DEBUG: "true"
       KUIPER__BASIC__RESTPORT: 59720
     hostname: edgex-kuiper
     image: lfedge/ekuiper:1.4-alpine

--- a/docker-compose-no-secty-arm64.yml
+++ b/docker-compose-no-secty-arm64.yml
@@ -273,9 +273,13 @@ services:
       CONNECTION__EDGEX__REDISMSGBUS__PROTOCOL: redis
       CONNECTION__EDGEX__REDISMSGBUS__SERVER: edgex-redis
       CONNECTION__EDGEX__REDISMSGBUS__TYPE: redis
-      EDGEX__DEFAULT__CONNECTIONSELECTOR: edgex.redisMsgBus
+      EDGEX__DEFAULT__PORT: 6379
+      EDGEX__DEFAULT__PROTOCOL: redis
+      EDGEX__DEFAULT__SERVER: edgex-redis
       EDGEX__DEFAULT__TOPIC: rules-events
+      EDGEX__DEFAULT__TYPE: redis
       KUIPER__BASIC__CONSOLELOG: "true"
+      KUIPER__BASIC__DEBUG: "true"
       KUIPER__BASIC__RESTPORT: 59720
     hostname: edgex-kuiper
     image: lfedge/ekuiper:1.4-alpine

--- a/docker-compose-no-secty-with-app-sample-arm64.yml
+++ b/docker-compose-no-secty-with-app-sample-arm64.yml
@@ -303,9 +303,13 @@ services:
       CONNECTION__EDGEX__REDISMSGBUS__PROTOCOL: redis
       CONNECTION__EDGEX__REDISMSGBUS__SERVER: edgex-redis
       CONNECTION__EDGEX__REDISMSGBUS__TYPE: redis
-      EDGEX__DEFAULT__CONNECTIONSELECTOR: edgex.redisMsgBus
+      EDGEX__DEFAULT__PORT: 6379
+      EDGEX__DEFAULT__PROTOCOL: redis
+      EDGEX__DEFAULT__SERVER: edgex-redis
       EDGEX__DEFAULT__TOPIC: rules-events
+      EDGEX__DEFAULT__TYPE: redis
       KUIPER__BASIC__CONSOLELOG: "true"
+      KUIPER__BASIC__DEBUG: "true"
       KUIPER__BASIC__RESTPORT: 59720
     hostname: edgex-kuiper
     image: lfedge/ekuiper:1.4-alpine

--- a/docker-compose-no-secty-with-app-sample-arm64.yml
+++ b/docker-compose-no-secty-with-app-sample-arm64.yml
@@ -309,7 +309,6 @@ services:
       EDGEX__DEFAULT__TOPIC: rules-events
       EDGEX__DEFAULT__TYPE: redis
       KUIPER__BASIC__CONSOLELOG: "true"
-      KUIPER__BASIC__DEBUG: "true"
       KUIPER__BASIC__RESTPORT: 59720
     hostname: edgex-kuiper
     image: lfedge/ekuiper:1.4-alpine

--- a/docker-compose-no-secty-with-app-sample.yml
+++ b/docker-compose-no-secty-with-app-sample.yml
@@ -303,9 +303,13 @@ services:
       CONNECTION__EDGEX__REDISMSGBUS__PROTOCOL: redis
       CONNECTION__EDGEX__REDISMSGBUS__SERVER: edgex-redis
       CONNECTION__EDGEX__REDISMSGBUS__TYPE: redis
-      EDGEX__DEFAULT__CONNECTIONSELECTOR: edgex.redisMsgBus
+      EDGEX__DEFAULT__PORT: 6379
+      EDGEX__DEFAULT__PROTOCOL: redis
+      EDGEX__DEFAULT__SERVER: edgex-redis
       EDGEX__DEFAULT__TOPIC: rules-events
+      EDGEX__DEFAULT__TYPE: redis
       KUIPER__BASIC__CONSOLELOG: "true"
+      KUIPER__BASIC__DEBUG: "true"
       KUIPER__BASIC__RESTPORT: 59720
     hostname: edgex-kuiper
     image: lfedge/ekuiper:1.4-alpine

--- a/docker-compose-no-secty-with-app-sample.yml
+++ b/docker-compose-no-secty-with-app-sample.yml
@@ -309,7 +309,6 @@ services:
       EDGEX__DEFAULT__TOPIC: rules-events
       EDGEX__DEFAULT__TYPE: redis
       KUIPER__BASIC__CONSOLELOG: "true"
-      KUIPER__BASIC__DEBUG: "true"
       KUIPER__BASIC__RESTPORT: 59720
     hostname: edgex-kuiper
     image: lfedge/ekuiper:1.4-alpine

--- a/docker-compose-no-secty.yml
+++ b/docker-compose-no-secty.yml
@@ -279,7 +279,6 @@ services:
       EDGEX__DEFAULT__TOPIC: rules-events
       EDGEX__DEFAULT__TYPE: redis
       KUIPER__BASIC__CONSOLELOG: "true"
-      KUIPER__BASIC__DEBUG: "true"
       KUIPER__BASIC__RESTPORT: 59720
     hostname: edgex-kuiper
     image: lfedge/ekuiper:1.4-alpine

--- a/docker-compose-no-secty.yml
+++ b/docker-compose-no-secty.yml
@@ -273,9 +273,13 @@ services:
       CONNECTION__EDGEX__REDISMSGBUS__PROTOCOL: redis
       CONNECTION__EDGEX__REDISMSGBUS__SERVER: edgex-redis
       CONNECTION__EDGEX__REDISMSGBUS__TYPE: redis
-      EDGEX__DEFAULT__CONNECTIONSELECTOR: edgex.redisMsgBus
+      EDGEX__DEFAULT__PORT: 6379
+      EDGEX__DEFAULT__PROTOCOL: redis
+      EDGEX__DEFAULT__SERVER: edgex-redis
       EDGEX__DEFAULT__TOPIC: rules-events
+      EDGEX__DEFAULT__TYPE: redis
       KUIPER__BASIC__CONSOLELOG: "true"
+      KUIPER__BASIC__DEBUG: "true"
       KUIPER__BASIC__RESTPORT: 59720
     hostname: edgex-kuiper
     image: lfedge/ekuiper:1.4-alpine

--- a/docker-compose-with-app-sample-arm64.yml
+++ b/docker-compose-with-app-sample-arm64.yml
@@ -806,7 +806,6 @@ services:
       EDGEX__DEFAULT__TOPIC: rules-events
       EDGEX__DEFAULT__TYPE: redis
       KUIPER__BASIC__CONSOLELOG: "true"
-      KUIPER__BASIC__DEBUG: "true"
       KUIPER__BASIC__RESTPORT: 59720
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper

--- a/docker-compose-with-app-sample-arm64.yml
+++ b/docker-compose-with-app-sample-arm64.yml
@@ -800,9 +800,13 @@ services:
       CONNECTION__EDGEX__REDISMSGBUS__PROTOCOL: redis
       CONNECTION__EDGEX__REDISMSGBUS__SERVER: edgex-redis
       CONNECTION__EDGEX__REDISMSGBUS__TYPE: redis
-      EDGEX__DEFAULT__CONNECTIONSELECTOR: edgex.redisMsgBus
+      EDGEX__DEFAULT__PORT: 6379
+      EDGEX__DEFAULT__PROTOCOL: redis
+      EDGEX__DEFAULT__SERVER: edgex-redis
       EDGEX__DEFAULT__TOPIC: rules-events
+      EDGEX__DEFAULT__TYPE: redis
       KUIPER__BASIC__CONSOLELOG: "true"
+      KUIPER__BASIC__DEBUG: "true"
       KUIPER__BASIC__RESTPORT: 59720
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper

--- a/docker-compose-with-app-sample.yml
+++ b/docker-compose-with-app-sample.yml
@@ -806,7 +806,6 @@ services:
       EDGEX__DEFAULT__TOPIC: rules-events
       EDGEX__DEFAULT__TYPE: redis
       KUIPER__BASIC__CONSOLELOG: "true"
-      KUIPER__BASIC__DEBUG: "true"
       KUIPER__BASIC__RESTPORT: 59720
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper

--- a/docker-compose-with-app-sample.yml
+++ b/docker-compose-with-app-sample.yml
@@ -800,9 +800,13 @@ services:
       CONNECTION__EDGEX__REDISMSGBUS__PROTOCOL: redis
       CONNECTION__EDGEX__REDISMSGBUS__SERVER: edgex-redis
       CONNECTION__EDGEX__REDISMSGBUS__TYPE: redis
-      EDGEX__DEFAULT__CONNECTIONSELECTOR: edgex.redisMsgBus
+      EDGEX__DEFAULT__PORT: 6379
+      EDGEX__DEFAULT__PROTOCOL: redis
+      EDGEX__DEFAULT__SERVER: edgex-redis
       EDGEX__DEFAULT__TOPIC: rules-events
+      EDGEX__DEFAULT__TYPE: redis
       KUIPER__BASIC__CONSOLELOG: "true"
+      KUIPER__BASIC__DEBUG: "true"
       KUIPER__BASIC__RESTPORT: 59720
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -739,9 +739,13 @@ services:
       CONNECTION__EDGEX__REDISMSGBUS__PROTOCOL: redis
       CONNECTION__EDGEX__REDISMSGBUS__SERVER: edgex-redis
       CONNECTION__EDGEX__REDISMSGBUS__TYPE: redis
-      EDGEX__DEFAULT__CONNECTIONSELECTOR: edgex.redisMsgBus
+      EDGEX__DEFAULT__PORT: 6379
+      EDGEX__DEFAULT__PROTOCOL: redis
+      EDGEX__DEFAULT__SERVER: edgex-redis
       EDGEX__DEFAULT__TOPIC: rules-events
+      EDGEX__DEFAULT__TYPE: redis
       KUIPER__BASIC__CONSOLELOG: "true"
+      KUIPER__BASIC__DEBUG: "true"
       KUIPER__BASIC__RESTPORT: 59720
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -745,7 +745,6 @@ services:
       EDGEX__DEFAULT__TOPIC: rules-events
       EDGEX__DEFAULT__TYPE: redis
       KUIPER__BASIC__CONSOLELOG: "true"
-      KUIPER__BASIC__DEBUG: "true"
       KUIPER__BASIC__RESTPORT: 59720
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper

--- a/taf/docker-compose-taf-arm64.yml
+++ b/taf/docker-compose-taf-arm64.yml
@@ -1140,9 +1140,13 @@ services:
       CONNECTION__EDGEX__REDISMSGBUS__PROTOCOL: redis
       CONNECTION__EDGEX__REDISMSGBUS__SERVER: edgex-redis
       CONNECTION__EDGEX__REDISMSGBUS__TYPE: redis
-      EDGEX__DEFAULT__CONNECTIONSELECTOR: edgex.redisMsgBus
+      EDGEX__DEFAULT__PORT: 6379
+      EDGEX__DEFAULT__PROTOCOL: redis
+      EDGEX__DEFAULT__SERVER: edgex-redis
       EDGEX__DEFAULT__TOPIC: rules-events
+      EDGEX__DEFAULT__TYPE: redis
       KUIPER__BASIC__CONSOLELOG: "true"
+      KUIPER__BASIC__DEBUG: "true"
       KUIPER__BASIC__RESTPORT: 59720
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper

--- a/taf/docker-compose-taf-arm64.yml
+++ b/taf/docker-compose-taf-arm64.yml
@@ -1146,7 +1146,6 @@ services:
       EDGEX__DEFAULT__TOPIC: rules-events
       EDGEX__DEFAULT__TYPE: redis
       KUIPER__BASIC__CONSOLELOG: "true"
-      KUIPER__BASIC__DEBUG: "true"
       KUIPER__BASIC__RESTPORT: 59720
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper

--- a/taf/docker-compose-taf-mqtt-bus-arm64.yml
+++ b/taf/docker-compose-taf-mqtt-bus-arm64.yml
@@ -1187,9 +1187,14 @@ services:
       CONNECTION__EDGEX__REDISMSGBUS__PROTOCOL: redis
       CONNECTION__EDGEX__REDISMSGBUS__SERVER: edgex-redis
       CONNECTION__EDGEX__REDISMSGBUS__TYPE: redis
-      EDGEX__DEFAULT__CONNECTIONSELECTOR: edgex.mqttMsgBus
+      EDGEX__DEFAULT__OPTIONAL__CLIENTID: kuiper-rules-engine
+      EDGEX__DEFAULT__PORT: 1883
+      EDGEX__DEFAULT__PROTOCOL: tcp
+      EDGEX__DEFAULT__SERVER: edgex-mqtt-broker
       EDGEX__DEFAULT__TOPIC: rules-events
+      EDGEX__DEFAULT__TYPE: mqtt
       KUIPER__BASIC__CONSOLELOG: "true"
+      KUIPER__BASIC__DEBUG: "true"
       KUIPER__BASIC__RESTPORT: 59720
     hostname: edgex-kuiper
     image: lfedge/ekuiper:1.4-alpine

--- a/taf/docker-compose-taf-mqtt-bus-arm64.yml
+++ b/taf/docker-compose-taf-mqtt-bus-arm64.yml
@@ -1179,6 +1179,7 @@ services:
     - mqtt-broker
     environment:
       CONNECTION__EDGEX__MQTTMSGBUS__OPTIONAL__CLIENTID: kuiper-rules-engine
+      CONNECTION__EDGEX__MQTTMSGBUS__OPTIONAL__KEEPALIVE: 500
       CONNECTION__EDGEX__MQTTMSGBUS__PORT: 1883
       CONNECTION__EDGEX__MQTTMSGBUS__PROTOCOL: tcp
       CONNECTION__EDGEX__MQTTMSGBUS__SERVER: edgex-mqtt-broker
@@ -1188,13 +1189,13 @@ services:
       CONNECTION__EDGEX__REDISMSGBUS__SERVER: edgex-redis
       CONNECTION__EDGEX__REDISMSGBUS__TYPE: redis
       EDGEX__DEFAULT__OPTIONAL__CLIENTID: kuiper-rules-engine
+      EDGEX__DEFAULT__OPTIONAL__KEEPALIVE: 500
       EDGEX__DEFAULT__PORT: 1883
       EDGEX__DEFAULT__PROTOCOL: tcp
       EDGEX__DEFAULT__SERVER: edgex-mqtt-broker
       EDGEX__DEFAULT__TOPIC: rules-events
       EDGEX__DEFAULT__TYPE: mqtt
       KUIPER__BASIC__CONSOLELOG: "true"
-      KUIPER__BASIC__DEBUG: "true"
       KUIPER__BASIC__RESTPORT: 59720
     hostname: edgex-kuiper
     image: lfedge/ekuiper:1.4-alpine

--- a/taf/docker-compose-taf-mqtt-bus.yml
+++ b/taf/docker-compose-taf-mqtt-bus.yml
@@ -1187,9 +1187,14 @@ services:
       CONNECTION__EDGEX__REDISMSGBUS__PROTOCOL: redis
       CONNECTION__EDGEX__REDISMSGBUS__SERVER: edgex-redis
       CONNECTION__EDGEX__REDISMSGBUS__TYPE: redis
-      EDGEX__DEFAULT__CONNECTIONSELECTOR: edgex.mqttMsgBus
+      EDGEX__DEFAULT__OPTIONAL__CLIENTID: kuiper-rules-engine
+      EDGEX__DEFAULT__PORT: 1883
+      EDGEX__DEFAULT__PROTOCOL: tcp
+      EDGEX__DEFAULT__SERVER: edgex-mqtt-broker
       EDGEX__DEFAULT__TOPIC: rules-events
+      EDGEX__DEFAULT__TYPE: mqtt
       KUIPER__BASIC__CONSOLELOG: "true"
+      KUIPER__BASIC__DEBUG: "true"
       KUIPER__BASIC__RESTPORT: 59720
     hostname: edgex-kuiper
     image: lfedge/ekuiper:1.4-alpine

--- a/taf/docker-compose-taf-mqtt-bus.yml
+++ b/taf/docker-compose-taf-mqtt-bus.yml
@@ -1179,6 +1179,7 @@ services:
     - mqtt-broker
     environment:
       CONNECTION__EDGEX__MQTTMSGBUS__OPTIONAL__CLIENTID: kuiper-rules-engine
+      CONNECTION__EDGEX__MQTTMSGBUS__OPTIONAL__KEEPALIVE: 500
       CONNECTION__EDGEX__MQTTMSGBUS__PORT: 1883
       CONNECTION__EDGEX__MQTTMSGBUS__PROTOCOL: tcp
       CONNECTION__EDGEX__MQTTMSGBUS__SERVER: edgex-mqtt-broker
@@ -1188,13 +1189,13 @@ services:
       CONNECTION__EDGEX__REDISMSGBUS__SERVER: edgex-redis
       CONNECTION__EDGEX__REDISMSGBUS__TYPE: redis
       EDGEX__DEFAULT__OPTIONAL__CLIENTID: kuiper-rules-engine
+      EDGEX__DEFAULT__OPTIONAL__KEEPALIVE: 500
       EDGEX__DEFAULT__PORT: 1883
       EDGEX__DEFAULT__PROTOCOL: tcp
       EDGEX__DEFAULT__SERVER: edgex-mqtt-broker
       EDGEX__DEFAULT__TOPIC: rules-events
       EDGEX__DEFAULT__TYPE: mqtt
       KUIPER__BASIC__CONSOLELOG: "true"
-      KUIPER__BASIC__DEBUG: "true"
       KUIPER__BASIC__RESTPORT: 59720
     hostname: edgex-kuiper
     image: lfedge/ekuiper:1.4-alpine

--- a/taf/docker-compose-taf-no-secty-arm64.yml
+++ b/taf/docker-compose-taf-no-secty-arm64.yml
@@ -491,9 +491,13 @@ services:
       CONNECTION__EDGEX__REDISMSGBUS__PROTOCOL: redis
       CONNECTION__EDGEX__REDISMSGBUS__SERVER: edgex-redis
       CONNECTION__EDGEX__REDISMSGBUS__TYPE: redis
-      EDGEX__DEFAULT__CONNECTIONSELECTOR: edgex.redisMsgBus
+      EDGEX__DEFAULT__PORT: 6379
+      EDGEX__DEFAULT__PROTOCOL: redis
+      EDGEX__DEFAULT__SERVER: edgex-redis
       EDGEX__DEFAULT__TOPIC: rules-events
+      EDGEX__DEFAULT__TYPE: redis
       KUIPER__BASIC__CONSOLELOG: "true"
+      KUIPER__BASIC__DEBUG: "true"
       KUIPER__BASIC__RESTPORT: 59720
     hostname: edgex-kuiper
     image: lfedge/ekuiper:1.4-alpine

--- a/taf/docker-compose-taf-no-secty-arm64.yml
+++ b/taf/docker-compose-taf-no-secty-arm64.yml
@@ -497,7 +497,6 @@ services:
       EDGEX__DEFAULT__TOPIC: rules-events
       EDGEX__DEFAULT__TYPE: redis
       KUIPER__BASIC__CONSOLELOG: "true"
-      KUIPER__BASIC__DEBUG: "true"
       KUIPER__BASIC__RESTPORT: 59720
     hostname: edgex-kuiper
     image: lfedge/ekuiper:1.4-alpine

--- a/taf/docker-compose-taf-no-secty-mqtt-bus-arm64.yml
+++ b/taf/docker-compose-taf-no-secty-mqtt-bus-arm64.yml
@@ -536,6 +536,7 @@ services:
     - mqtt-broker
     environment:
       CONNECTION__EDGEX__MQTTMSGBUS__OPTIONAL__CLIENTID: kuiper-rules-engine
+      CONNECTION__EDGEX__MQTTMSGBUS__OPTIONAL__KEEPALIVE: 500
       CONNECTION__EDGEX__MQTTMSGBUS__PORT: 1883
       CONNECTION__EDGEX__MQTTMSGBUS__PROTOCOL: tcp
       CONNECTION__EDGEX__MQTTMSGBUS__SERVER: edgex-mqtt-broker
@@ -545,13 +546,13 @@ services:
       CONNECTION__EDGEX__REDISMSGBUS__SERVER: edgex-redis
       CONNECTION__EDGEX__REDISMSGBUS__TYPE: redis
       EDGEX__DEFAULT__OPTIONAL__CLIENTID: kuiper-rules-engine
+      EDGEX__DEFAULT__OPTIONAL__KEEPALIVE: 500
       EDGEX__DEFAULT__PORT: 1883
       EDGEX__DEFAULT__PROTOCOL: tcp
       EDGEX__DEFAULT__SERVER: edgex-mqtt-broker
       EDGEX__DEFAULT__TOPIC: rules-events
       EDGEX__DEFAULT__TYPE: mqtt
       KUIPER__BASIC__CONSOLELOG: "true"
-      KUIPER__BASIC__DEBUG: "true"
       KUIPER__BASIC__RESTPORT: 59720
     hostname: edgex-kuiper
     image: lfedge/ekuiper:1.4-alpine

--- a/taf/docker-compose-taf-no-secty-mqtt-bus-arm64.yml
+++ b/taf/docker-compose-taf-no-secty-mqtt-bus-arm64.yml
@@ -544,9 +544,14 @@ services:
       CONNECTION__EDGEX__REDISMSGBUS__PROTOCOL: redis
       CONNECTION__EDGEX__REDISMSGBUS__SERVER: edgex-redis
       CONNECTION__EDGEX__REDISMSGBUS__TYPE: redis
-      EDGEX__DEFAULT__CONNECTIONSELECTOR: edgex.mqttMsgBus
+      EDGEX__DEFAULT__OPTIONAL__CLIENTID: kuiper-rules-engine
+      EDGEX__DEFAULT__PORT: 1883
+      EDGEX__DEFAULT__PROTOCOL: tcp
+      EDGEX__DEFAULT__SERVER: edgex-mqtt-broker
       EDGEX__DEFAULT__TOPIC: rules-events
+      EDGEX__DEFAULT__TYPE: mqtt
       KUIPER__BASIC__CONSOLELOG: "true"
+      KUIPER__BASIC__DEBUG: "true"
       KUIPER__BASIC__RESTPORT: 59720
     hostname: edgex-kuiper
     image: lfedge/ekuiper:1.4-alpine

--- a/taf/docker-compose-taf-no-secty-mqtt-bus.yml
+++ b/taf/docker-compose-taf-no-secty-mqtt-bus.yml
@@ -536,6 +536,7 @@ services:
     - mqtt-broker
     environment:
       CONNECTION__EDGEX__MQTTMSGBUS__OPTIONAL__CLIENTID: kuiper-rules-engine
+      CONNECTION__EDGEX__MQTTMSGBUS__OPTIONAL__KEEPALIVE: 500
       CONNECTION__EDGEX__MQTTMSGBUS__PORT: 1883
       CONNECTION__EDGEX__MQTTMSGBUS__PROTOCOL: tcp
       CONNECTION__EDGEX__MQTTMSGBUS__SERVER: edgex-mqtt-broker
@@ -545,13 +546,13 @@ services:
       CONNECTION__EDGEX__REDISMSGBUS__SERVER: edgex-redis
       CONNECTION__EDGEX__REDISMSGBUS__TYPE: redis
       EDGEX__DEFAULT__OPTIONAL__CLIENTID: kuiper-rules-engine
+      EDGEX__DEFAULT__OPTIONAL__KEEPALIVE: 500
       EDGEX__DEFAULT__PORT: 1883
       EDGEX__DEFAULT__PROTOCOL: tcp
       EDGEX__DEFAULT__SERVER: edgex-mqtt-broker
       EDGEX__DEFAULT__TOPIC: rules-events
       EDGEX__DEFAULT__TYPE: mqtt
       KUIPER__BASIC__CONSOLELOG: "true"
-      KUIPER__BASIC__DEBUG: "true"
       KUIPER__BASIC__RESTPORT: 59720
     hostname: edgex-kuiper
     image: lfedge/ekuiper:1.4-alpine

--- a/taf/docker-compose-taf-no-secty-mqtt-bus.yml
+++ b/taf/docker-compose-taf-no-secty-mqtt-bus.yml
@@ -544,9 +544,14 @@ services:
       CONNECTION__EDGEX__REDISMSGBUS__PROTOCOL: redis
       CONNECTION__EDGEX__REDISMSGBUS__SERVER: edgex-redis
       CONNECTION__EDGEX__REDISMSGBUS__TYPE: redis
-      EDGEX__DEFAULT__CONNECTIONSELECTOR: edgex.mqttMsgBus
+      EDGEX__DEFAULT__OPTIONAL__CLIENTID: kuiper-rules-engine
+      EDGEX__DEFAULT__PORT: 1883
+      EDGEX__DEFAULT__PROTOCOL: tcp
+      EDGEX__DEFAULT__SERVER: edgex-mqtt-broker
       EDGEX__DEFAULT__TOPIC: rules-events
+      EDGEX__DEFAULT__TYPE: mqtt
       KUIPER__BASIC__CONSOLELOG: "true"
+      KUIPER__BASIC__DEBUG: "true"
       KUIPER__BASIC__RESTPORT: 59720
     hostname: edgex-kuiper
     image: lfedge/ekuiper:1.4-alpine

--- a/taf/docker-compose-taf-no-secty.yml
+++ b/taf/docker-compose-taf-no-secty.yml
@@ -491,9 +491,13 @@ services:
       CONNECTION__EDGEX__REDISMSGBUS__PROTOCOL: redis
       CONNECTION__EDGEX__REDISMSGBUS__SERVER: edgex-redis
       CONNECTION__EDGEX__REDISMSGBUS__TYPE: redis
-      EDGEX__DEFAULT__CONNECTIONSELECTOR: edgex.redisMsgBus
+      EDGEX__DEFAULT__PORT: 6379
+      EDGEX__DEFAULT__PROTOCOL: redis
+      EDGEX__DEFAULT__SERVER: edgex-redis
       EDGEX__DEFAULT__TOPIC: rules-events
+      EDGEX__DEFAULT__TYPE: redis
       KUIPER__BASIC__CONSOLELOG: "true"
+      KUIPER__BASIC__DEBUG: "true"
       KUIPER__BASIC__RESTPORT: 59720
     hostname: edgex-kuiper
     image: lfedge/ekuiper:1.4-alpine

--- a/taf/docker-compose-taf-no-secty.yml
+++ b/taf/docker-compose-taf-no-secty.yml
@@ -497,7 +497,6 @@ services:
       EDGEX__DEFAULT__TOPIC: rules-events
       EDGEX__DEFAULT__TYPE: redis
       KUIPER__BASIC__CONSOLELOG: "true"
-      KUIPER__BASIC__DEBUG: "true"
       KUIPER__BASIC__RESTPORT: 59720
     hostname: edgex-kuiper
     image: lfedge/ekuiper:1.4-alpine

--- a/taf/docker-compose-taf-perf-arm64.yml
+++ b/taf/docker-compose-taf-perf-arm64.yml
@@ -820,9 +820,13 @@ services:
       CONNECTION__EDGEX__REDISMSGBUS__PROTOCOL: redis
       CONNECTION__EDGEX__REDISMSGBUS__SERVER: edgex-redis
       CONNECTION__EDGEX__REDISMSGBUS__TYPE: redis
-      EDGEX__DEFAULT__CONNECTIONSELECTOR: edgex.redisMsgBus
+      EDGEX__DEFAULT__PORT: 6379
+      EDGEX__DEFAULT__PROTOCOL: redis
+      EDGEX__DEFAULT__SERVER: edgex-redis
       EDGEX__DEFAULT__TOPIC: rules-events
+      EDGEX__DEFAULT__TYPE: redis
       KUIPER__BASIC__CONSOLELOG: "true"
+      KUIPER__BASIC__DEBUG: "true"
       KUIPER__BASIC__RESTPORT: 59720
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper

--- a/taf/docker-compose-taf-perf-arm64.yml
+++ b/taf/docker-compose-taf-perf-arm64.yml
@@ -826,7 +826,6 @@ services:
       EDGEX__DEFAULT__TOPIC: rules-events
       EDGEX__DEFAULT__TYPE: redis
       KUIPER__BASIC__CONSOLELOG: "true"
-      KUIPER__BASIC__DEBUG: "true"
       KUIPER__BASIC__RESTPORT: 59720
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper

--- a/taf/docker-compose-taf-perf-no-secty-arm64.yml
+++ b/taf/docker-compose-taf-perf-no-secty-arm64.yml
@@ -320,9 +320,13 @@ services:
       CONNECTION__EDGEX__REDISMSGBUS__PROTOCOL: redis
       CONNECTION__EDGEX__REDISMSGBUS__SERVER: edgex-redis
       CONNECTION__EDGEX__REDISMSGBUS__TYPE: redis
-      EDGEX__DEFAULT__CONNECTIONSELECTOR: edgex.redisMsgBus
+      EDGEX__DEFAULT__PORT: 6379
+      EDGEX__DEFAULT__PROTOCOL: redis
+      EDGEX__DEFAULT__SERVER: edgex-redis
       EDGEX__DEFAULT__TOPIC: rules-events
+      EDGEX__DEFAULT__TYPE: redis
       KUIPER__BASIC__CONSOLELOG: "true"
+      KUIPER__BASIC__DEBUG: "true"
       KUIPER__BASIC__RESTPORT: 59720
     hostname: edgex-kuiper
     image: lfedge/ekuiper:1.4-alpine

--- a/taf/docker-compose-taf-perf-no-secty-arm64.yml
+++ b/taf/docker-compose-taf-perf-no-secty-arm64.yml
@@ -326,7 +326,6 @@ services:
       EDGEX__DEFAULT__TOPIC: rules-events
       EDGEX__DEFAULT__TYPE: redis
       KUIPER__BASIC__CONSOLELOG: "true"
-      KUIPER__BASIC__DEBUG: "true"
       KUIPER__BASIC__RESTPORT: 59720
     hostname: edgex-kuiper
     image: lfedge/ekuiper:1.4-alpine

--- a/taf/docker-compose-taf-perf-no-secty.yml
+++ b/taf/docker-compose-taf-perf-no-secty.yml
@@ -320,9 +320,13 @@ services:
       CONNECTION__EDGEX__REDISMSGBUS__PROTOCOL: redis
       CONNECTION__EDGEX__REDISMSGBUS__SERVER: edgex-redis
       CONNECTION__EDGEX__REDISMSGBUS__TYPE: redis
-      EDGEX__DEFAULT__CONNECTIONSELECTOR: edgex.redisMsgBus
+      EDGEX__DEFAULT__PORT: 6379
+      EDGEX__DEFAULT__PROTOCOL: redis
+      EDGEX__DEFAULT__SERVER: edgex-redis
       EDGEX__DEFAULT__TOPIC: rules-events
+      EDGEX__DEFAULT__TYPE: redis
       KUIPER__BASIC__CONSOLELOG: "true"
+      KUIPER__BASIC__DEBUG: "true"
       KUIPER__BASIC__RESTPORT: 59720
     hostname: edgex-kuiper
     image: lfedge/ekuiper:1.4-alpine

--- a/taf/docker-compose-taf-perf-no-secty.yml
+++ b/taf/docker-compose-taf-perf-no-secty.yml
@@ -326,7 +326,6 @@ services:
       EDGEX__DEFAULT__TOPIC: rules-events
       EDGEX__DEFAULT__TYPE: redis
       KUIPER__BASIC__CONSOLELOG: "true"
-      KUIPER__BASIC__DEBUG: "true"
       KUIPER__BASIC__RESTPORT: 59720
     hostname: edgex-kuiper
     image: lfedge/ekuiper:1.4-alpine

--- a/taf/docker-compose-taf-perf.yml
+++ b/taf/docker-compose-taf-perf.yml
@@ -820,9 +820,13 @@ services:
       CONNECTION__EDGEX__REDISMSGBUS__PROTOCOL: redis
       CONNECTION__EDGEX__REDISMSGBUS__SERVER: edgex-redis
       CONNECTION__EDGEX__REDISMSGBUS__TYPE: redis
-      EDGEX__DEFAULT__CONNECTIONSELECTOR: edgex.redisMsgBus
+      EDGEX__DEFAULT__PORT: 6379
+      EDGEX__DEFAULT__PROTOCOL: redis
+      EDGEX__DEFAULT__SERVER: edgex-redis
       EDGEX__DEFAULT__TOPIC: rules-events
+      EDGEX__DEFAULT__TYPE: redis
       KUIPER__BASIC__CONSOLELOG: "true"
+      KUIPER__BASIC__DEBUG: "true"
       KUIPER__BASIC__RESTPORT: 59720
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper

--- a/taf/docker-compose-taf-perf.yml
+++ b/taf/docker-compose-taf-perf.yml
@@ -826,7 +826,6 @@ services:
       EDGEX__DEFAULT__TOPIC: rules-events
       EDGEX__DEFAULT__TYPE: redis
       KUIPER__BASIC__CONSOLELOG: "true"
-      KUIPER__BASIC__DEBUG: "true"
       KUIPER__BASIC__RESTPORT: 59720
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper

--- a/taf/docker-compose-taf.yml
+++ b/taf/docker-compose-taf.yml
@@ -1140,9 +1140,13 @@ services:
       CONNECTION__EDGEX__REDISMSGBUS__PROTOCOL: redis
       CONNECTION__EDGEX__REDISMSGBUS__SERVER: edgex-redis
       CONNECTION__EDGEX__REDISMSGBUS__TYPE: redis
-      EDGEX__DEFAULT__CONNECTIONSELECTOR: edgex.redisMsgBus
+      EDGEX__DEFAULT__PORT: 6379
+      EDGEX__DEFAULT__PROTOCOL: redis
+      EDGEX__DEFAULT__SERVER: edgex-redis
       EDGEX__DEFAULT__TOPIC: rules-events
+      EDGEX__DEFAULT__TYPE: redis
       KUIPER__BASIC__CONSOLELOG: "true"
+      KUIPER__BASIC__DEBUG: "true"
       KUIPER__BASIC__RESTPORT: 59720
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper

--- a/taf/docker-compose-taf.yml
+++ b/taf/docker-compose-taf.yml
@@ -1146,7 +1146,6 @@ services:
       EDGEX__DEFAULT__TOPIC: rules-events
       EDGEX__DEFAULT__TYPE: redis
       KUIPER__BASIC__CONSOLELOG: "true"
-      KUIPER__BASIC__DEBUG: "true"
       KUIPER__BASIC__RESTPORT: 59720
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper


### PR DESCRIPTION
<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-compose/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-compose/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?) **N/A**
  <link to docs PR>


## Testing Instructions
Run edgex stack with **Redis** MessageBus un-secure
Create stream and rule
Verify eKuiper logs don't have error connecting to MessageBus 
Run edgex stack with **MQTT** MessageBus un-secure
Create stream and rule
Verify eKuiper logs don't have error connecting to MessageBus 