### PR TITLE
feat: Add ui-dev and device-dev options

### DIFF
--- a/compose-builder/.env
+++ b/compose-builder/.env
@@ -19,9 +19,9 @@
  #
 
 RELEASE_FOLDER=../
-REPOSITORY=nexus3.edgexfoundry.org:10004
 CORE_EDGEX_REPOSITORY=nexus3.edgexfoundry.org:10004
 APP_SVC_REPOSITORY=nexus3.edgexfoundry.org:10004
+DEVICE_SVC_REPOSITORY=nexus3.edgexfoundry.org:10004
 UI_REPOSITORY=nexus3.edgexfoundry.org:10004
 CORE_EDGEX_VERSION=latest
 APP_SERVICE_CONFIG_VERSION=latest

--- a/compose-builder/Makefile
+++ b/compose-builder/Makefile
@@ -33,7 +33,7 @@ GEN_EXT_DIR=gen_ext_compose
 # Dashes at beginning & end of line ensure space before/after the first/last option on that line
 # and don't impact the option list
 define OPTIONS
- - arm64 no-secty dev app-dev delayed-start -
+ - arm64 no-secty dev app-dev device-dev ui-dev delayed-start -
  - zmq-bus mqtt-bus mqtt-broker -
  - taf-secty taf-no-secty taf-perf taf-perf-no-secty -
  - ds-onvif-camera  ds-usb-camera ds-bacnet ds-camera ds-grove ds-modbus ds-mqtt ds-rest ds-snmp ds-virtual ds-llrp ds-coap ds-gpio -
@@ -46,22 +46,37 @@ ARGS:=$(wordlist 2,$(words $(MAKECMDGOALS)),$(MAKECMDGOALS))
 $(eval $(ARGS):;@:)
 
 # Order of processing these arguments is important so the overrides in the 'add' compose files occur properly.
+
 ifeq (dev, $(filter dev,$(ARGS)))
 	export CORE_EDGEX_REPOSITORY=edgexfoundry
-	export DEV=-dev
-	# matches the way that edgex-go to versioning the docker images for `make docker`
-	export CORE_EDGEX_VERSION:="0.0.0"
-else
-	export DEV=
+	export CORE_EDGEX_VERSION=0.0.0-dev
+	export DEV=-dev # require for the gateways scripts since they look for this
 endif
 ifeq (app-dev, $(filter app-dev,$(ARGS)))
 	export APP_SVC_REPOSITORY=edgexfoundry
 	export APP_SVC_DEV=-dev
-	export APP_SERVICE_CONFIG_VERSION="0.0.0"
-else
-	export APP_SVC_DEV=
+	export APP_SERVICE_CONFIG_VERSION=0.0.0-dev
+	export APP_LLRP_VERSION=0.0.0-dev
 endif
-
+ifeq (device-dev, $(filter device-dev,$(ARGS)))
+	export DEVICE_SVC_REPOSITORY=edgexfoundry
+	export DEVICE_BACNET_VERSION=0.0.0-dev
+	export DEVICE_CAMERA_VERSION=0.0.0-dev
+	export DEVICE_MODBUS_VERSION=0.0.0-dev
+	export DEVICE_MQTT_VERSION=0.0.0-dev
+	export DEVICE_REST_VERSION=0.0.0-dev
+	export DEVICE_SNMP_VERSION=0.0.0-dev
+	export DEVICE_VIRTUAL_VERSION=0.0.0-dev
+	export DEVICE_LLRP_VERSION=0.0.0-dev
+	export DEVICE_COAP_VERSION=0.0.0-dev
+	export DEVICE_GPIO_VERSION=0.0.0-dev
+	export DEVICE_ONVIFCAM_VERSION=0.0.0-dev
+	export DEVICE_USBCAM_VERSION=0.0.0-dev
+endif
+ifeq (ui-dev, $(filter ui-dev,$(ARGS)))
+	export UI_REPOSITORY=edgexfoundry
+	export EDGEX_UI_VERSION=0.0.0-dev
+endif
 ifeq (arm64, $(filter arm64,$(ARGS)))
 	export ARCH=-arm64
 else
@@ -839,18 +854,12 @@ gen:
 	rm -rf ./$(GEN_EXT_DIR)
 
 get-token:
-	DEV=$(DEV) \
-	ARCH=$(ARCH) \
 	sh ./get-api-gateway-token.sh
 
 upload-tls-cert:
-	DEV=$(DEV) \
-	ARCH=$(ARCH) \
 	sh ./upload-api-gateway-cert.sh
 
 get-consul-acl-token:
-	DEV=$(DEV) \
-	ARCH=$(ARCH) \
 	sh ./get-consul-acl-token.sh
 
 up:

--- a/compose-builder/README.md
+++ b/compose-builder/README.md
@@ -180,11 +180,14 @@ Runs the EdgeX services as specified by:
 Options:
     no-secty:        Runs in Non-Secure Mode, otherwise runs in Secure Mode
     arm64:           Runs using ARM64 images
-    dev:             Runs using local dev built images from edgex-go repo's
-                     'make docker' which creates docker images tagged with '0.0.0-dev'
-    app-dev:         Runs using local dev built images from 
-                     app-service-configurable repo's
-                     'make docker' which creates docker images tagged with '0.0.0-dev'
+    dev:             Runs using local built images from edgex-go repo
+                     'make docker' creates local docker images tagged with '0.0.0-dev'
+    app-dev:         Runs using local built images from application service repos
+                     'make docker' creates local docker images tagged with '0.0.0-dev`
+    device-dev:      Runs using local built images from device service repos
+                     'make docker' creates local docker images tagged with '0.0.0-dev'
+    ui-dev:          Runs using local built images from edgex-ui-go repo
+                     'make docker' creates local docker image tagged with '0.0.0-dev'
     delayed-start:   Runs with delayed start services- 
                      spire related services and spiffe-token-provider service included
     ds-modbus:       Runs with device-modbus included
@@ -275,12 +278,14 @@ Options:
     no-secty:        Generates non-secure compose,
                      otherwise generates secure compose file
     arm64:           Generates compose file using ARM64 images
-    dev:             Generates compose file using local dev built images 
-                     from edgex-go repo's. 
-                     'make docker' which creates docker images tagged with '0.0.0-dev'
-    app-dev:         Generates compose file using local dev built images 
-                     from app-service-configurable repo's
-                     'make docker' which creates docker images tagged with '0.0.0-dev'
+    dev:             Generates using local built images from edgex-go repo
+                     'make docker' creates local docker images tagged with '0.0.0-dev'
+    app-dev:         Generates using local built images from application service repos
+                     'make docker' creates local docker images tagged with '0.0.0-dev`
+    device-dev:      Generates using local built images from device service repos
+                     'make docker' creates local docker images tagged with '0.0.0-dev'
+    ui-dev:          Generates using local built images from edgex-ui-go repo
+                     'make docker' creates local docker image tagged with '0.0.0-dev'
     delayed-start:   Generates compose file with delayed start services- spire 
                      related services and spiffe-token-provider service included
     ds-modbus:       Generates compose file with device-modbus included
@@ -323,7 +328,7 @@ Generates a Kong access token as specified by:
 Options:
     arm64:  Generates a Kong access token using ARM64 image
     dev:    Generates a Kong access token using local dev built docker image
-            'make docker', which creates docker images tagged with '0.0.0-dev'    
+            'make docker' creates local docker images tagged with '0.0.0-dev'    
 ```
 #### Upload-tls-cert
 
@@ -333,8 +338,8 @@ Upload a bring-your-own (BYO) TLS certificate to the Kong proxy server as specif
 Options:
     arm64:  Upload TLS certificate to the Kong server using ARM64 image
     dev:    Upload TLS certificate to the Kong server using local dev built docker image
-            'make docker', which creates docker images tagged with '0.0.0-dev'
-Environment Variables: 
+            'make docker' creates local docker images tagged with '0.0.0-dev'    
+    Environment Variables: 
     CERT_INPUT_FILE=<full_path_to_cert_file>: the full file name path to your own certificate file, this is required
     KEY_INPUT_FILE=<full_path_to_key_file>: the full file name path to your own key file, this is required
     EXTRA_SNIS="comma_separated_server_name_list_if_any": an extra server name indicator list in addition to localhost and kong, this is optional and can be omitted
@@ -343,12 +348,8 @@ Environment Variables:
 #### Get-consul-acl-token
 
 ```
-get-consul-acl-token [options]
-Retrieve the Consul ACL token as specified by:
-Options:
-    arm64:  Retrieves the Consul ACL token using ARM64 image
-    dev:    Retrieves the Consul ACL token using local dev built docker image
-            'make docker', which creates docker images tagged with '0.0.0-dev'
+get-consul-acl-token 
+Retrieves the Consul ACL token
 ```
 
 #### Compose
@@ -360,10 +361,14 @@ Generates the EdgeX compose file as specified by options and stores them in the 
 Options:
     no-secty:      Generates non-secure compose file, otherwise generates secure compose file
     arm64:         Generates compose file using ARM64 images
-    dev:           Generates compose file using local dev built images from edgex-go repo's
-                   'make docker' which creates docker images tagged with '0.0.0-dev'
-    app-dev:       Generates compose file using local dev built images from app-service-configurable repo's
-                   'make docker' which creates docker images tagged with '0.0.0-dev'
+    dev:           Generates using local built images from edgex-go repo
+                   'make docker' creates local docker images tagged with '0.0.0-dev'
+    app-dev:       Generates using local built images from application service repos
+                   'make docker' creates local docker images tagged with '0.0.0-dev`
+    device-dev:    Generates using local built images from device service repos
+                   'make docker' creates local docker images tagged with '0.0.0-dev'
+    ui-dev:        Generates using local built images from edgex-ui-go repo
+                   'make docker' creates local docker image tagged with '0.0.0-dev'
     delayed-start: Generates compose file with delayed start services- spire related services and
                    spiffe-token-provider service included
     ds-bacnet:     Generates compose file with device-bacnet included

--- a/compose-builder/add-app-rfid-llrp-inventory.yml
+++ b/compose-builder/add-app-rfid-llrp-inventory.yml
@@ -1,5 +1,5 @@
 # /*******************************************************************************
-#  * Copyright 2021 Intel Corporation.
+#  * Copyright 2022 Intel Corporation.
 #  *
 #  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 #  * in compliance with the License. You may obtain a copy of the License at

--- a/compose-builder/add-asc-external-mqtt-trigger.yml
+++ b/compose-builder/add-asc-external-mqtt-trigger.yml
@@ -17,7 +17,7 @@ version: '3.7'
 
 services:
   app-service-external-mqtt-trigger:
-    image: ${APP_SVC_REPOSITORY}/app-service-configurable${ARCH}:${APP_SERVICE_CONFIG_VERSION}${APP_SVC_DEV}
+    image: ${APP_SVC_REPOSITORY}/app-service-configurable${ARCH}:${APP_SERVICE_CONFIG_VERSION}
     ports:
       - 127.0.0.1:59706:59706/tcp
     container_name: edgex-app-external-mqtt-trigger

--- a/compose-builder/add-asc-http-export.yml
+++ b/compose-builder/add-asc-http-export.yml
@@ -17,7 +17,7 @@ version: '3.7'
 
 services:
   app-service-http-export:
-    image: ${APP_SVC_REPOSITORY}/app-service-configurable${ARCH}:${APP_SERVICE_CONFIG_VERSION}${APP_SVC_DEV}
+    image: ${APP_SVC_REPOSITORY}/app-service-configurable${ARCH}:${APP_SERVICE_CONFIG_VERSION}
     ports:
       - 127.0.0.1:59704:59704/tcp
     container_name: edgex-app-http-export

--- a/compose-builder/add-asc-metrics-influxdb.yml
+++ b/compose-builder/add-asc-metrics-influxdb.yml
@@ -17,7 +17,7 @@ version: '3.7'
 
 services:
   app-metrics-influxdb:
-    image: ${APP_SVC_REPOSITORY}/app-service-configurable${ARCH}:${APP_SERVICE_CONFIG_VERSION}${APP_SVC_DEV}
+    image: ${APP_SVC_REPOSITORY}/app-service-configurable${ARCH}:${APP_SERVICE_CONFIG_VERSION}
     ports:
       - 127.0.0.1:59707:59707/tcp
     container_name: edgex-app-metrics-influxdb

--- a/compose-builder/add-asc-mqtt-export.yml
+++ b/compose-builder/add-asc-mqtt-export.yml
@@ -17,7 +17,7 @@ version: '3.7'
 
 services:
   app-service-mqtt-export:
-    image: ${APP_SVC_REPOSITORY}/app-service-configurable${ARCH}:${APP_SERVICE_CONFIG_VERSION}${APP_SVC_DEV}
+    image: ${APP_SVC_REPOSITORY}/app-service-configurable${ARCH}:${APP_SERVICE_CONFIG_VERSION}
     ports:
       - 127.0.0.1:59703:59703/tcp
     container_name: edgex-app-mqtt-export

--- a/compose-builder/add-asc-sample.yml
+++ b/compose-builder/add-asc-sample.yml
@@ -17,7 +17,7 @@ version: '3.7'
 
 services:
   app-service-sample:
-    image: ${APP_SVC_REPOSITORY}/app-service-configurable${ARCH}:${APP_SERVICE_CONFIG_VERSION}${APP_SVC_DEV}
+    image: ${APP_SVC_REPOSITORY}/app-service-configurable${ARCH}:${APP_SERVICE_CONFIG_VERSION}
     ports:
       - 127.0.0.1:59700:59700/tcp
     container_name: edgex-app-sample

--- a/compose-builder/add-delayed-start-services.yml
+++ b/compose-builder/add-delayed-start-services.yml
@@ -22,7 +22,7 @@ volumes:
 
 services:
   security-spire-server:
-    image: ${CORE_EDGEX_REPOSITORY}/security-spire-server${ARCH}:${CORE_EDGEX_VERSION}${DEV}
+    image: ${CORE_EDGEX_REPOSITORY}/security-spire-server${ARCH}:${CORE_EDGEX_VERSION}
     entrypoint:
       - /edgex-init/ready_to_run_wait_install.sh
     command: docker-entrypoint.sh
@@ -53,7 +53,7 @@ services:
       - no-new-privileges:true
 
   security-spire-agent:
-    image: ${CORE_EDGEX_REPOSITORY}/security-spire-agent${ARCH}:${CORE_EDGEX_VERSION}${DEV}
+    image: ${CORE_EDGEX_REPOSITORY}/security-spire-agent${ARCH}:${CORE_EDGEX_VERSION}
     entrypoint:
       - /edgex-init/ready_to_run_wait_install.sh
     command: docker-entrypoint.sh
@@ -84,7 +84,7 @@ services:
       - no-new-privileges:true
 
   security-spire-config:
-    image: ${CORE_EDGEX_REPOSITORY}/security-spire-config${ARCH}:${CORE_EDGEX_VERSION}${DEV}
+    image: ${CORE_EDGEX_REPOSITORY}/security-spire-config${ARCH}:${CORE_EDGEX_VERSION}
     entrypoint:
       - /edgex-init/ready_to_run_wait_install.sh
     command: docker-entrypoint.sh
@@ -110,7 +110,7 @@ services:
       - no-new-privileges:true
 
   security-spiffe-token-provider:
-    image: ${CORE_EDGEX_REPOSITORY}/security-spiffe-token-provider${ARCH}:${CORE_EDGEX_VERSION}${DEV}
+    image: ${CORE_EDGEX_REPOSITORY}/security-spiffe-token-provider${ARCH}:${CORE_EDGEX_VERSION}
     entrypoint:
       - /edgex-init/ready_to_run_wait_install.sh
     command: /security-spiffe-token-provider -cp=consul.http://edgex-core-consul:8500 --registry --confdir=/res

--- a/compose-builder/add-device-bacnet.yml
+++ b/compose-builder/add-device-bacnet.yml
@@ -1,5 +1,5 @@
 # /*******************************************************************************
-#  * Copyright 2021 Intel Corporation.
+#  * Copyright 2022 Intel Corporation.
 #  *
 #  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 #  * in compliance with the License. You may obtain a copy of the License at
@@ -17,7 +17,7 @@ version: '3.7'
 
 services:
   device-bacnet:
-    image: ${REPOSITORY}/device-bacnet${ARCH}:${DEVICE_BACNET_VERSION}
+    image: ${DEVICE_SVC_REPOSITORY}/device-bacnet${ARCH}:${DEVICE_BACNET_VERSION}
     ports:
       - "127.0.0.1:59980:59980"
     container_name: edgex-device-bacnet

--- a/compose-builder/add-device-camera.yml
+++ b/compose-builder/add-device-camera.yml
@@ -1,5 +1,5 @@
 # /*******************************************************************************
-#  * Copyright 2021 Intel Corporation.
+#  * Copyright 2022 Intel Corporation.
 #  *
 #  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 #  * in compliance with the License. You may obtain a copy of the License at
@@ -17,7 +17,7 @@ version: '3.7'
 
 services:
   device-camera:
-    image: ${REPOSITORY}/device-camera${ARCH}:${DEVICE_CAMERA_VERSION}
+    image: ${DEVICE_SVC_REPOSITORY}/device-camera${ARCH}:${DEVICE_CAMERA_VERSION}
     ports:
       - "127.0.0.1:59985:59985"
     container_name: edgex-device-camera

--- a/compose-builder/add-device-coap.yml
+++ b/compose-builder/add-device-coap.yml
@@ -1,5 +1,5 @@
 # /*******************************************************************************
-#  * Copyright 2021 Intel Corporation.
+#  * Copyright 2022 Intel Corporation.
 #  *
 #  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 #  * in compliance with the License. You may obtain a copy of the License at
@@ -17,7 +17,7 @@ version: '3.7'
 
 services:
   device-coap:
-    image: ${REPOSITORY}/device-coap${ARCH}:${DEVICE_COAP_VERSION}
+    image: ${DEVICE_SVC_REPOSITORY}/device-coap${ARCH}:${DEVICE_COAP_VERSION}
     ports:
     - "127.0.0.1:59988:59988"
     container_name: edgex-device-coap

--- a/compose-builder/add-device-gpio.yml
+++ b/compose-builder/add-device-gpio.yml
@@ -1,5 +1,5 @@
 # /*******************************************************************************
-#  * Copyright 2021 Intel Corporation.
+#  * Copyright 2022 Intel Corporation.
 #  *
 #  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 #  * in compliance with the License. You may obtain a copy of the License at
@@ -17,7 +17,7 @@ version: '3.7'
 
 services:
   device-gpio:
-    image: ${REPOSITORY}/device-gpio${ARCH}:${DEVICE_GPIO_VERSION}
+    image: ${DEVICE_SVC_REPOSITORY}/device-gpio${ARCH}:${DEVICE_GPIO_VERSION}
     ports:
     - "127.0.0.1:59994:59994"
     container_name: edgex-device-gpio

--- a/compose-builder/add-device-grove.yml
+++ b/compose-builder/add-device-grove.yml
@@ -1,5 +1,5 @@
 # /*******************************************************************************
-#  * Copyright 2021 Intel Corporation.
+#  * Copyright 2022 Intel Corporation.
 #  *
 #  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 #  * in compliance with the License. You may obtain a copy of the License at
@@ -17,7 +17,7 @@ version: '3.7'
 
 services:
   device-grove:
-    image: ${REPOSITORY}/device-grove${ARCH}:${DEVICE_GROVE_VERSION}
+    image: ${DEVICE_SVC_REPOSITORY}/device-grove${ARCH}:${DEVICE_GROVE_VERSION}
     ports:
       - "127.0.0.1:59992:59992"
     container_name: edgex-device-grove

--- a/compose-builder/add-device-modbus.yml
+++ b/compose-builder/add-device-modbus.yml
@@ -1,5 +1,5 @@
 # /*******************************************************************************
-#  * Copyright 2021 Intel Corporation.
+#  * Copyright 2022 Intel Corporation.
 #  *
 #  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 #  * in compliance with the License. You may obtain a copy of the License at
@@ -17,7 +17,7 @@ version: '3.7'
 
 services:
   device-modbus:
-    image: ${REPOSITORY}/device-modbus${ARCH}:${DEVICE_MODBUS_VERSION}
+    image: ${DEVICE_SVC_REPOSITORY}/device-modbus${ARCH}:${DEVICE_MODBUS_VERSION}
     ports:
       - "127.0.0.1:59901:59901"
     container_name: edgex-device-modbus

--- a/compose-builder/add-device-mqtt.yml
+++ b/compose-builder/add-device-mqtt.yml
@@ -1,5 +1,5 @@
 # /*******************************************************************************
-#  * Copyright 2021 Intel Corporation.
+#  * Copyright 2022 Intel Corporation.
 #  *
 #  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 #  * in compliance with the License. You may obtain a copy of the License at
@@ -17,7 +17,7 @@ version: '3.7'
 
 services:
   device-mqtt:
-    image: ${REPOSITORY}/device-mqtt${ARCH}:${DEVICE_MQTT_VERSION}
+    image: ${DEVICE_SVC_REPOSITORY}/device-mqtt${ARCH}:${DEVICE_MQTT_VERSION}
     ports:
       - "127.0.0.1:59982:59982"
     container_name: edgex-device-mqtt

--- a/compose-builder/add-device-onvif-camera.yml
+++ b/compose-builder/add-device-onvif-camera.yml
@@ -18,7 +18,7 @@ version: '3.7'
 
 services:
   device-onvif-camera:
-    image: ${REPOSITORY}/device-onvif-camera${ARCH}:${DEVICE_ONVIFCAM_VERSION}
+    image: ${DEVICE_SVC_REPOSITORY}/device-onvif-camera${ARCH}:${DEVICE_ONVIFCAM_VERSION}
     ports:
       - "127.0.0.1:59984:59984"
     container_name: edgex-device-onvif-camera

--- a/compose-builder/add-device-rest.yml
+++ b/compose-builder/add-device-rest.yml
@@ -1,5 +1,5 @@
 # /*******************************************************************************
-#  * Copyright 2021 Intel Corporation.
+#  * Copyright 2022 Intel Corporation.
 #  *
 #  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 #  * in compliance with the License. You may obtain a copy of the License at
@@ -17,7 +17,7 @@ version: '3.7'
 
 services:
   device-rest:
-    image: ${REPOSITORY}/device-rest${ARCH}:${DEVICE_REST_VERSION}
+    image: ${DEVICE_SVC_REPOSITORY}/device-rest${ARCH}:${DEVICE_REST_VERSION}
     ports:
       - "127.0.0.1:59986:59986"
     container_name: edgex-device-rest

--- a/compose-builder/add-device-rfid-llrp.yml
+++ b/compose-builder/add-device-rfid-llrp.yml
@@ -1,5 +1,5 @@
 # /*******************************************************************************
-#  * Copyright 2021 Intel Corporation.
+#  * Copyright 2022 Intel Corporation.
 #  *
 #  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 #  * in compliance with the License. You may obtain a copy of the License at
@@ -17,7 +17,7 @@ version: '3.7'
 
 services:
   device-rfid-llrp:
-    image: ${REPOSITORY}/device-rfid-llrp${ARCH}:${DEVICE_LLRP_VERSION}
+    image: ${DEVICE_SVC_REPOSITORY}/device-rfid-llrp${ARCH}:${DEVICE_LLRP_VERSION}
     ports:
     - "127.0.0.1:59989:59989"
     container_name: edgex-device-rfid-llrp

--- a/compose-builder/add-device-snmp.yml
+++ b/compose-builder/add-device-snmp.yml
@@ -1,5 +1,5 @@
 # /*******************************************************************************
-#  * Copyright 2021 Intel Corporation.
+#  * Copyright 2022 Intel Corporation.
 #  *
 #  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 #  * in compliance with the License. You may obtain a copy of the License at
@@ -17,7 +17,7 @@ version: '3.7'
 
 services:
   device-snmp:
-    image: ${REPOSITORY}/device-snmp${ARCH}:${DEVICE_SNMP_VERSION}
+    image: ${DEVICE_SVC_REPOSITORY}/device-snmp${ARCH}:${DEVICE_SNMP_VERSION}
     ports:
       - "127.0.0.1:59993:59993"
     container_name: edgex-device-snmp

--- a/compose-builder/add-device-usb-camera.yml
+++ b/compose-builder/add-device-usb-camera.yml
@@ -18,7 +18,7 @@ version: '3.7'
 
 services:
   device-usb-camera:
-    image: ${REPOSITORY}/device-usb-camera${ARCH}:${DEVICE_USBCAM_VERSION}
+    image: ${DEVICE_SVC_REPOSITORY}/device-usb-camera${ARCH}:${DEVICE_USBCAM_VERSION}
     ports:
       - "127.0.0.1:59983:59983"
       - "127.0.0.1:8554:8554/tcp"

--- a/compose-builder/add-device-virtual.yml
+++ b/compose-builder/add-device-virtual.yml
@@ -1,5 +1,5 @@
 # /*******************************************************************************
-#  * Copyright 2021 Intel Corporation.
+#  * Copyright 2022 Intel Corporation.
 #  *
 #  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 #  * in compliance with the License. You may obtain a copy of the License at
@@ -17,7 +17,7 @@ version: '3.7'
 
 services:
   device-virtual:
-    image: ${REPOSITORY}/device-virtual${ARCH}:${DEVICE_VIRTUAL_VERSION}
+    image: ${DEVICE_SVC_REPOSITORY}/device-virtual${ARCH}:${DEVICE_VIRTUAL_VERSION}
     ports:
     - "127.0.0.1:59900:59900"
     container_name: edgex-device-virtual

--- a/compose-builder/add-security.yml
+++ b/compose-builder/add-security.yml
@@ -29,7 +29,7 @@ volumes:
 
 services:
   security-bootstrapper:
-    image: ${CORE_EDGEX_REPOSITORY}/security-bootstrapper${ARCH}:${CORE_EDGEX_VERSION}${DEV}
+    image: ${CORE_EDGEX_REPOSITORY}/security-bootstrapper${ARCH}:${CORE_EDGEX_VERSION}
     user: "root:root" # Must run as root
     container_name: edgex-security-bootstrapper
     hostname: edgex-security-bootstrapper
@@ -67,7 +67,7 @@ services:
       - secretstore-setup
 
   secretstore-setup:
-    image: ${CORE_EDGEX_REPOSITORY}/security-secretstore-setup${ARCH}:${CORE_EDGEX_VERSION}${DEV}
+    image: ${CORE_EDGEX_REPOSITORY}/security-secretstore-setup${ARCH}:${CORE_EDGEX_VERSION}
     user: "root:root" # must run as root
     container_name: edgex-security-secretstore-setup
     hostname: edgex-security-secretstore-setup
@@ -233,7 +233,7 @@ services:
       - no-new-privileges:true
 
   proxy-setup:
-    image: ${CORE_EDGEX_REPOSITORY}/security-proxy-setup${ARCH}:${CORE_EDGEX_VERSION}${DEV}
+    image: ${CORE_EDGEX_REPOSITORY}/security-proxy-setup${ARCH}:${CORE_EDGEX_VERSION}
     user: "${EDGEX_USER}:${EDGEX_GROUP}"
     container_name: edgex-security-proxy-setup
     hostname: edgex-security-proxy-setup

--- a/compose-builder/add-taf-app-services.yml
+++ b/compose-builder/add-taf-app-services.yml
@@ -17,7 +17,7 @@ version: '3.7'
 
 services:
   app-service-functional-tests:
-    image: ${APP_SVC_REPOSITORY}/app-service-configurable${ARCH}:${APP_SERVICE_CONFIG_VERSION}${APP_SVC_DEV}
+    image: ${APP_SVC_REPOSITORY}/app-service-configurable${ARCH}:${APP_SERVICE_CONFIG_VERSION}
     ports:
       - 59705:59705/tcp
     container_name: app-functional-tests
@@ -39,7 +39,7 @@ services:
     user: "${EDGEX_USER}:${EDGEX_GROUP}"
 
   scalability-test-mqtt-export:
-    image: ${APP_SVC_REPOSITORY}/app-service-configurable${ARCH}:${APP_SERVICE_CONFIG_VERSION}${APP_SVC_DEV}
+    image: ${APP_SVC_REPOSITORY}/app-service-configurable${ARCH}:${APP_SERVICE_CONFIG_VERSION}
     ports:
       - "59710:59703" #Exposing as different port to avoid conflict with other MQTT export instance
     container_name: edgex-scalability-test-mqtt-export

--- a/compose-builder/docker-compose-base.yml
+++ b/compose-builder/docker-compose-base.yml
@@ -1,6 +1,6 @@
 # /*******************************************************************************
 #  * Copyright 2020 Redis Labs Inc.
-#  * Copyright 2021 Intel Corporation.
+#  * Copyright 2022 Intel Corporation.
 #  *
 #  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 #  * in compliance with the License. You may obtain a copy of the License at
@@ -65,7 +65,7 @@ services:
       - no-new-privileges:true
 
   system:
-    image: ${CORE_EDGEX_REPOSITORY}/sys-mgmt-agent${ARCH}:${CORE_EDGEX_VERSION}${DEV}
+    image: ${CORE_EDGEX_REPOSITORY}/sys-mgmt-agent${ARCH}:${CORE_EDGEX_VERSION}
     user: "root:root" # must run as root to allow binding to docker socket.
     ports:
       - "127.0.0.1:58890:58890"
@@ -95,7 +95,7 @@ services:
       - label:disable # needed for CentOS to provide docker access
 
   notifications:
-    image: ${CORE_EDGEX_REPOSITORY}/support-notifications${ARCH}:${CORE_EDGEX_VERSION}${DEV}
+    image: ${CORE_EDGEX_REPOSITORY}/support-notifications${ARCH}:${CORE_EDGEX_VERSION}
     user: "${EDGEX_USER}:${EDGEX_GROUP}"
     ports:
       - "127.0.0.1:59860:59860"
@@ -116,7 +116,7 @@ services:
       - no-new-privileges:true
 
   metadata:
-    image: ${CORE_EDGEX_REPOSITORY}/core-metadata${ARCH}:${CORE_EDGEX_VERSION}${DEV}
+    image: ${CORE_EDGEX_REPOSITORY}/core-metadata${ARCH}:${CORE_EDGEX_VERSION}
     user: "${EDGEX_USER}:${EDGEX_GROUP}"
     ports:
       - "127.0.0.1:59881:59881"
@@ -139,7 +139,7 @@ services:
       - no-new-privileges:true
 
   data:
-    image: ${CORE_EDGEX_REPOSITORY}/core-data${ARCH}:${CORE_EDGEX_VERSION}${DEV}
+    image: ${CORE_EDGEX_REPOSITORY}/core-data${ARCH}:${CORE_EDGEX_VERSION}
     user: "${EDGEX_USER}:${EDGEX_GROUP}"
     ports:
       - "127.0.0.1:59880:59880"
@@ -162,7 +162,7 @@ services:
       - no-new-privileges:true
 
   command:
-    image: ${CORE_EDGEX_REPOSITORY}/core-command${ARCH}:${CORE_EDGEX_VERSION}${DEV}
+    image: ${CORE_EDGEX_REPOSITORY}/core-command${ARCH}:${CORE_EDGEX_VERSION}
     user: "${EDGEX_USER}:${EDGEX_GROUP}"
     ports:
       - "127.0.0.1:59882:59882"
@@ -184,7 +184,7 @@ services:
       - no-new-privileges:true
 
   scheduler:
-    image: ${CORE_EDGEX_REPOSITORY}/support-scheduler${ARCH}:${CORE_EDGEX_VERSION}${DEV}
+    image: ${CORE_EDGEX_REPOSITORY}/support-scheduler${ARCH}:${CORE_EDGEX_VERSION}
     user: "${EDGEX_USER}:${EDGEX_GROUP}"
     ports:
       - "127.0.0.1:59861:59861"
@@ -207,7 +207,7 @@ services:
       - no-new-privileges:true
 
   app-service-rules:
-    image: ${APP_SVC_REPOSITORY}/app-service-configurable${ARCH}:${APP_SERVICE_CONFIG_VERSION}${APP_SVC_DEV}
+    image: ${APP_SVC_REPOSITORY}/app-service-configurable${ARCH}:${APP_SERVICE_CONFIG_VERSION}
     user: "${EDGEX_USER}:${EDGEX_GROUP}"
     ports:
       - "127.0.0.1:59701:59701"

--- a/compose-builder/get-api-gateway-token.sh
+++ b/compose-builder/get-api-gateway-token.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 # /*******************************************************************************
-#  * Copyright 2021 Intel Corporation.
+#  * Copyright 2022 Intel Corporation.
 #  *
 #  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 #  * in compliance with the License. You may obtain a copy of the License at
@@ -19,9 +19,9 @@
 # versions are loaded from .env file
 . ./.env
 
-if [ "$DEV" = "-dev" ]; then
-  CORE_EDGEX_REPOSITORY=edgexfoundry
-  CORE_EDGEX_VERSION=0.0.0
+if [ $DEV = "-dev" ]; then
+  export CORE_EDGEX_REPOSITORY=edgexfoundry
+  export CORE_EDGEX_VERSION=0.0.0-dev
 fi
 
 # Init key dir
@@ -41,12 +41,12 @@ JWT_VOLUME=/tmp/edgex/secrets/security-proxy-setup
 ID=`uuidgen`
 
 docker run --rm -it -e KONGURL_SERVER=edgex-kong -e "ID=${ID}" -e "JWT_FILE=${JWT_FILE}" --network edgex_edgex-network --entrypoint "" -v ${GW_KEY_DIR}:/keys -v ${JWT_VOLUME}:${JWT_VOLUME} \
-       ${CORE_EDGEX_REPOSITORY}/security-proxy-setup${ARCH}:${CORE_EDGEX_VERSION}${DEV} \
+       ${CORE_EDGEX_REPOSITORY}/security-proxy-setup${ARCH}:${CORE_EDGEX_VERSION} \
         /bin/sh -c 'JWT=`cat ${JWT_FILE}`; /edgex/secrets-config proxy adduser --token-type jwt --id ${ID} --algorithm ES256  --public_key /keys/gateway.pub \
               --user gateway --group gateway --jwt ${JWT} > /dev/null'
 
 docker run --rm -it -e KONGURL_SERVER=edgex-kong -e "ID=${ID}" --network edgex_edgex-network --entrypoint "" -v ${GW_KEY_DIR}:/keys \
-       ${CORE_EDGEX_REPOSITORY}/security-proxy-setup${ARCH}:${CORE_EDGEX_VERSION}${DEV} \
+       ${CORE_EDGEX_REPOSITORY}/security-proxy-setup${ARCH}:${CORE_EDGEX_VERSION} \
        /bin/sh -c '/edgex/secrets-config proxy jwt --algorithm ES256 --id ${ID} --private_key /keys/gateway.key'
 
 # Clean Up

--- a/compose-builder/get-consul-acl-token.sh
+++ b/compose-builder/get-consul-acl-token.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 # /*******************************************************************************
-#  * Copyright 2021 Intel Corporation.
+#  * Copyright 2022 Intel Corporation.
 #  *
 #  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 #  * in compliance with the License. You may obtain a copy of the License at
@@ -13,16 +13,8 @@
 #  * the License.
 #  *******************************************************************************/
 
-# DEV and ARCH are set in environment prior to calling script
-# example: DEV=-dev ARCH=-arm64 ./get-consul-acl-token.sh
-
 # versions are loaded from .env file
 . ./.env
-
-if [ "$DEV" = "-dev" ]; then
-  CORE_EDGEX_REPOSITORY=edgexfoundry
-  CORE_EDGEX_VERSION=0.0.0
-fi
 
 docker exec -it edgex-core-consul /bin/sh -c \
   'cat "$STAGEGATE_REGISTRY_ACL_MANAGEMENTTOKENPATH" | jq -r '.SecretID' '

--- a/compose-builder/upload-api-gateway-cert.sh
+++ b/compose-builder/upload-api-gateway-cert.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 # /*******************************************************************************
-#  * Copyright 2021 Intel Corporation.
+#  * Copyright 2022 Intel Corporation.
 #  *
 #  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 #  * in compliance with the License. You may obtain a copy of the License at
@@ -29,9 +29,9 @@ usage()
 # versions are loaded from .env file
 . ./.env
 
-if [ "$DEV" = "-dev" ]; then
-  CORE_EDGEX_REPOSITORY=edgexfoundry
-  CORE_EDGEX_VERSION=0.0.0
+if [ $DEV = "-dev" ]; then
+  export CORE_EDGEX_REPOSITORY=edgexfoundry
+  export CORE_EDGEX_VERSION=0.0.0-dev
 fi
 
 # required input sanity checks
@@ -57,7 +57,7 @@ KEY_FILE_NAME=$(basename ${KEY_INPUT_FILE})
 
 echo "Uploading Kong TLS certificate with certificate file: ${CERT_FILE_NAME}, key file: ${KEY_FILE_NAME}, extra server name list: [${EXTRA_SNIS}]"
 docker run --rm -it -e KONGURL_SERVER=edgex-kong --network edgex_edgex-network --entrypoint "" -v ${PWD}/${STAGING}:/${STAGING} \
-       ${CORE_EDGEX_REPOSITORY}/security-proxy-setup${ARCH}:${CORE_EDGEX_VERSION}${DEV} \
+       ${CORE_EDGEX_REPOSITORY}/security-proxy-setup${ARCH}:${CORE_EDGEX_VERSION} \
         /edgex/secrets-config proxy tls --incert /${STAGING}/${CERT_FILE_NAME} \
         --inkey /${STAGING}/${KEY_FILE_NAME} \
         --snis "${EXTRA_SNIS}"


### PR DESCRIPTION
Also cleaned up use of DEV variable

closes #197

Signed-off-by: Leonard Goodell <leonard.goodell@intel.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-compose/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-compose/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?) **N/A**
  <link to docs PR>


## Testing Instructions
With this branch..
Run `make build` from compose builder.
Verify none of the generated compose file(TAF included) changed.
Build local docker images for edgex-go, UI, ASC and Device Virtual
run `make run ds-virtual asc-http asc-mqtt asc-sample dev app-dev device-dev ui-dev`
Verify all edgex services running are local `0.0.0-dev` versions
Verify all services are running properly
run `make get-token`
Verify token returned works in API Gateway
run `make get-consul-acl-token'
Verify token returned works in Consul

