### PR TITLE
fix(TUI): use correct bash usage for selection arrays

### DIFF
--- a/compose-builder/tui-generator.sh
+++ b/compose-builder/tui-generator.sh
@@ -97,7 +97,7 @@ function additionalServiceOption() {
     do
         arglist+=("$index" "${additionalOptsDesc[$index]}" "OFF") # Nothing is selected by-default
     done
-    SELECTED_OTHERS+=$($WHIPTAIL --title "Additional Services" \
+    readarray -t SELECTED_OTHERS < <("$WHIPTAIL" --title "Additional Services" \
                 --notags --separate-output \
                 --ok-button Next \
                 --nocancel \
@@ -123,7 +123,7 @@ function appServiceOption() {
     do
         arglist+=("$index" "${appServiceDesc[$index]}" "OFF") # Nothing is selected by-default
     done
-    SELECTED_APPSERVICES+=$($WHIPTAIL --title "App Services" \
+    readarray -t SELECTED_APPSERVICES < <("$WHIPTAIL" --title "App Services" \
                 --ok-button Next \
                 --nocancel \
                 --notags --separate-output \
@@ -171,7 +171,7 @@ function devServiceOption() {
     do
         arglist+=("$index" "${deviceServiceDesc[$index]}" "OFF") # Nothing is selected by-default
     done
-    SELECTED_DEVSERVICES=$($WHIPTAIL --title "Device Services" \
+    readarray -t SELECTED_DEVSERVICES < <("$WHIPTAIL" --title "Device Services" \
                 --ok-button Next \
                 --nocancel \
                 --notags --separate-output \
@@ -196,7 +196,7 @@ function msgBusOption() {
     do
         arglist+=("$index" "${msgBusDesc[$index]}" "OFF") # Nothing is selected by-default
     done
-    SELECTED_BUS=$($WHIPTAIL --title "Message Bus Alternatives" \
+    readarray -t SELECTED_BUS < <("$WHIPTAIL" --title "Message Bus Alternatives" \
                 --ok-button Next \
                 --nocancel \
                 --notags --separate-output \


### PR DESCRIPTION
wrong usage of inserting selections via whiptail UI in bash
clubbed them into a single string with new-line character at
index 0. An optimal way was to use `readarray -t <VAR> < <..`
instead of `<VAR>+=`. This PR fixes the issue.
A potential benefit would be to make the TUI bash script more
extensible for selected individual service names
(e.g. using `for`/`case`) for future usage / tweaks.

Closes #248

Signed-off-by: Shantanoo 'Shan' Desai <shantanoo.desai@gmail.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-compose/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-compose/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>


## Testing Instructions
<!-- How can the reviewers test your change? -->
