### PR TITLE
feat: Add "up" command to run the generated docker compose file

### DIFF
--- a/compose-builder/Makefile
+++ b/compose-builder/Makefile
@@ -855,6 +855,9 @@ get-consul-acl-token:
 	ARCH=$(ARCH) \
 	sh ./get-consul-acl-token.sh
 
+up:
+	docker-compose -p edgex -f docker-compose.yml up -d
+
 down:
 	$(COMPOSE_DOWN)
 

--- a/compose-builder/README.md
+++ b/compose-builder/README.md
@@ -214,6 +214,13 @@ Options:
 Services:
     <names...>: Runs only services listed (and their dependent services) where 'name' matches a service name in one of the compose files used
 ```
+#### Up
+
+```
+up
+Start all Edgex services using the docker-compose.yml file resulting from last time "make gen" was run. Use this command when the docker-compose.yml file has been modified after generating it. This command Will result in error if the docker-compose.yml file doesn't exist.
+```
+
 #### Down
 
 ```    


### PR DESCRIPTION
Useful if the generated compose file has been modified and need to rerun with the `-p edgex` options that are used with `make run`.

Signed-off-by: Leonard Goodell <leonard.goodell@intel.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-compose/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-compose/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?) **N/A - README was updated**
  <link to docs PR>


## Testing Instructions
from compose builder do the following:

- remove old docker-compose.yml file if it exists
- Run `make up`
- Verify command resulted in File Not Found error
- Run `make gen no-secty ds-virtual`
- Run `make up`
- Verify service all started under the `edgex` stack
