### PR TITLE
fix(security): eKuiper env variables and volumes for secure mqtt

### DIFF
--- a/compose-builder/add-secure-mqtt-messagebus.yml
+++ b/compose-builder/add-secure-mqtt-messagebus.yml
@@ -15,10 +15,17 @@
 
 version: '3.7'
 
+volumes:
+  kuiper-sources:
+  kuiper-connections:
+
 services:
   secretstore-setup:
     environment:
       SECUREMESSAGEBUS_TYPE: mqtt
+    volumes:
+      - kuiper-sources:/tmp/kuiper:z
+      - kuiper-connections:/tmp/kuiper-connections:z
   
   data:
     environment:
@@ -49,4 +56,17 @@ services:
     environment:
       TRIGGER_EDGEXMESSAGEBUS_OPTIONAL_AUTHMODE: usernamepassword
       TRIGGER_EDGEXMESSAGEBUS_OPTIONAL_SECRETNAME: message-bus
-      
+  
+  rulesengine:
+    entrypoint: [ "/edgex-init/kuiper_wait_install.sh" ]
+    env_file:
+      - common-sec-stage-gate.env
+    volumes:
+      - kuiper-sources:/kuiper/etc/sources:z
+      - kuiper-connections:/kuiper/etc/connections:z
+      - edgex-init:/edgex-init:ro,z
+    depends_on:
+      - security-bootstrapper
+      - secretstore-setup
+      - database
+  

--- a/taf/docker-compose-taf-mqtt-bus-arm64.yml
+++ b/taf/docker-compose-taf-mqtt-bus-arm64.yml
@@ -1258,7 +1258,13 @@ services:
     depends_on:
     - database
     - mqtt-broker
+    - secretstore-setup
+    - security-bootstrapper
+    entrypoint:
+    - /edgex-init/kuiper_wait_install.sh
     environment:
+      API_GATEWAY_HOST: edgex-kong
+      API_GATEWAY_STATUS_PORT: '8100'
       CONNECTION__EDGEX__MQTTMSGBUS__OPTIONAL__CLIENTID: kuiper-rules-engine
       CONNECTION__EDGEX__MQTTMSGBUS__OPTIONAL__KEEPALIVE: 500
       CONNECTION__EDGEX__MQTTMSGBUS__PORT: 1883
@@ -1278,6 +1284,22 @@ services:
       EDGEX__DEFAULT__TYPE: mqtt
       KUIPER__BASIC__CONSOLELOG: "true"
       KUIPER__BASIC__RESTPORT: 59720
+      PROXY_SETUP_HOST: edgex-security-proxy-setup
+      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_DATABASE_HOST: edgex-redis
+      STAGEGATE_DATABASE_PORT: '6379'
+      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_KONGDB_HOST: edgex-kong-db
+      STAGEGATE_KONGDB_PORT: '5432'
+      STAGEGATE_KONGDB_READYPORT: '54325'
+      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_REGISTRY_HOST: edgex-core-consul
+      STAGEGATE_REGISTRY_PORT: '8500'
+      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-kuiper
     image: lfedge/ekuiper:1.6-alpine
     networks:
@@ -1290,7 +1312,10 @@ services:
     - no-new-privileges:true
     user: kuiper:kuiper
     volumes:
+    - edgex-init:/edgex-init:ro,z
     - kuiper-data:/kuiper/data:z
+    - kuiper-connections:/kuiper/etc/connections:z
+    - kuiper-sources:/kuiper/etc/sources:z
   scalability-test-mqtt-export:
     command: /app-service-configurable -cp=consul.http://edgex-core-consul:8500 --registry
       --confdir=/res
@@ -1491,6 +1516,8 @@ services:
     - edgex-init:/edgex-init:ro,z
     - /tmp/edgex/secrets:/tmp/edgex/secrets:z
     - kong:/tmp/kong:z
+    - kuiper-sources:/tmp/kuiper:z
+    - kuiper-connections:/tmp/kuiper-connections:z
     - vault-config:/vault/config:z
   security-bootstrapper:
     container_name: edgex-security-bootstrapper
@@ -1893,7 +1920,9 @@ volumes:
   db-data: {}
   edgex-init: {}
   kong: {}
+  kuiper-connections: {}
   kuiper-data: {}
+  kuiper-sources: {}
   mqtt: {}
   postgres-config: {}
   postgres-data: {}

--- a/taf/docker-compose-taf-mqtt-bus.yml
+++ b/taf/docker-compose-taf-mqtt-bus.yml
@@ -1258,7 +1258,13 @@ services:
     depends_on:
     - database
     - mqtt-broker
+    - secretstore-setup
+    - security-bootstrapper
+    entrypoint:
+    - /edgex-init/kuiper_wait_install.sh
     environment:
+      API_GATEWAY_HOST: edgex-kong
+      API_GATEWAY_STATUS_PORT: '8100'
       CONNECTION__EDGEX__MQTTMSGBUS__OPTIONAL__CLIENTID: kuiper-rules-engine
       CONNECTION__EDGEX__MQTTMSGBUS__OPTIONAL__KEEPALIVE: 500
       CONNECTION__EDGEX__MQTTMSGBUS__PORT: 1883
@@ -1278,6 +1284,22 @@ services:
       EDGEX__DEFAULT__TYPE: mqtt
       KUIPER__BASIC__CONSOLELOG: "true"
       KUIPER__BASIC__RESTPORT: 59720
+      PROXY_SETUP_HOST: edgex-security-proxy-setup
+      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_DATABASE_HOST: edgex-redis
+      STAGEGATE_DATABASE_PORT: '6379'
+      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_KONGDB_HOST: edgex-kong-db
+      STAGEGATE_KONGDB_PORT: '5432'
+      STAGEGATE_KONGDB_READYPORT: '54325'
+      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_REGISTRY_HOST: edgex-core-consul
+      STAGEGATE_REGISTRY_PORT: '8500'
+      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-kuiper
     image: lfedge/ekuiper:1.6-alpine
     networks:
@@ -1290,7 +1312,10 @@ services:
     - no-new-privileges:true
     user: kuiper:kuiper
     volumes:
+    - edgex-init:/edgex-init:ro,z
     - kuiper-data:/kuiper/data:z
+    - kuiper-connections:/kuiper/etc/connections:z
+    - kuiper-sources:/kuiper/etc/sources:z
   scalability-test-mqtt-export:
     command: /app-service-configurable -cp=consul.http://edgex-core-consul:8500 --registry
       --confdir=/res
@@ -1491,6 +1516,8 @@ services:
     - edgex-init:/edgex-init:ro,z
     - /tmp/edgex/secrets:/tmp/edgex/secrets:z
     - kong:/tmp/kong:z
+    - kuiper-sources:/tmp/kuiper:z
+    - kuiper-connections:/tmp/kuiper-connections:z
     - vault-config:/vault/config:z
   security-bootstrapper:
     container_name: edgex-security-bootstrapper
@@ -1893,7 +1920,9 @@ volumes:
   db-data: {}
   edgex-init: {}
   kong: {}
+  kuiper-connections: {}
   kuiper-data: {}
+  kuiper-sources: {}
   mqtt: {}
   postgres-config: {}
   postgres-data: {}


### PR DESCRIPTION
Closes:#285
Signed-off-by: intel <joshua.silverio@intel.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-compose/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-compose/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>


## Testing Instructions
<!-- How can the reviewers test your change? -->
Can gen compose file 
- make gen dev ds-virtual mqtt-bus
- make up
- check kuiper container and app rules engine container to see the mqtt-bus connection success and flowing data
- shell into kuiper container and cat /kuiper/etc/sources/edgex.yaml to confirm usr/pass of mqtt-bus is configured correctly
