### PR TITLE
fix: Correct get-api-gateway-token.sh script for when DEV env is empty

### DIFF
--- a/compose-builder/get-api-gateway-token.sh
+++ b/compose-builder/get-api-gateway-token.sh
@@ -19,7 +19,7 @@
 # versions are loaded from .env file
 . ./.env
 
-if [ $DEV = "-dev" ]; then
+if [ "$DEV" = "-dev" ]; then
   export CORE_EDGEX_REPOSITORY=edgexfoundry
   export CORE_EDGEX_VERSION=0.0.0-dev
 fi


### PR DESCRIPTION
Signed-off-by: Leonard Goodell <leonard.goodell@intel.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-compose/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-compose/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?) **N/A**
  <link to docs PR>


## Testing Instructions
Run secure stack
Run `make get-token`
Verify no error message, just token displayed.
