### PR TITLE
feat: Update the README to reference TUI Generator

### DIFF
--- a/compose-builder/README.md
+++ b/compose-builder/README.md
@@ -5,6 +5,8 @@ This folder contains the `Compose Builder` which is made up of **source** compos
 > **Note to Developers**: 
 > *Once you have edited and tested your changes to these source files you **MUST** regenerate the standard `pre-release` compose files using the `make build` command.*
 >
+> Any new options added to the `make gen` and `make run` commands must to also be added to the new` tui-generator.sh` script
+>
 > **You must use *docker-compose version 1.27.2* due to bug in later versions that generates the `depends_on` sections incorrectly for compose version 3.x**
 
 ### Generate next release compose files
@@ -122,6 +124,10 @@ This folder contains the following environment files:
     This file contains the common environment overrides used by all App Service Configurable instances using the `http-export` profile
 - **asc-mqtt-export.env**
 - This file contains the common environment overrides used by all App Service Configurable instances using the `mqtt-export` profile
+
+### TUI (terminal UI)
+
+Compose builder now has the TUI Generator tool that provides menus to select the options described in the [Makefile](#makefile) section below for generation and running of custom compose files. To use this tool simply run `./tui-generator.sh` in a Linux terminal from the `compose-builder` folder.
 
 ### Makefile
 

--- a/compose-builder/tui-generator.sh
+++ b/compose-builder/tui-generator.sh
@@ -51,6 +51,7 @@ declare -A additionalOptsDesc=(
 declare -A appServiceDesc=(
     [asc-http]="Include HTTP Export App Service"
     [asc-mqtt]="Include MQTT Export App Service"
+    [asc-metrics]="Include Metrics to InfluxDB App Service"
     [asc-sample]="Include Sample App Service"
     [as-llrp]="Include RFID LLRP Inventory"
     [asc-ex-mqtt]="Include External MQTT Trigger App Service"


### PR DESCRIPTION
Also added missing `asc-metrics` to the tui-generator.sh

Signed-off-by: Leonard Goodell <leonard.goodell@intel.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-compose/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-compose/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [ ] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>


## Testing Instructions
<!-- How can the reviewers test your change? -->
