### PR TITLE
build: Update to latest 3rd party version that don't break

### DIFF
--- a/compose-builder/.env
+++ b/compose-builder/.env
@@ -39,15 +39,15 @@ DEVICE_LLRP_VERSION=latest
 DEVICE_COAP_VERSION=latest
 DEVICE_GPIO_VERSION=latest
 
-# Note that Vault images don't have non-patch versions like 1.9
-VAULT_VERSION=1.8.9
-CONSUL_VERSION=1.10.10
+# Note that Vault images don't have non-patch versions like 1.10
+VAULT_VERSION=1.10.3
+CONSUL_VERSION=1.12
 # Note that Postgres images don't use patch versions.
-POSTGRES_VERSION=13.5-alpine
-REDIS_VERSION=6.2.6-alpine
-KONG_VERSION=2.6.1
-KUIPER_VERSION=1.4.4-alpine
-MOSQUITTO_VERSION=2.0.14
+POSTGRES_VERSION=13.7-alpine
+REDIS_VERSION=6.2-alpine
+KONG_VERSION=2.8
+KUIPER_VERSION=1.5-alpine
+MOSQUITTO_VERSION=2.0
 
 EDGEX_USER=2002
 EDGEX_GROUP=2001

--- a/docker-compose-arm64.yml
+++ b/docker-compose-arm64.yml
@@ -185,7 +185,7 @@ services:
       STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-core-consul
-    image: consul:1.10.10
+    image: consul:1.12
     networks:
       edgex-network: {}
     ports:
@@ -304,7 +304,7 @@ services:
       STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-redis
-    image: redis:6.2.6-alpine
+    image: redis:6.2-alpine
     networks:
       edgex-network: {}
     ports:
@@ -477,7 +477,7 @@ services:
       STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-kong
-    image: kong:2.6.1
+    image: kong:2.8
     networks:
       edgex-network: {}
     ports:
@@ -533,7 +533,7 @@ services:
       STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-kong-db
-    image: postgres:13.5-alpine
+    image: postgres:13.7-alpine
     networks:
       edgex-network: {}
     ports:
@@ -763,7 +763,7 @@ services:
       STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-kuiper
-    image: lfedge/ekuiper:1.4.4-alpine
+    image: lfedge/ekuiper:1.5-alpine
     networks:
       edgex-network: {}
     ports:
@@ -1037,7 +1037,7 @@ services:
       VAULT_CONFIG_DIR: /vault/config
       VAULT_UI: "true"
     hostname: edgex-vault
-    image: vault:1.8.9
+    image: vault:1.10.3
     networks:
       edgex-network: {}
     ports:

--- a/docker-compose-no-secty-arm64.yml
+++ b/docker-compose-no-secty-arm64.yml
@@ -88,7 +88,7 @@ services:
     command: agent -ui -bootstrap -server -client 0.0.0.0
     container_name: edgex-core-consul
     hostname: edgex-core-consul
-    image: consul:1.10.10
+    image: consul:1.12
     networks:
       edgex-network: {}
     ports:
@@ -142,7 +142,7 @@ services:
       EDGEX_SECURITY_SECRET_STORE: "false"
       REGISTRY_HOST: edgex-core-consul
     hostname: edgex-redis
-    image: redis:6.2.6-alpine
+    image: redis:6.2-alpine
     networks:
       edgex-network: {}
     ports:
@@ -281,7 +281,7 @@ services:
       KUIPER__BASIC__CONSOLELOG: "true"
       KUIPER__BASIC__RESTPORT: 59720
     hostname: edgex-kuiper
-    image: lfedge/ekuiper:1.4.4-alpine
+    image: lfedge/ekuiper:1.5-alpine
     networks:
       edgex-network: {}
     ports:

--- a/docker-compose-no-secty-with-app-sample-arm64.yml
+++ b/docker-compose-no-secty-with-app-sample-arm64.yml
@@ -118,7 +118,7 @@ services:
     command: agent -ui -bootstrap -server -client 0.0.0.0
     container_name: edgex-core-consul
     hostname: edgex-core-consul
-    image: consul:1.10.10
+    image: consul:1.12
     networks:
       edgex-network: {}
     ports:
@@ -172,7 +172,7 @@ services:
       EDGEX_SECURITY_SECRET_STORE: "false"
       REGISTRY_HOST: edgex-core-consul
     hostname: edgex-redis
-    image: redis:6.2.6-alpine
+    image: redis:6.2-alpine
     networks:
       edgex-network: {}
     ports:
@@ -311,7 +311,7 @@ services:
       KUIPER__BASIC__CONSOLELOG: "true"
       KUIPER__BASIC__RESTPORT: 59720
     hostname: edgex-kuiper
-    image: lfedge/ekuiper:1.4.4-alpine
+    image: lfedge/ekuiper:1.5-alpine
     networks:
       edgex-network: {}
     ports:

--- a/docker-compose-no-secty-with-app-sample.yml
+++ b/docker-compose-no-secty-with-app-sample.yml
@@ -118,7 +118,7 @@ services:
     command: agent -ui -bootstrap -server -client 0.0.0.0
     container_name: edgex-core-consul
     hostname: edgex-core-consul
-    image: consul:1.10.10
+    image: consul:1.12
     networks:
       edgex-network: {}
     ports:
@@ -172,7 +172,7 @@ services:
       EDGEX_SECURITY_SECRET_STORE: "false"
       REGISTRY_HOST: edgex-core-consul
     hostname: edgex-redis
-    image: redis:6.2.6-alpine
+    image: redis:6.2-alpine
     networks:
       edgex-network: {}
     ports:
@@ -311,7 +311,7 @@ services:
       KUIPER__BASIC__CONSOLELOG: "true"
       KUIPER__BASIC__RESTPORT: 59720
     hostname: edgex-kuiper
-    image: lfedge/ekuiper:1.4.4-alpine
+    image: lfedge/ekuiper:1.5-alpine
     networks:
       edgex-network: {}
     ports:

--- a/docker-compose-no-secty.yml
+++ b/docker-compose-no-secty.yml
@@ -88,7 +88,7 @@ services:
     command: agent -ui -bootstrap -server -client 0.0.0.0
     container_name: edgex-core-consul
     hostname: edgex-core-consul
-    image: consul:1.10.10
+    image: consul:1.12
     networks:
       edgex-network: {}
     ports:
@@ -142,7 +142,7 @@ services:
       EDGEX_SECURITY_SECRET_STORE: "false"
       REGISTRY_HOST: edgex-core-consul
     hostname: edgex-redis
-    image: redis:6.2.6-alpine
+    image: redis:6.2-alpine
     networks:
       edgex-network: {}
     ports:
@@ -281,7 +281,7 @@ services:
       KUIPER__BASIC__CONSOLELOG: "true"
       KUIPER__BASIC__RESTPORT: 59720
     hostname: edgex-kuiper
-    image: lfedge/ekuiper:1.4.4-alpine
+    image: lfedge/ekuiper:1.5-alpine
     networks:
       edgex-network: {}
     ports:

--- a/docker-compose-with-app-sample-arm64.yml
+++ b/docker-compose-with-app-sample-arm64.yml
@@ -246,7 +246,7 @@ services:
       STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-core-consul
-    image: consul:1.10.10
+    image: consul:1.12
     networks:
       edgex-network: {}
     ports:
@@ -365,7 +365,7 @@ services:
       STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-redis
-    image: redis:6.2.6-alpine
+    image: redis:6.2-alpine
     networks:
       edgex-network: {}
     ports:
@@ -538,7 +538,7 @@ services:
       STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-kong
-    image: kong:2.6.1
+    image: kong:2.8
     networks:
       edgex-network: {}
     ports:
@@ -594,7 +594,7 @@ services:
       STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-kong-db
-    image: postgres:13.5-alpine
+    image: postgres:13.7-alpine
     networks:
       edgex-network: {}
     ports:
@@ -824,7 +824,7 @@ services:
       STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-kuiper
-    image: lfedge/ekuiper:1.4.4-alpine
+    image: lfedge/ekuiper:1.5-alpine
     networks:
       edgex-network: {}
     ports:
@@ -1098,7 +1098,7 @@ services:
       VAULT_CONFIG_DIR: /vault/config
       VAULT_UI: "true"
     hostname: edgex-vault
-    image: vault:1.8.9
+    image: vault:1.10.3
     networks:
       edgex-network: {}
     ports:

--- a/docker-compose-with-app-sample.yml
+++ b/docker-compose-with-app-sample.yml
@@ -246,7 +246,7 @@ services:
       STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-core-consul
-    image: consul:1.10.10
+    image: consul:1.12
     networks:
       edgex-network: {}
     ports:
@@ -365,7 +365,7 @@ services:
       STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-redis
-    image: redis:6.2.6-alpine
+    image: redis:6.2-alpine
     networks:
       edgex-network: {}
     ports:
@@ -538,7 +538,7 @@ services:
       STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-kong
-    image: kong:2.6.1
+    image: kong:2.8
     networks:
       edgex-network: {}
     ports:
@@ -594,7 +594,7 @@ services:
       STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-kong-db
-    image: postgres:13.5-alpine
+    image: postgres:13.7-alpine
     networks:
       edgex-network: {}
     ports:
@@ -824,7 +824,7 @@ services:
       STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-kuiper
-    image: lfedge/ekuiper:1.4.4-alpine
+    image: lfedge/ekuiper:1.5-alpine
     networks:
       edgex-network: {}
     ports:
@@ -1098,7 +1098,7 @@ services:
       VAULT_CONFIG_DIR: /vault/config
       VAULT_UI: "true"
     hostname: edgex-vault
-    image: vault:1.8.9
+    image: vault:1.10.3
     networks:
       edgex-network: {}
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -185,7 +185,7 @@ services:
       STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-core-consul
-    image: consul:1.10.10
+    image: consul:1.12
     networks:
       edgex-network: {}
     ports:
@@ -304,7 +304,7 @@ services:
       STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-redis
-    image: redis:6.2.6-alpine
+    image: redis:6.2-alpine
     networks:
       edgex-network: {}
     ports:
@@ -477,7 +477,7 @@ services:
       STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-kong
-    image: kong:2.6.1
+    image: kong:2.8
     networks:
       edgex-network: {}
     ports:
@@ -533,7 +533,7 @@ services:
       STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-kong-db
-    image: postgres:13.5-alpine
+    image: postgres:13.7-alpine
     networks:
       edgex-network: {}
     ports:
@@ -763,7 +763,7 @@ services:
       STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-kuiper
-    image: lfedge/ekuiper:1.4.4-alpine
+    image: lfedge/ekuiper:1.5-alpine
     networks:
       edgex-network: {}
     ports:
@@ -1037,7 +1037,7 @@ services:
       VAULT_CONFIG_DIR: /vault/config
       VAULT_UI: "true"
     hostname: edgex-vault
-    image: vault:1.8.9
+    image: vault:1.10.3
     networks:
       edgex-network: {}
     ports:

--- a/taf/docker-compose-taf-arm64.yml
+++ b/taf/docker-compose-taf-arm64.yml
@@ -440,7 +440,7 @@ services:
       STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-core-consul
-    image: consul:1.10.10
+    image: consul:1.12
     networks:
       edgex-network: {}
     ports:
@@ -559,7 +559,7 @@ services:
       STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-redis
-    image: redis:6.2.6-alpine
+    image: redis:6.2-alpine
     networks:
       edgex-network: {}
     ports:
@@ -851,7 +851,7 @@ services:
       STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-kong
-    image: kong:2.6.1
+    image: kong:2.8
     networks:
       edgex-network: {}
     ports:
@@ -907,7 +907,7 @@ services:
       STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-kong-db
-    image: postgres:13.5-alpine
+    image: postgres:13.7-alpine
     networks:
       edgex-network: {}
     ports:
@@ -1001,7 +1001,7 @@ services:
     command: /usr/sbin/mosquitto -c /mosquitto-no-auth.conf
     container_name: edgex-mqtt-broker
     hostname: edgex-mqtt-broker
-    image: eclipse-mosquitto:2.0.14
+    image: eclipse-mosquitto:2.0
     networks:
       edgex-network: {}
     ports:
@@ -1164,7 +1164,7 @@ services:
       STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-kuiper
-    image: lfedge/ekuiper:1.4.4-alpine
+    image: lfedge/ekuiper:1.5-alpine
     networks:
       edgex-network: {}
     ports:
@@ -1505,7 +1505,7 @@ services:
       VAULT_CONFIG_DIR: /vault/config
       VAULT_UI: "true"
     hostname: edgex-vault
-    image: vault:1.8.9
+    image: vault:1.10.3
     networks:
       edgex-network: {}
     ports:

--- a/taf/docker-compose-taf-mqtt-bus-arm64.yml
+++ b/taf/docker-compose-taf-mqtt-bus-arm64.yml
@@ -461,7 +461,7 @@ services:
       STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-core-consul
-    image: consul:1.10.10
+    image: consul:1.12
     networks:
       edgex-network: {}
     ports:
@@ -586,7 +586,7 @@ services:
       STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-redis
-    image: redis:6.2.6-alpine
+    image: redis:6.2-alpine
     networks:
       edgex-network: {}
     ports:
@@ -898,7 +898,7 @@ services:
       STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-kong
-    image: kong:2.6.1
+    image: kong:2.8
     networks:
       edgex-network: {}
     ports:
@@ -954,7 +954,7 @@ services:
       STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-kong-db
-    image: postgres:13.5-alpine
+    image: postgres:13.7-alpine
     networks:
       edgex-network: {}
     ports:
@@ -1048,7 +1048,7 @@ services:
     command: /usr/sbin/mosquitto -c /mosquitto-no-auth.conf
     container_name: edgex-mqtt-broker
     hostname: edgex-mqtt-broker
-    image: eclipse-mosquitto:2.0.14
+    image: eclipse-mosquitto:2.0
     networks:
       edgex-network: {}
     ports:
@@ -1198,7 +1198,7 @@ services:
       KUIPER__BASIC__CONSOLELOG: "true"
       KUIPER__BASIC__RESTPORT: 59720
     hostname: edgex-kuiper
-    image: lfedge/ekuiper:1.4.4-alpine
+    image: lfedge/ekuiper:1.5-alpine
     networks:
       edgex-network: {}
     ports:
@@ -1540,7 +1540,7 @@ services:
       VAULT_CONFIG_DIR: /vault/config
       VAULT_UI: "true"
     hostname: edgex-vault
-    image: vault:1.8.9
+    image: vault:1.10.3
     networks:
       edgex-network: {}
     ports:

--- a/taf/docker-compose-taf-mqtt-bus.yml
+++ b/taf/docker-compose-taf-mqtt-bus.yml
@@ -461,7 +461,7 @@ services:
       STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-core-consul
-    image: consul:1.10.10
+    image: consul:1.12
     networks:
       edgex-network: {}
     ports:
@@ -586,7 +586,7 @@ services:
       STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-redis
-    image: redis:6.2.6-alpine
+    image: redis:6.2-alpine
     networks:
       edgex-network: {}
     ports:
@@ -898,7 +898,7 @@ services:
       STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-kong
-    image: kong:2.6.1
+    image: kong:2.8
     networks:
       edgex-network: {}
     ports:
@@ -954,7 +954,7 @@ services:
       STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-kong-db
-    image: postgres:13.5-alpine
+    image: postgres:13.7-alpine
     networks:
       edgex-network: {}
     ports:
@@ -1048,7 +1048,7 @@ services:
     command: /usr/sbin/mosquitto -c /mosquitto-no-auth.conf
     container_name: edgex-mqtt-broker
     hostname: edgex-mqtt-broker
-    image: eclipse-mosquitto:2.0.14
+    image: eclipse-mosquitto:2.0
     networks:
       edgex-network: {}
     ports:
@@ -1198,7 +1198,7 @@ services:
       KUIPER__BASIC__CONSOLELOG: "true"
       KUIPER__BASIC__RESTPORT: 59720
     hostname: edgex-kuiper
-    image: lfedge/ekuiper:1.4.4-alpine
+    image: lfedge/ekuiper:1.5-alpine
     networks:
       edgex-network: {}
     ports:
@@ -1540,7 +1540,7 @@ services:
       VAULT_CONFIG_DIR: /vault/config
       VAULT_UI: "true"
     hostname: edgex-vault
-    image: vault:1.8.9
+    image: vault:1.10.3
     networks:
       edgex-network: {}
     ports:

--- a/taf/docker-compose-taf-no-secty-arm64.yml
+++ b/taf/docker-compose-taf-no-secty-arm64.yml
@@ -216,7 +216,7 @@ services:
     command: agent -ui -bootstrap -server -client 0.0.0.0
     container_name: edgex-core-consul
     hostname: edgex-core-consul
-    image: consul:1.10.10
+    image: consul:1.12
     networks:
       edgex-network: {}
     ports:
@@ -270,7 +270,7 @@ services:
       EDGEX_SECURITY_SECRET_STORE: "false"
       REGISTRY_HOST: edgex-core-consul
     hostname: edgex-redis
-    image: redis:6.2.6-alpine
+    image: redis:6.2-alpine
     networks:
       edgex-network: {}
     ports:
@@ -446,7 +446,7 @@ services:
     command: /usr/sbin/mosquitto -c /mosquitto-no-auth.conf
     container_name: edgex-mqtt-broker
     hostname: edgex-mqtt-broker
-    image: eclipse-mosquitto:2.0.14
+    image: eclipse-mosquitto:2.0
     networks:
       edgex-network: {}
     ports:
@@ -499,7 +499,7 @@ services:
       KUIPER__BASIC__CONSOLELOG: "true"
       KUIPER__BASIC__RESTPORT: 59720
     hostname: edgex-kuiper
-    image: lfedge/ekuiper:1.4.4-alpine
+    image: lfedge/ekuiper:1.5-alpine
     networks:
       edgex-network: {}
     ports:

--- a/taf/docker-compose-taf-no-secty-mqtt-bus-arm64.yml
+++ b/taf/docker-compose-taf-no-secty-mqtt-bus-arm64.yml
@@ -237,7 +237,7 @@ services:
     command: agent -ui -bootstrap -server -client 0.0.0.0
     container_name: edgex-core-consul
     hostname: edgex-core-consul
-    image: consul:1.10.10
+    image: consul:1.12
     networks:
       edgex-network: {}
     ports:
@@ -297,7 +297,7 @@ services:
       EDGEX_SECURITY_SECRET_STORE: "false"
       REGISTRY_HOST: edgex-core-consul
     hostname: edgex-redis
-    image: redis:6.2.6-alpine
+    image: redis:6.2-alpine
     networks:
       edgex-network: {}
     ports:
@@ -493,7 +493,7 @@ services:
     command: /usr/sbin/mosquitto -c /mosquitto-no-auth.conf
     container_name: edgex-mqtt-broker
     hostname: edgex-mqtt-broker
-    image: eclipse-mosquitto:2.0.14
+    image: eclipse-mosquitto:2.0
     networks:
       edgex-network: {}
     ports:
@@ -555,7 +555,7 @@ services:
       KUIPER__BASIC__CONSOLELOG: "true"
       KUIPER__BASIC__RESTPORT: 59720
     hostname: edgex-kuiper
-    image: lfedge/ekuiper:1.4.4-alpine
+    image: lfedge/ekuiper:1.5-alpine
     networks:
       edgex-network: {}
     ports:

--- a/taf/docker-compose-taf-no-secty-mqtt-bus.yml
+++ b/taf/docker-compose-taf-no-secty-mqtt-bus.yml
@@ -237,7 +237,7 @@ services:
     command: agent -ui -bootstrap -server -client 0.0.0.0
     container_name: edgex-core-consul
     hostname: edgex-core-consul
-    image: consul:1.10.10
+    image: consul:1.12
     networks:
       edgex-network: {}
     ports:
@@ -297,7 +297,7 @@ services:
       EDGEX_SECURITY_SECRET_STORE: "false"
       REGISTRY_HOST: edgex-core-consul
     hostname: edgex-redis
-    image: redis:6.2.6-alpine
+    image: redis:6.2-alpine
     networks:
       edgex-network: {}
     ports:
@@ -493,7 +493,7 @@ services:
     command: /usr/sbin/mosquitto -c /mosquitto-no-auth.conf
     container_name: edgex-mqtt-broker
     hostname: edgex-mqtt-broker
-    image: eclipse-mosquitto:2.0.14
+    image: eclipse-mosquitto:2.0
     networks:
       edgex-network: {}
     ports:
@@ -555,7 +555,7 @@ services:
       KUIPER__BASIC__CONSOLELOG: "true"
       KUIPER__BASIC__RESTPORT: 59720
     hostname: edgex-kuiper
-    image: lfedge/ekuiper:1.4.4-alpine
+    image: lfedge/ekuiper:1.5-alpine
     networks:
       edgex-network: {}
     ports:

--- a/taf/docker-compose-taf-no-secty.yml
+++ b/taf/docker-compose-taf-no-secty.yml
@@ -216,7 +216,7 @@ services:
     command: agent -ui -bootstrap -server -client 0.0.0.0
     container_name: edgex-core-consul
     hostname: edgex-core-consul
-    image: consul:1.10.10
+    image: consul:1.12
     networks:
       edgex-network: {}
     ports:
@@ -270,7 +270,7 @@ services:
       EDGEX_SECURITY_SECRET_STORE: "false"
       REGISTRY_HOST: edgex-core-consul
     hostname: edgex-redis
-    image: redis:6.2.6-alpine
+    image: redis:6.2-alpine
     networks:
       edgex-network: {}
     ports:
@@ -446,7 +446,7 @@ services:
     command: /usr/sbin/mosquitto -c /mosquitto-no-auth.conf
     container_name: edgex-mqtt-broker
     hostname: edgex-mqtt-broker
-    image: eclipse-mosquitto:2.0.14
+    image: eclipse-mosquitto:2.0
     networks:
       edgex-network: {}
     ports:
@@ -499,7 +499,7 @@ services:
       KUIPER__BASIC__CONSOLELOG: "true"
       KUIPER__BASIC__RESTPORT: 59720
     hostname: edgex-kuiper
-    image: lfedge/ekuiper:1.4.4-alpine
+    image: lfedge/ekuiper:1.5-alpine
     networks:
       edgex-network: {}
     ports:

--- a/taf/docker-compose-taf-perf-arm64.yml
+++ b/taf/docker-compose-taf-perf-arm64.yml
@@ -252,7 +252,7 @@ services:
       STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-core-consul
-    image: consul:1.10.10
+    image: consul:1.12
     networks:
       edgex-network: {}
     ports:
@@ -371,7 +371,7 @@ services:
       STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-redis
-    image: redis:6.2.6-alpine
+    image: redis:6.2-alpine
     networks:
       edgex-network: {}
     ports:
@@ -544,7 +544,7 @@ services:
       STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-kong
-    image: kong:2.6.1
+    image: kong:2.8
     networks:
       edgex-network: {}
     ports:
@@ -600,7 +600,7 @@ services:
       STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-kong-db
-    image: postgres:13.5-alpine
+    image: postgres:13.7-alpine
     networks:
       edgex-network: {}
     ports:
@@ -681,7 +681,7 @@ services:
     command: /usr/sbin/mosquitto -c /mosquitto-no-auth.conf
     container_name: edgex-mqtt-broker
     hostname: edgex-mqtt-broker
-    image: eclipse-mosquitto:2.0.14
+    image: eclipse-mosquitto:2.0
     networks:
       edgex-network: {}
     ports:
@@ -844,7 +844,7 @@ services:
       STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-kuiper
-    image: lfedge/ekuiper:1.4.4-alpine
+    image: lfedge/ekuiper:1.5-alpine
     networks:
       edgex-network: {}
     ports:
@@ -1118,7 +1118,7 @@ services:
       VAULT_CONFIG_DIR: /vault/config
       VAULT_UI: "true"
     hostname: edgex-vault
-    image: vault:1.8.9
+    image: vault:1.10.3
     networks:
       edgex-network: {}
     ports:

--- a/taf/docker-compose-taf-perf-no-secty-arm64.yml
+++ b/taf/docker-compose-taf-perf-no-secty-arm64.yml
@@ -121,7 +121,7 @@ services:
     command: agent -ui -bootstrap -server -client 0.0.0.0
     container_name: edgex-core-consul
     hostname: edgex-core-consul
-    image: consul:1.10.10
+    image: consul:1.12
     networks:
       edgex-network: {}
     ports:
@@ -175,7 +175,7 @@ services:
       EDGEX_SECURITY_SECRET_STORE: "false"
       REGISTRY_HOST: edgex-core-consul
     hostname: edgex-redis
-    image: redis:6.2.6-alpine
+    image: redis:6.2-alpine
     networks:
       edgex-network: {}
     ports:
@@ -275,7 +275,7 @@ services:
     command: /usr/sbin/mosquitto -c /mosquitto-no-auth.conf
     container_name: edgex-mqtt-broker
     hostname: edgex-mqtt-broker
-    image: eclipse-mosquitto:2.0.14
+    image: eclipse-mosquitto:2.0
     networks:
       edgex-network: {}
     ports:
@@ -328,7 +328,7 @@ services:
       KUIPER__BASIC__CONSOLELOG: "true"
       KUIPER__BASIC__RESTPORT: 59720
     hostname: edgex-kuiper
-    image: lfedge/ekuiper:1.4.4-alpine
+    image: lfedge/ekuiper:1.5-alpine
     networks:
       edgex-network: {}
     ports:

--- a/taf/docker-compose-taf-perf-no-secty.yml
+++ b/taf/docker-compose-taf-perf-no-secty.yml
@@ -121,7 +121,7 @@ services:
     command: agent -ui -bootstrap -server -client 0.0.0.0
     container_name: edgex-core-consul
     hostname: edgex-core-consul
-    image: consul:1.10.10
+    image: consul:1.12
     networks:
       edgex-network: {}
     ports:
@@ -175,7 +175,7 @@ services:
       EDGEX_SECURITY_SECRET_STORE: "false"
       REGISTRY_HOST: edgex-core-consul
     hostname: edgex-redis
-    image: redis:6.2.6-alpine
+    image: redis:6.2-alpine
     networks:
       edgex-network: {}
     ports:
@@ -275,7 +275,7 @@ services:
     command: /usr/sbin/mosquitto -c /mosquitto-no-auth.conf
     container_name: edgex-mqtt-broker
     hostname: edgex-mqtt-broker
-    image: eclipse-mosquitto:2.0.14
+    image: eclipse-mosquitto:2.0
     networks:
       edgex-network: {}
     ports:
@@ -328,7 +328,7 @@ services:
       KUIPER__BASIC__CONSOLELOG: "true"
       KUIPER__BASIC__RESTPORT: 59720
     hostname: edgex-kuiper
-    image: lfedge/ekuiper:1.4.4-alpine
+    image: lfedge/ekuiper:1.5-alpine
     networks:
       edgex-network: {}
     ports:

--- a/taf/docker-compose-taf-perf.yml
+++ b/taf/docker-compose-taf-perf.yml
@@ -252,7 +252,7 @@ services:
       STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-core-consul
-    image: consul:1.10.10
+    image: consul:1.12
     networks:
       edgex-network: {}
     ports:
@@ -371,7 +371,7 @@ services:
       STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-redis
-    image: redis:6.2.6-alpine
+    image: redis:6.2-alpine
     networks:
       edgex-network: {}
     ports:
@@ -544,7 +544,7 @@ services:
       STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-kong
-    image: kong:2.6.1
+    image: kong:2.8
     networks:
       edgex-network: {}
     ports:
@@ -600,7 +600,7 @@ services:
       STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-kong-db
-    image: postgres:13.5-alpine
+    image: postgres:13.7-alpine
     networks:
       edgex-network: {}
     ports:
@@ -681,7 +681,7 @@ services:
     command: /usr/sbin/mosquitto -c /mosquitto-no-auth.conf
     container_name: edgex-mqtt-broker
     hostname: edgex-mqtt-broker
-    image: eclipse-mosquitto:2.0.14
+    image: eclipse-mosquitto:2.0
     networks:
       edgex-network: {}
     ports:
@@ -844,7 +844,7 @@ services:
       STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-kuiper
-    image: lfedge/ekuiper:1.4.4-alpine
+    image: lfedge/ekuiper:1.5-alpine
     networks:
       edgex-network: {}
     ports:
@@ -1118,7 +1118,7 @@ services:
       VAULT_CONFIG_DIR: /vault/config
       VAULT_UI: "true"
     hostname: edgex-vault
-    image: vault:1.8.9
+    image: vault:1.10.3
     networks:
       edgex-network: {}
     ports:

--- a/taf/docker-compose-taf.yml
+++ b/taf/docker-compose-taf.yml
@@ -440,7 +440,7 @@ services:
       STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-core-consul
-    image: consul:1.10.10
+    image: consul:1.12
     networks:
       edgex-network: {}
     ports:
@@ -559,7 +559,7 @@ services:
       STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-redis
-    image: redis:6.2.6-alpine
+    image: redis:6.2-alpine
     networks:
       edgex-network: {}
     ports:
@@ -851,7 +851,7 @@ services:
       STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-kong
-    image: kong:2.6.1
+    image: kong:2.8
     networks:
       edgex-network: {}
     ports:
@@ -907,7 +907,7 @@ services:
       STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-kong-db
-    image: postgres:13.5-alpine
+    image: postgres:13.7-alpine
     networks:
       edgex-network: {}
     ports:
@@ -1001,7 +1001,7 @@ services:
     command: /usr/sbin/mosquitto -c /mosquitto-no-auth.conf
     container_name: edgex-mqtt-broker
     hostname: edgex-mqtt-broker
-    image: eclipse-mosquitto:2.0.14
+    image: eclipse-mosquitto:2.0
     networks:
       edgex-network: {}
     ports:
@@ -1164,7 +1164,7 @@ services:
       STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-kuiper
-    image: lfedge/ekuiper:1.4.4-alpine
+    image: lfedge/ekuiper:1.5-alpine
     networks:
       edgex-network: {}
     ports:
@@ -1505,7 +1505,7 @@ services:
       VAULT_CONFIG_DIR: /vault/config
       VAULT_UI: "true"
     hostname: edgex-vault
-    image: vault:1.8.9
+    image: vault:1.10.3
     networks:
       edgex-network: {}
     ports:


### PR DESCRIPTION
**Note:** 
- Redis 7 breaks the PubSub auth when in secure mode. Staying with 6.x for now.
- Postgres 14 breaks Kong (2.6 & 2.8) bootstrapping. Staying with 13.x for now.

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-compose/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?) **N/A**
  <link to docs PR>


## Testing Instructions
Run stack in secure mode
Verify all service bootstrap properly
Verify /ping via API Gateway