### PR TITLE
feat: Add optional support to use compose V2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,14 @@ $(eval $(ARGS):;@:)
 
 OPTIONS:=" arm64 no-secty app-sample " # Must have spaces around words for `filter-out` function to work properly
 
+# Current default is to use stand alone docker-compose.
+# Since compose V2 with the new "docker compose" command in the docker CLI has been released
+# we are supporting both versions. In EdgeX 3.0 we'll just support compose V2.
+DOCKER_COMPOSE=docker-compose
+ifeq (, $(shell which docker-compose))
+	DOCKER_COMPOSE=docker compose
+endif
+
 ifeq (arm64, $(filter arm64,$(ARGS)))
 	ARM64=-arm64
 	ARM64_OPTION=arm64
@@ -38,7 +46,7 @@ endif
 SERVICES:=$(filter-out $(OPTIONS),$(ARGS))
 
 define COMPOSE_DOWN
-	docker-compose -p edgex -f docker-compose.yml -f docker-compose-with-app-sample.yml down $1
+	${DOCKER_COMPOSE} -p edgex -f docker-compose.yml -f docker-compose-with-app-sample.yml down $1
 endef
 
 # Define additional phony targets for all options to enable support for tab-completion in shell
@@ -46,16 +54,16 @@ endef
 .PHONY: $(OPTIONS)
 
 portainer:
-	docker-compose -p portainer -f docker-compose-portainer.yml up -d
+	${DOCKER_COMPOSE} -p portainer -f docker-compose-portainer.yml up -d
 
 portainer-down:
-	docker-compose -p portainer -f docker-compose-portainer.yml down
+	${DOCKER_COMPOSE} -p portainer -f docker-compose-portainer.yml down
 
 pull:
-	docker-compose -f docker-compose${NO_SECURITY}${ARM64}.yml pull ${SERVICES}
+	${DOCKER_COMPOSE} -f docker-compose${NO_SECURITY}${ARM64}.yml pull ${SERVICES}
 
 run:
-	docker-compose -p edgex -f docker-compose${NO_SECURITY}${APP_SAMPLE}${ARM64}.yml up -d ${SERVICES}
+	${DOCKER_COMPOSE} -p edgex -f docker-compose${NO_SECURITY}${APP_SAMPLE}${ARM64}.yml up -d ${SERVICES}
 
 down:
 	$(COMPOSE_DOWN)

--- a/README.md
+++ b/README.md
@@ -12,6 +12,12 @@ This `branch` contains the `pre-release` docker compose files that pull and run 
 
 These `pre-release` docker compose files are generated from the multiple source compose files located in the `compose-builder` folder. See [README](compose-builder/README.md) there for details on regenerating these files after making changes to the source files. 
 
+
+
+### Compose Tool
+
+The Makefile in this folder expects `docker-compose` tool or the new Compose V2 plug-in for the Docker CLI. The `docker-compose` tool will be used if it is found in the `path`, otherwise it will try the `docker compose` CLI command.
+
 ### Compose Files
 
 This folder contains the following compose files:

--- a/compose-builder/Makefile
+++ b/compose-builder/Makefile
@@ -23,6 +23,16 @@
 include .env
 include common-security.env
 
+# Current default is to use stand alone docker-compose.
+# Since compose V2 with the new "docker compose" command in the docker CLI has been released
+# we are supporting both versions. In EdgeX 3.0 we'll just support compose V2.
+DOCKER_COMPOSE=docker-compose
+GEN_COMMAND=config
+ ifeq (, $(shell which docker-compose))
+	 DOCKER_COMPOSE=docker compose
+	 GEN_COMMAND=convert
+ endif
+
 COMPOSE_FILES:=-f docker-compose-base.yml
 TOKEN_LIST=
 KNOWN_SECRETS_LIST=redisdb[app-rules-engine]
@@ -849,7 +859,7 @@ export SPIFFE_TRUSTDOMAIN
 export SPIFFE_ENDPOINTSOCKET
 
 define COMPOSE_DOWN
-	docker-compose -p edgex \
+	${DOCKER_COMPOSE} -p edgex \
 		-f docker-compose-base.yml \
 		-f add-device-bacnet.yml \
 		-f add-device-camera.yml \
@@ -928,14 +938,14 @@ taf-compose-perf: gen
 	cat gen-header docker-compose.yml > $(RELEASE_FOLDER)/taf/docker-compose-taf-perf$(NO_SECURITY)$(BUS)$(ARCH).yml
 
 run: gen
-	docker-compose -p edgex up -d $(SERVICES)
+	${DOCKER_COMPOSE}  -p edgex up -d $(SERVICES)
 
 pull: gen
-	docker-compose pull $(SERVICES)
+	${DOCKER_COMPOSE}  pull $(SERVICES)
 
 gen:
 	$(GROVE_CHECK) \
-	docker-compose -p edgex $(COMPOSE_FILES) config > docker-compose.yml
+	${DOCKER_COMPOSE}  -p edgex $(COMPOSE_FILES) ${GEN_COMMAND} > docker-compose.yml
 	rm -rf ./$(GEN_EXT_DIR)
 
 get-token:
@@ -948,7 +958,7 @@ get-consul-acl-token:
 	sh ./get-consul-acl-token.sh
 
 up:
-	docker-compose -p edgex -f docker-compose.yml up -d
+	${DOCKER_COMPOSE}  -p edgex -f docker-compose.yml up -d
 
 down:
 	$(COMPOSE_DOWN)

--- a/compose-builder/README.md
+++ b/compose-builder/README.md
@@ -9,6 +9,10 @@ This folder contains the `Compose Builder` which is made up of **source** compos
 >
 > **You must use *docker-compose version 1.27.2* due to bug in later versions that generates the `depends_on` sections incorrectly for compose version 3.x**
 
+### Compose Tool
+
+The Makefile in this folder expects `docker-compose` tool or the new Compose V2 plug-in for the Docker CLI. The `docker-compose` tool will be used if it is found in the `path`, otherwise it will try the `docker compose` CLI command.
+
 ### Generate next release compose files
 
 Do the following to generate the compose files for next release such as `jakarta` 

--- a/compose-builder/README.md
+++ b/compose-builder/README.md
@@ -2,12 +2,14 @@
 
 This folder contains the `Compose Builder` which is made up of **source** compose, **environment** files and a **makefile** for building the single file docker composes files. The `master` branch builds the `pre-release`  compose files which are placed in the top level of this repository. 
 
-> **Note to Developers**: 
+### **Note to Developers**: 
 > *Once you have edited and tested your changes to these source files you **MUST** regenerate the standard `pre-release` compose files using the `make build` command.*
 >
 > Any new options added to the `make gen` and `make run` commands must to also be added to the new` tui-generator.sh` script
 >
-> **You must use *docker-compose version 1.27.2* due to bug in later versions that generates the `depends_on` sections incorrectly for compose version 3.x**
+> **You must use *docker-compose version 1.27.2* due to bug in later versions that generates the `depends_on` sections incorrectly for compose version 3.x**.
+>
+> **You MUST NOT use the new `compose v2` as it generates compose files that are not compatible with `docker-compose` which is used by TAF**
 
 ### Compose Tool
 


### PR DESCRIPTION
closes #272

Signed-off-by: Leonard Goodell <leonard.goodell@intel.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-compose/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-compose/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [x] I have opened a PR for the related docs change (if not, why?) 
  README's have been updated


## Testing Instructions
From clean system (EdgeX not running with all EdgeX containers, volumes and networks removed)
With `docker-compose` installed and `compose V2` installed
### From **top level** folder
- run `make run no-secty` 
- verify `docker-compose` was used and all services run fine
- Rename `docker-compose` so it isn't found
- run `make run no-secty` 
- verify `docker compose` was used and all services run fine
- run `make clean`
- verify `docker compose` was used
- Verify all service, containers, volumes and networks are gone.
- Restore `docker-compose` so it is found
### From **compose-builder** folder
- run `make run no-secty` 
- verify `docker-compose` with `config` command where used and all services run fine
- Rename `docker-compose` so it isn't found
- run `make run no-secty` 
- verify `docker compose` with `convert` were used and all services run fine
- run `make clean`
- verify `docker compose` was used
- Verify all service, containers, volumes and networks are gone.
- Restore `docker-compose` so it is found


