### PR TITLE
refactor!: Change to only support compose V2 to generate and run compose files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,13 +24,8 @@ $(eval $(ARGS):;@:)
 
 OPTIONS:=" arm64 no-secty app-sample " # Must have spaces around words for `filter-out` function to work properly
 
-# Current default is to use stand alone docker-compose.
-# Since compose V2 with the new "docker compose" command in the docker CLI has been released
-# we are supporting both versions. In EdgeX 3.0 we'll just support compose V2.
-DOCKER_COMPOSE=docker-compose
-ifeq (, $(shell which docker-compose))
-	DOCKER_COMPOSE=docker compose
-endif
+# This tool now only supports compose V2, aka "docker compose" as it has replaced to old docker-compose tool.
+DOCKER_COMPOSE=docker compose
 
 ifeq (arm64, $(filter arm64,$(ARGS)))
 	ARM64=-arm64

--- a/README.md
+++ b/README.md
@@ -16,7 +16,9 @@ These `pre-release` docker compose files are generated from the multiple source 
 
 ### Compose Tool
 
-The Makefile in this folder expects `docker-compose` tool or the new Compose V2 plug-in for the Docker CLI. The `docker-compose` tool will be used if it is found in the `path`, otherwise it will try the `docker compose` CLI command.
+The Makefile in this folder expects the `docker compose` CLI command.
+The old stand-alone `docker-compose` tool is no longer supported.
+See https://docs.docker.com/compose/install/ for installation details for the latest `docker compose` CLI command.
 
 ### Compose Files
 

--- a/compose-builder/Makefile
+++ b/compose-builder/Makefile
@@ -39,7 +39,7 @@ BUS=
 # and don't impact the option list
 define OPTIONS
  - arm64 no-secty dev app-dev device-dev ui-dev delayed-start -
- - zmq-bus nats-bus mqtt-bus mqtt-broker -
+ - zmq-bus nats-bus mqtt-bus mqtt-broker mqtt-verbose -
  - taf-secty taf-no-secty taf-perf taf-perf-no-secty -
  - ds-onvif-camera  ds-usb-camera ds-bacnet ds-modbus ds-mqtt ds-rest ds-snmp ds-virtual ds-llrp ds-coap ds-gpio -
  - asc-http asc-mqtt asc-sample asc-metrics as-llrp asc-ex-mqtt -
@@ -92,6 +92,12 @@ ifeq (arm64, $(filter arm64,$(ARGS)))
 	export ARCH=-arm64
 else
 	export ARCH=
+endif
+
+ifeq (mqtt-verbose, $(filter mqtt-verbose,$(ARGS)))
+	export MQTT_VERBOSE=-v
+else
+    export MQTT_VERBOSE=
 endif
 
 # Add Device Services
@@ -983,10 +989,10 @@ build-taf:
 	make taf-compose taf-no-secty
 	make taf-compose taf-secty arm64
 	make taf-compose taf-no-secty arm64
-	make taf-compose taf-secty mqtt-bus
-	make taf-compose taf-no-secty mqtt-bus
-	make taf-compose taf-secty mqtt-bus arm64
-	make taf-compose taf-no-secty mqtt-bus arm64
+	make taf-compose taf-secty mqtt-bus mqtt-verbose
+	make taf-compose taf-no-secty mqtt-bus mqtt-verbose
+	make taf-compose taf-secty mqtt-bus mqtt-verbose arm64
+	make taf-compose taf-no-secty mqtt-bus mqtt-verbose arm64
 	make taf-compose-perf taf-perf
 	make taf-compose-perf taf-perf-no-secty
 	make taf-compose-perf taf-perf arm64
@@ -1008,6 +1014,7 @@ pull: gen
 	${DOCKER_COMPOSE}  pull $(SERVICES)
 
 gen:
+	echo MQTT_VERBOSE=${MQTT_VERBOSE}
 	${DOCKER_COMPOSE}  -p edgex $(COMPOSE_FILES) ${GEN_COMMAND} > docker-compose.yml
 	rm -rf ./$(GEN_EXT_DIR)
 

--- a/compose-builder/Makefile
+++ b/compose-builder/Makefile
@@ -23,15 +23,9 @@
 include .env
 include common-security.env
 
-# Current default is to use stand alone docker-compose.
-# Since compose V2 with the new "docker compose" command in the docker CLI has been released
-# we are supporting both versions. In EdgeX 3.0 we'll just support compose V2.
-DOCKER_COMPOSE=docker-compose
-GEN_COMMAND=config
- ifeq (, $(shell which docker-compose))
-	 DOCKER_COMPOSE=docker compose
-	 GEN_COMMAND=convert
- endif
+# This tool now only supports compose V2, aka "docker compose" as it has replaced to old docker-compose tool.
+DOCKER_COMPOSE=docker compose
+GEN_COMMAND=convert
 
 COMPOSE_FILES:=-f docker-compose-base.yml
 TOKEN_LIST=

--- a/compose-builder/README.md
+++ b/compose-builder/README.md
@@ -5,36 +5,36 @@ This folder contains the `Compose Builder` which is made up of **source** compos
 ### **Note to Developers**: 
 > *Once you have edited and tested your changes to these source files you **MUST** regenerate the standard `pre-release` compose files using the `make build` command.*
 >
-> Any new options added to the `make gen` and `make run` commands must to also be added to the new` tui-generator.sh` script
+> Any options added or removed to/from the `make gen` and `make run` commands must to also be added/removed to/from the new` tui-generator.sh` script
 >
-> **You must use *docker-compose version 1.27.2* due to bug in later versions that generates the `depends_on` sections incorrectly for compose version 3.x**.
->
-> **You MUST NOT use the new `compose v2` as it generates compose files that are not compatible with `docker-compose` which is used by TAF**
 
-### Compose Tool
+### Compose CLI Command
 
-The Makefile in this folder expects `docker-compose` tool or the new Compose V2 plug-in for the Docker CLI. The `docker-compose` tool will be used if it is found in the `path`, otherwise it will try the `docker compose` CLI command.
+The Makefile in this folder expects the `docker compose` CLI command.
+The old stand-alone `docker-compose` tool is no longer supported.
+See https://docs.docker.com/compose/install/ for installation details for the latest `docker compose` CLI command.
 
 ### Generate next release compose files
 
-Do the following to generate the compose files for next release such as `jakarta` 
+Do the following to generate the compose files for next release such as `minnesota`
 
-1. Create the new `release` branch from this branch, i.e create the `jakarta` branch
+1. Create the new `release` branch from this branch, i.e create the `minnesota` branch (**Now done by DevOps release processes**)
 2. Checkout a new working branch from the new `release` branch
-3. Update the `REPOSITORY`, `CORE_EDGEX_REPOSITORY`, `APP_SVC_REPOSITORY`, and `versions` contained in the `.env` file appropriately for the new release
-4. Run `make build` 
-5. Update the two READMEs to be specific to the new `release`
-6. Commit changes, open PR and merge PR
-7. TAG the new release branch, i.e. `2.1.0`
-8. Update EdgeX documentation to refer to the new release branch.
+3. Update the `REPOSITORY`, `CORE_EDGEX_REPOSITORY` and `APP_SVC_REPOSITORY` (**Now done by DevOps release processes**)
+4. Update `versions` contained in the `.env` file appropriately for the new release
+5. Run `make build` 
+6. Update the two READMEs to be specific to the new `release`
+7. Commit changes, open PR and merge PR
+8. TAG the new release branch (**Now done by DevOps release processes**)
+9. Update EdgeX documentation to refer to the new release branch. (**Now done by DevOps release processes**)
 
 ### Generate dot release compose files
 
-1. Checkout a new working branch from the target `release` branch for the dot release, i.e the `ireland` branch
+1. Checkout a new working branch from the target `release` branch for the dot release, i.e the `jakarta` branch
 2. Update the and `versions` contained in the `.env` file appropriately for the dot release
 3. Run `make build` 
 4. Commit changes, open PR and merge PR
-5. TAG the release branch for the dot release, i.e. `2.0.1`
+5. TAG the release branch for the dot release (**Now done by DevOps release processes**)
 
 ### Multiple Compose files approach
 

--- a/compose-builder/README.md
+++ b/compose-builder/README.md
@@ -239,6 +239,7 @@ Options:
     mqtt-broker:     Runs with a MQTT Broker service included
     mqtt-bus:        Runs with services configure for MQTT Message Bus
                      The MQTT Broker service is also included.
+    mqtt-verbose     Enables MQTT Broker verbose logging.
     nats-bus:        Runs with services configure for NATS Message Bus
                      The NATS Server service is also included.
     zmq-bus:         Runs with services configure for ZMQ Message Bus
@@ -337,6 +338,7 @@ Options:
     mqtt-broker:     Generates compose file with a MQTT Broker service included
     mqtt-bus:        Generates compose file with services configured for MQTT Message Bus
                      The MQTT Broker service is also included.
+    mqtt-verbose     Enables MQTT Broker verbose logging.
     nats-bus:        Generates compose file with services configured for NAT Message Bus
                      The NATS Server service is also included.
     zmq-bus:         Generates compose file with services configured for ZMQ Message Bus
@@ -418,6 +420,7 @@ Options:
     mqtt-broker:   Generates compose file with a MQTT Broker service included
     mqtt-bus:      Generates compose file with services configure for MQTT Message Bus
                    The MQTT Broker service is also included.
+    mqtt-verbose   Enables MQTT Broker verbose logging.
     nats-bus:      Generates compose file with services configure for NATS Message Bus
                    The NATS Server service is also included.
     zmq-bus:       Generates compose file with services configured for ZMQ Message Bus

--- a/compose-builder/add-mqtt-broker.yml
+++ b/compose-builder/add-mqtt-broker.yml
@@ -18,7 +18,7 @@ version: '3.7'
 services:
   mqtt-broker:
     image: eclipse-mosquitto:${MOSQUITTO_VERSION}
-    command: "/usr/sbin/mosquitto -c /mosquitto-no-auth.conf -v"
+    command: "/usr/sbin/mosquitto ${MQTT_VERBOSE} -c /mosquitto-no-auth.conf"
     ports:
       - "127.0.0.1:1883:1883"
     container_name: edgex-mqtt-broker

--- a/compose-builder/add-mqtt-broker.yml
+++ b/compose-builder/add-mqtt-broker.yml
@@ -18,7 +18,7 @@ version: '3.7'
 services:
   mqtt-broker:
     image: eclipse-mosquitto:${MOSQUITTO_VERSION}
-    command: "/usr/sbin/mosquitto -c /mosquitto-no-auth.conf"
+    command: "/usr/sbin/mosquitto -c /mosquitto-no-auth.conf -v"
     ports:
       - "127.0.0.1:1883:1883"
     container_name: edgex-mqtt-broker

--- a/compose-builder/add-secure-mqtt-broker.yml
+++ b/compose-builder/add-secure-mqtt-broker.yml
@@ -20,7 +20,7 @@ volumes:
 
 services:
   mqtt-broker:
-    command: /usr/sbin/mosquitto -c /mosquitto/config/mosquitto.conf
+    command: "/usr/sbin/mosquitto ${MQTT_VERBOSE} -c /mosquitto/config/mosquitto.conf"
     entrypoint: ["/edgex-init/messagebus_wait_install.sh"]
     env_file:
       - common-security.env
@@ -28,7 +28,7 @@ services:
     environment:
       BROKER_TYPE: mosquitto
       CONF_DIR: /edgex-init/bootstrap-mosquitto/res
-      ENTRYPOINT: /docker-entrypoint.sh /usr/sbin/mosquitto -c /mosquitto/config/mosquitto.conf
+      ENTRYPOINT: /docker-entrypoint.sh /usr/sbin/mosquitto ${MQTT_VERBOSE} -c  /mosquitto/config/mosquitto.conf
     volumes:
     - mqtt:/mosquitto:z
     - edgex-init:/edgex-init:ro,z

--- a/compose-builder/add-taf-device-services-mods.yml
+++ b/compose-builder/add-taf-device-services-mods.yml
@@ -14,18 +14,16 @@
 #  *******************************************************************************/
 
 version: '3.7'
-volumes:
-  PROFILE_VOLUME_PLACE_HOLDER:
 
 services:
   device-virtual:
     command: "-cp=consul.http://edgex-core-consul:8500 --registry --configDir=CONFIG_DIR_PLACE_HOLDER"
     volumes:
-      - PROFILE_VOLUME_PLACE_HOLDER:CONFIG_DIR_PLACE_HOLDER:z
+      - /PROFILE_VOLUME_PLACE_HOLDER:CONFIG_DIR_PLACE_HOLDER:z
 
   device-modbus:
     command: "-cp=consul.http://edgex-core-consul:8500 --registry --configDir=CONFIG_DIR_PLACE_HOLDER"
     volumes:
-      - PROFILE_VOLUME_PLACE_HOLDER:CONFIG_DIR_PLACE_HOLDER:z
+      - /PROFILE_VOLUME_PLACE_HOLDER:CONFIG_DIR_PLACE_HOLDER:z
     depends_on:
       - modbus-simulator

--- a/compose-builder/tui-generator.sh
+++ b/compose-builder/tui-generator.sh
@@ -45,6 +45,7 @@ COLUMNS=$(tput cols)
 declare -A additionalOptsDesc=(
     [modbus-sim]="Include ModBus Simulator"
     [mqtt-broker]="Include MQTT Broker"
+    [mqtt-verbose]="Enable MQTT Broker verbose logging"
 )
 
 ## App Service Descriptions

--- a/docker-compose-arm64.yml
+++ b/docker-compose-arm64.yml
@@ -24,22 +24,26 @@
 #
 # From the compose-builder folder use `make build` to regenerate all standard compose files variations
 #
-networks:
-  edgex-network:
-    driver: bridge
+name: edgex
 services:
   app-service-rules:
-    command: /app-service-configurable -cp=consul.http://edgex-core-consul:8500 --registry
+    command:
+    - /app-service-configurable
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
     container_name: edgex-app-rules-engine
     depends_on:
-    - consul
-    - data
-    - security-bootstrapper
+      consul:
+        condition: service_started
+      data:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/ready_to_run_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
@@ -52,54 +56,78 @@ services:
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SERVICE_HOST: edgex-app-rules-engine
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-app-rules-engine
     image: nexus3.edgexfoundry.org:10004/app-service-configurable-arm64:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59701:59701/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59701
+      published: "59701"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - /tmp/edgex/secrets/app-rules-engine:/tmp/edgex/secrets/app-rules-engine:ro,z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/app-rules-engine
+      target: /tmp/edgex/secrets/app-rules-engine
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   command:
-    command: /core-command -cp=consul.http://edgex-core-consul:8500 --registry
+    command:
+    - /core-command
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
     container_name: edgex-core-command
     depends_on:
-    - consul
-    - database
-    - metadata
-    - secretstore-setup
-    - security-bootstrapper
+      consul:
+        condition: service_started
+      database:
+        condition: service_started
+      metadata:
+        condition: service_started
+      secretstore-setup:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/ready_to_run_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
@@ -112,110 +140,173 @@ services:
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SERVICE_HOST: edgex-core-command
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-core-command
     image: nexus3.edgexfoundry.org:10004/core-command-arm64:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59882:59882/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59882
+      published: "59882"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - /tmp/edgex/secrets/core-command:/tmp/edgex/secrets/core-command:ro,z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/core-command
+      target: /tmp/edgex/secrets/core-command
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   consul:
-    command: agent -ui -bootstrap -server -client 0.0.0.0
+    command:
+    - agent
+    - -ui
+    - -bootstrap
+    - -server
+    - -client
+    - 0.0.0.0
     container_name: edgex-core-consul
     depends_on:
-    - security-bootstrapper
-    - vault
+      security-bootstrapper:
+        condition: service_started
+      vault:
+        condition: service_started
     entrypoint:
     - /edgex-init/consul_wait_install.sh
     environment:
-      ADD_REGISTRY_ACL_ROLES: ''
+      ADD_REGISTRY_ACL_ROLES: ""
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
-      EDGEX_GROUP: '2001'
+      API_GATEWAY_STATUS_PORT: "8100"
+      EDGEX_GROUP: "2001"
       EDGEX_SECURITY_SECRET_STORE: "true"
-      EDGEX_USER: '2002'
+      EDGEX_USER: "2002"
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_ACL_BOOTSTRAPTOKENPATH: /tmp/edgex/secrets/consul-acl-token/bootstrap_token.json
       STAGEGATE_REGISTRY_ACL_MANAGEMENTTOKENPATH: /tmp/edgex/secrets/consul-acl-token/mgmt_token.json
       STAGEGATE_REGISTRY_ACL_SENTINELFILEPATH: /consul/config/consul_acl_done
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-core-consul
     image: consul:1.13
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:8500:8500/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 8500
+      published: "8500"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: root:root
     volumes:
-    - consul-config:/consul/config:z
-    - consul-data:/consul/data:z
-    - edgex-init:/edgex-init:ro,z
-    - consul-acl-token:/tmp/edgex/secrets/consul-acl-token:z
-    - /tmp/edgex/secrets/edgex-consul:/tmp/edgex/secrets/edgex-consul:ro,z
+    - type: volume
+      source: consul-config
+      target: /consul/config
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: consul-data
+      target: /consul/data
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: consul-acl-token
+      target: /tmp/edgex/secrets/consul-acl-token
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/edgex-consul
+      target: /tmp/edgex/secrets/edgex-consul
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   data:
-    command: /core-data -cp=consul.http://edgex-core-consul:8500 --registry
+    command:
+    - /core-data
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
     container_name: edgex-core-data
     depends_on:
-    - consul
-    - database
-    - metadata
-    - secretstore-setup
-    - security-bootstrapper
+      consul:
+        condition: service_started
+      database:
+        condition: service_started
+      metadata:
+        condition: service_started
+      secretstore-setup:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/ready_to_run_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
@@ -227,52 +318,74 @@ services:
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SECRETSTORE_TOKENFILE: /tmp/edgex/secrets/core-data/secrets-token.json
       SERVICE_HOST: edgex-core-data
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-core-data
     image: nexus3.edgexfoundry.org:10004/core-data-arm64:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:5563:5563/tcp
-    - 127.0.0.1:59880:59880/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 5563
+      published: "5563"
+      protocol: tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59880
+      published: "59880"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - /tmp/edgex/secrets/core-data:/tmp/edgex/secrets/core-data:ro,z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/core-data
+      target: /tmp/edgex/secrets/core-data
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   database:
     container_name: edgex-redis
     depends_on:
-    - secretstore-setup
-    - security-bootstrapper
+      secretstore-setup:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/redis_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
@@ -285,31 +398,35 @@ services:
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-redis
     image: redis:7.0-alpine
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:6379:6379/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 6379
+      published: "6379"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
@@ -318,23 +435,52 @@ services:
     - /run
     user: root:root
     volumes:
-    - db-data:/data:z
-    - edgex-init:/edgex-init:ro,z
-    - redis-config:/run/redis/conf:z
-    - /tmp/edgex/secrets/security-bootstrapper-redis:/tmp/edgex/secrets/security-bootstrapper-redis:ro,z
+    - type: volume
+      source: db-data
+      target: /data
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: redis-config
+      target: /run/redis/conf
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/security-bootstrapper-redis
+      target: /tmp/edgex/secrets/security-bootstrapper-redis
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   device-rest:
-    command: /device-rest -cp=consul.http://edgex-core-consul:8500 --registry
+    command:
+    - /device-rest
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
     container_name: edgex-device-rest
     depends_on:
-    - consul
-    - data
-    - metadata
-    - security-bootstrapper
+      consul:
+        condition: service_started
+      data:
+        condition: service_started
+      metadata:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/ready_to_run_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
@@ -346,53 +492,76 @@ services:
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SERVICE_HOST: edgex-device-rest
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-device-rest
     image: nexus3.edgexfoundry.org:10004/device-rest-arm64:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59986:59986/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59986
+      published: "59986"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - /tmp/edgex/secrets/device-rest:/tmp/edgex/secrets/device-rest:ro,z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/device-rest
+      target: /tmp/edgex/secrets/device-rest
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   device-virtual:
-    command: /device-virtual -cp=consul.http://edgex-core-consul:8500 --registry
+    command:
+    - /device-virtual
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
     container_name: edgex-device-virtual
     depends_on:
-    - consul
-    - data
-    - metadata
-    - security-bootstrapper
+      consul:
+        condition: service_started
+      data:
+        condition: service_started
+      metadata:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/ready_to_run_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
@@ -404,57 +573,75 @@ services:
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SERVICE_HOST: edgex-device-virtual
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-device-virtual
     image: nexus3.edgexfoundry.org:10004/device-virtual-arm64:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59900:59900/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59900
+      published: "59900"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - /tmp/edgex/secrets/device-virtual:/tmp/edgex/secrets/device-virtual:ro,z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/device-virtual
+      target: /tmp/edgex/secrets/device-virtual
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   kong:
     container_name: edgex-kong
     depends_on:
-    - kong-db
-    - security-bootstrapper
+      kong-db:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/kong_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       KONG_ADMIN_ACCESS_LOG: /dev/stdout
       KONG_ADMIN_ERROR_LOG: /dev/stderr
       KONG_ADMIN_LISTEN: 127.0.0.1:8001, 127.0.0.1:8444 ssl
       KONG_DATABASE: postgres
       KONG_DNS_ORDER: LAST,A,CNAME
-      KONG_DNS_VALID_TTL: '1'
-      KONG_NGINX_WORKER_PROCESSES: '1'
+      KONG_DNS_VALID_TTL: "1"
+      KONG_NGINX_WORKER_PROCESSES: "1"
       KONG_PG_HOST: edgex-kong-db
       KONG_PG_PASSWORD_FILE: /tmp/postgres-config/.pgpassword
       KONG_PROXY_ACCESS_LOG: /dev/stdout
@@ -463,28 +650,38 @@ services:
       KONG_STATUS_LISTEN: 0.0.0.0:8100
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-kong
     image: kong:2.8
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 8000:8000/tcp
-    - 127.0.0.1:8100:8100/tcp
-    - 8443:8443/tcp
+    - mode: ingress
+      target: 8000
+      published: "8000"
+      protocol: tcp
+    - mode: ingress
+      target: 8443
+      published: "8443"
+      protocol: tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 8100
+      published: "8100"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
@@ -495,50 +692,77 @@ services:
     tty: true
     user: kong:nogroup
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - /tmp/edgex/secrets/security-proxy-setup:/tmp/edgex/secrets/security-proxy-setup:ro,z
-    - postgres-config:/tmp/postgres-config:z
-    - kong:/usr/local/kong:z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: postgres-config
+      target: /tmp/postgres-config
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: kong
+      target: /usr/local/kong
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/security-proxy-setup
+      target: /tmp/edgex/secrets/security-proxy-setup
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   kong-db:
     container_name: edgex-kong-db
     depends_on:
-    - security-bootstrapper
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/postgres_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       EDGEX_SECURITY_SECRET_STORE: "true"
       POSTGRES_DB: kong
       POSTGRES_PASSWORD_FILE: /tmp/postgres-config/.pgpassword
       POSTGRES_USER: kong
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-kong-db
     image: postgres:13.8-alpine
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:5432:5432/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 5432
+      published: "5432"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
@@ -549,23 +773,47 @@ services:
     - /run
     user: root:root
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - postgres-config:/tmp/postgres-config:z
-    - postgres-data:/var/lib/postgresql/data:z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: postgres-data
+      target: /var/lib/postgresql/data
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: postgres-config
+      target: /tmp/postgres-config
+      bind:
+        selinux: z
+      volume: {}
   metadata:
-    command: /core-metadata -cp=consul.http://edgex-core-consul:8500 --registry
+    command:
+    - /core-metadata
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
     container_name: edgex-core-metadata
     depends_on:
-    - consul
-    - database
-    - notifications
-    - secretstore-setup
-    - security-bootstrapper
+      consul:
+        condition: service_started
+      database:
+        condition: service_started
+      notifications:
+        condition: service_started
+      secretstore-setup:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/ready_to_run_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
@@ -578,53 +826,76 @@ services:
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SERVICE_HOST: edgex-core-metadata
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-core-metadata
     image: nexus3.edgexfoundry.org:10004/core-metadata-arm64:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59881:59881/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59881
+      published: "59881"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - /tmp/edgex/secrets/core-metadata:/tmp/edgex/secrets/core-metadata:ro,z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/core-metadata
+      target: /tmp/edgex/secrets/core-metadata
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   notifications:
-    command: /support-notifications -cp=consul.http://edgex-core-consul:8500 --registry
+    command:
+    - /support-notifications
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
     container_name: edgex-support-notifications
     depends_on:
-    - consul
-    - database
-    - secretstore-setup
-    - security-bootstrapper
+      consul:
+        condition: service_started
+      database:
+        condition: service_started
+      secretstore-setup:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/ready_to_run_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
@@ -636,52 +907,71 @@ services:
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SERVICE_HOST: edgex-support-notifications
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-support-notifications
     image: nexus3.edgexfoundry.org:10004/support-notifications-arm64:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59860:59860/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59860
+      published: "59860"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - /tmp/edgex/secrets/support-notifications:/tmp/edgex/secrets/support-notifications:ro,z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/support-notifications
+      target: /tmp/edgex/secrets/support-notifications
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   proxy-setup:
     container_name: edgex-security-proxy-setup
     depends_on:
-    - kong
-    - secretstore-setup
-    - security-bootstrapper
+      kong:
+        condition: service_started
+      secretstore-setup:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/proxy_setup_wait_install.sh
     environment:
-      ADD_PROXY_ROUTE: ''
+      ADD_PROXY_ROUTE: ""
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       EDGEX_SECURITY_SECRET_STORE: "true"
       KONGURL_SERVER: edgex-kong
       PROXY_SETUP_HOST: edgex-security-proxy-setup
@@ -695,104 +985,157 @@ services:
       ROUTES_SUPPORT_SCHEDULER_HOST: edgex-support-scheduler
       ROUTES_SYS_MGMT_AGENT_HOST: edgex-sys-mgmt-agent
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-security-proxy-setup
     image: nexus3.edgexfoundry.org:10004/security-proxy-setup-arm64:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     read_only: true
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - consul-acl-token:/tmp/edgex/secrets/consul-acl-token:ro,z
-    - /tmp/edgex/secrets/security-proxy-setup:/tmp/edgex/secrets/security-proxy-setup:ro,z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/security-proxy-setup
+      target: /tmp/edgex/secrets/security-proxy-setup
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
+    - type: volume
+      source: consul-acl-token
+      target: /tmp/edgex/secrets/consul-acl-token
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
   rulesengine:
     container_name: edgex-kuiper
     depends_on:
-    - database
-    - secretstore-setup
-    - security-bootstrapper
+      database:
+        condition: service_started
+      secretstore-setup:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/kuiper_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
-      CONNECTION__EDGEX__REDISMSGBUS__PORT: 6379
+      API_GATEWAY_STATUS_PORT: "8100"
+      CONNECTION__EDGEX__REDISMSGBUS__PORT: "6379"
       CONNECTION__EDGEX__REDISMSGBUS__PROTOCOL: redis
       CONNECTION__EDGEX__REDISMSGBUS__SERVER: edgex-redis
       CONNECTION__EDGEX__REDISMSGBUS__TYPE: redis
-      EDGEX__DEFAULT__PORT: 6379
+      EDGEX__DEFAULT__PORT: "6379"
       EDGEX__DEFAULT__PROTOCOL: redis
       EDGEX__DEFAULT__SERVER: edgex-redis
       EDGEX__DEFAULT__TOPIC: rules-events
       EDGEX__DEFAULT__TYPE: redis
       KUIPER__BASIC__CONSOLELOG: "true"
-      KUIPER__BASIC__RESTPORT: 59720
+      KUIPER__BASIC__RESTPORT: "59720"
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-kuiper
     image: lfedge/ekuiper:1.7-alpine
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59720:59720/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59720
+      published: "59720"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: kuiper:kuiper
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - kuiper-data:/kuiper/data:z
-    - kuiper-connections:/kuiper/etc/connections:z
-    - kuiper-sources:/kuiper/etc/sources:z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: kuiper-data
+      target: /kuiper/data
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: kuiper-connections
+      target: /kuiper/etc/connections
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: kuiper-sources
+      target: /kuiper/etc/sources
+      bind:
+        selinux: z
+      volume: {}
   scheduler:
-    command: /support-scheduler -cp=consul.http://edgex-core-consul:8500 --registry
+    command:
+    - /support-scheduler
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
     container_name: edgex-support-scheduler
     depends_on:
-    - consul
-    - database
-    - secretstore-setup
-    - security-bootstrapper
+      consul:
+        condition: service_started
+      database:
+        condition: service_started
+      secretstore-setup:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/ready_to_run_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
@@ -806,79 +1149,97 @@ services:
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SERVICE_HOST: edgex-support-scheduler
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-support-scheduler
     image: nexus3.edgexfoundry.org:10004/support-scheduler-arm64:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59861:59861/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59861
+      published: "59861"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - /tmp/edgex/secrets/support-scheduler:/tmp/edgex/secrets/support-scheduler:ro,z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/support-scheduler
+      target: /tmp/edgex/secrets/support-scheduler
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   secretstore-setup:
     container_name: edgex-security-secretstore-setup
     depends_on:
-    - security-bootstrapper
-    - vault
+      security-bootstrapper:
+        condition: service_started
+      vault:
+        condition: service_started
     environment:
       ADD_KNOWN_SECRETS: redisdb[app-rules-engine],redisdb[device-rest],message-bus[device-rest],redisdb[device-virtual],message-bus[device-virtual]
-      ADD_SECRETSTORE_TOKENS: ''
+      ADD_SECRETSTORE_TOKENS: ""
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
-      EDGEX_GROUP: '2001'
+      API_GATEWAY_STATUS_PORT: "8100"
+      EDGEX_GROUP: "2001"
       EDGEX_SECURITY_SECRET_STORE: "true"
-      EDGEX_USER: '2002'
+      EDGEX_USER: "2002"
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SECUREMESSAGEBUS_TYPE: redis
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-security-secretstore-setup
     image: nexus3.edgexfoundry.org:10004/security-secretstore-setup-arm64:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     read_only: true
     restart: always
     security_opt:
@@ -888,46 +1249,82 @@ services:
     - /vault
     user: root:root
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - /tmp/edgex/secrets:/tmp/edgex/secrets:z
-    - kong:/tmp/kong:z
-    - kuiper-sources:/tmp/kuiper:z
-    - kuiper-connections:/tmp/kuiper-connections:z
-    - vault-config:/vault/config:z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets
+      target: /tmp/edgex/secrets
+      bind:
+        selinux: z
+        create_host_path: true
+    - type: volume
+      source: kong
+      target: /tmp/kong
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: kuiper-sources
+      target: /tmp/kuiper
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: kuiper-connections
+      target: /tmp/kuiper-connections
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: vault-config
+      target: /vault/config
+      bind:
+        selinux: z
+      volume: {}
   security-bootstrapper:
     container_name: edgex-security-bootstrapper
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
-      EDGEX_GROUP: '2001'
-      EDGEX_USER: '2002'
+      API_GATEWAY_STATUS_PORT: "8100"
+      EDGEX_GROUP: "2001"
+      EDGEX_USER: "2002"
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-security-bootstrapper
     image: nexus3.edgexfoundry.org:10004/security-bootstrapper-arm64:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: root:root
     volumes:
-    - edgex-init:/edgex-init:z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      bind:
+        selinux: z
+      volume: {}
   ui:
     container_name: edgex-ui-go
     environment:
@@ -936,9 +1333,12 @@ services:
     hostname: edgex-ui-go
     image: nexus3.edgexfoundry.org:10004/edgex-ui-arm64:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 4000:4000/tcp
+    - mode: ingress
+      target: 4000
+      published: "4000"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
@@ -947,30 +1347,32 @@ services:
   vault:
     cap_add:
     - IPC_LOCK
-    command: server
+    command:
+    - server
     container_name: edgex-vault
     depends_on:
-    - security-bootstrapper
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/vault_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
       VAULT_ADDR: http://edgex-vault:8200
       VAULT_CONFIG_DIR: /vault/config
@@ -978,32 +1380,69 @@ services:
     hostname: edgex-vault
     image: vault:1.11.5
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:8200:8200/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 8200
+      published: "8200"
+      protocol: tcp
     restart: always
     tmpfs:
     - /vault/config
     user: root:root
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - vault-file:/vault/file:z
-    - vault-logs:/vault/logs:z
-version: '3.7'
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: vault-file
+      target: /vault/file
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: vault-logs
+      target: /vault/logs
+      bind:
+        selinux: z
+      volume: {}
+networks:
+  edgex-network:
+    name: edgex_edgex-network
+    driver: bridge
 volumes:
-  consul-acl-token: {}
-  consul-config: {}
-  consul-data: {}
-  db-data: {}
-  edgex-init: {}
-  kong: {}
-  kuiper-connections: {}
-  kuiper-data: {}
-  kuiper-sources: {}
-  postgres-config: {}
-  postgres-data: {}
-  redis-config: {}
-  vault-config: {}
-  vault-file: {}
-  vault-logs: {}
-
+  consul-acl-token:
+    name: edgex_consul-acl-token
+  consul-config:
+    name: edgex_consul-config
+  consul-data:
+    name: edgex_consul-data
+  db-data:
+    name: edgex_db-data
+  edgex-init:
+    name: edgex_edgex-init
+  kong:
+    name: edgex_kong
+  kuiper-connections:
+    name: edgex_kuiper-connections
+  kuiper-data:
+    name: edgex_kuiper-data
+  kuiper-sources:
+    name: edgex_kuiper-sources
+  postgres-config:
+    name: edgex_postgres-config
+  postgres-data:
+    name: edgex_postgres-data
+  redis-config:
+    name: edgex_redis-config
+  vault-config:
+    name: edgex_vault-config
+  vault-file:
+    name: edgex_vault-file
+  vault-logs:
+    name: edgex_vault-logs

--- a/docker-compose-no-secty-arm64.yml
+++ b/docker-compose-no-secty-arm64.yml
@@ -24,15 +24,15 @@
 #
 # From the compose-builder folder use `make build` to regenerate all standard compose files variations
 #
-networks:
-  edgex-network:
-    driver: bridge
+name: edgex
 services:
   app-service-rules:
     container_name: edgex-app-rules-engine
     depends_on:
-    - consul
-    - data
+      consul:
+        condition: service_started
+      data:
+        condition: service_started
     environment:
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
@@ -48,9 +48,13 @@ services:
     hostname: edgex-app-rules-engine
     image: nexus3.edgexfoundry.org:10004/app-service-configurable-arm64:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59701:59701/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59701
+      published: "59701"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
@@ -59,9 +63,12 @@ services:
   command:
     container_name: edgex-core-command
     depends_on:
-    - consul
-    - database
-    - metadata
+      consul:
+        condition: service_started
+      database:
+        condition: service_started
+      metadata:
+        condition: service_started
     environment:
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
@@ -77,37 +84,64 @@ services:
     hostname: edgex-core-command
     image: nexus3.edgexfoundry.org:10004/core-command-arm64:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59882:59882/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59882
+      published: "59882"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
   consul:
-    command: agent -ui -bootstrap -server -client 0.0.0.0
+    command:
+    - agent
+    - -ui
+    - -bootstrap
+    - -server
+    - -client
+    - 0.0.0.0
     container_name: edgex-core-consul
     hostname: edgex-core-consul
     image: consul:1.13
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:8500:8500/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 8500
+      published: "8500"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: root:root
     volumes:
-    - consul-config:/consul/config:z
-    - consul-data:/consul/data:z
+    - type: volume
+      source: consul-config
+      target: /consul/config
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: consul-data
+      target: /consul/data
+      bind:
+        selinux: z
+      volume: {}
   data:
     container_name: edgex-core-data
     depends_on:
-    - consul
-    - database
-    - metadata
+      consul:
+        condition: service_started
+      database:
+        condition: service_started
+      metadata:
+        condition: service_started
     environment:
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
@@ -122,10 +156,18 @@ services:
     hostname: edgex-core-data
     image: nexus3.edgexfoundry.org:10004/core-data-arm64:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:5563:5563/tcp
-    - 127.0.0.1:59880:59880/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59880
+      published: "59880"
+      protocol: tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 5563
+      published: "5563"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
@@ -145,22 +187,34 @@ services:
     hostname: edgex-redis
     image: redis:7.0-alpine
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:6379:6379/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 6379
+      published: "6379"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: root:root
     volumes:
-    - db-data:/data:z
+    - type: volume
+      source: db-data
+      target: /data
+      bind:
+        selinux: z
+      volume: {}
   device-rest:
     container_name: edgex-device-rest
     depends_on:
-    - consul
-    - data
-    - metadata
+      consul:
+        condition: service_started
+      data:
+        condition: service_started
+      metadata:
+        condition: service_started
     environment:
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
@@ -175,9 +229,13 @@ services:
     hostname: edgex-device-rest
     image: nexus3.edgexfoundry.org:10004/device-rest-arm64:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59986:59986/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59986
+      published: "59986"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
@@ -186,9 +244,12 @@ services:
   device-virtual:
     container_name: edgex-device-virtual
     depends_on:
-    - consul
-    - data
-    - metadata
+      consul:
+        condition: service_started
+      data:
+        condition: service_started
+      metadata:
+        condition: service_started
     environment:
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
@@ -203,9 +264,13 @@ services:
     hostname: edgex-device-virtual
     image: nexus3.edgexfoundry.org:10004/device-virtual-arm64:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59900:59900/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59900
+      published: "59900"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
@@ -214,9 +279,12 @@ services:
   metadata:
     container_name: edgex-core-metadata
     depends_on:
-    - consul
-    - database
-    - notifications
+      consul:
+        condition: service_started
+      database:
+        condition: service_started
+      notifications:
+        condition: service_started
     environment:
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
@@ -232,9 +300,13 @@ services:
     hostname: edgex-core-metadata
     image: nexus3.edgexfoundry.org:10004/core-metadata-arm64:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59881:59881/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59881
+      published: "59881"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
@@ -243,8 +315,10 @@ services:
   notifications:
     container_name: edgex-support-notifications
     depends_on:
-    - consul
-    - database
+      consul:
+        condition: service_started
+      database:
+        condition: service_started
     environment:
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
@@ -259,9 +333,13 @@ services:
     hostname: edgex-support-notifications
     image: nexus3.edgexfoundry.org:10004/support-notifications-arm64:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59860:59860/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59860
+      published: "59860"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
@@ -270,37 +348,49 @@ services:
   rulesengine:
     container_name: edgex-kuiper
     depends_on:
-    - database
+      database:
+        condition: service_started
     environment:
-      CONNECTION__EDGEX__REDISMSGBUS__PORT: 6379
+      CONNECTION__EDGEX__REDISMSGBUS__PORT: "6379"
       CONNECTION__EDGEX__REDISMSGBUS__PROTOCOL: redis
       CONNECTION__EDGEX__REDISMSGBUS__SERVER: edgex-redis
       CONNECTION__EDGEX__REDISMSGBUS__TYPE: redis
-      EDGEX__DEFAULT__PORT: 6379
+      EDGEX__DEFAULT__PORT: "6379"
       EDGEX__DEFAULT__PROTOCOL: redis
       EDGEX__DEFAULT__SERVER: edgex-redis
       EDGEX__DEFAULT__TOPIC: rules-events
       EDGEX__DEFAULT__TYPE: redis
       KUIPER__BASIC__CONSOLELOG: "true"
-      KUIPER__BASIC__RESTPORT: 59720
+      KUIPER__BASIC__RESTPORT: "59720"
     hostname: edgex-kuiper
     image: lfedge/ekuiper:1.7-alpine
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59720:59720/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59720
+      published: "59720"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: kuiper:kuiper
     volumes:
-    - kuiper-data:/kuiper/data:z
+    - type: volume
+      source: kuiper-data
+      target: /kuiper/data
+      bind:
+        selinux: z
+      volume: {}
   scheduler:
     container_name: edgex-support-scheduler
     depends_on:
-    - consul
-    - database
+      consul:
+        condition: service_started
+      database:
+        condition: service_started
     environment:
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
@@ -317,9 +407,13 @@ services:
     hostname: edgex-support-scheduler
     image: nexus3.edgexfoundry.org:10004/support-scheduler-arm64:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59861:59861/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59861
+      published: "59861"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
@@ -333,18 +427,27 @@ services:
     hostname: edgex-ui-go
     image: nexus3.edgexfoundry.org:10004/edgex-ui-arm64:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 4000:4000/tcp
+    - mode: ingress
+      target: 4000
+      published: "4000"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
-version: '3.7'
+networks:
+  edgex-network:
+    name: edgex_edgex-network
+    driver: bridge
 volumes:
-  consul-config: {}
-  consul-data: {}
-  db-data: {}
-  kuiper-data: {}
-
+  consul-config:
+    name: edgex_consul-config
+  consul-data:
+    name: edgex_consul-data
+  db-data:
+    name: edgex_db-data
+  kuiper-data:
+    name: edgex_kuiper-data

--- a/docker-compose-no-secty-with-app-sample-arm64.yml
+++ b/docker-compose-no-secty-with-app-sample-arm64.yml
@@ -24,15 +24,15 @@
 #
 # From the compose-builder folder use `make build` to regenerate all standard compose files variations
 #
-networks:
-  edgex-network:
-    driver: bridge
+name: edgex
 services:
   app-service-rules:
     container_name: edgex-app-rules-engine
     depends_on:
-    - consul
-    - data
+      consul:
+        condition: service_started
+      data:
+        condition: service_started
     environment:
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
@@ -48,9 +48,13 @@ services:
     hostname: edgex-app-rules-engine
     image: nexus3.edgexfoundry.org:10004/app-service-configurable-arm64:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59701:59701/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59701
+      published: "59701"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
@@ -59,16 +63,18 @@ services:
   app-service-sample:
     container_name: edgex-app-sample
     depends_on:
-    - consul
-    - data
+      consul:
+        condition: service_started
+      data:
+        condition: service_started
     environment:
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
       CLIENTS_SUPPORT_NOTIFICATIONS_HOST: edgex-support-notifications
       CLIENTS_SUPPORT_SCHEDULER_HOST: edgex-support-scheduler
-      DATABASES_PRIMARY_HOST: edgex-redis
       DATABASE_HOST: edgex-redis
+      DATABASES_PRIMARY_HOST: edgex-redis
       EDGEX_PROFILE: sample
       EDGEX_SECURITY_SECRET_STORE: "false"
       MESSAGEBUS_HOST: edgex-redis
@@ -77,9 +83,13 @@ services:
     hostname: edgex-app-sample
     image: nexus3.edgexfoundry.org:10004/app-service-configurable-arm64:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59700:59700/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59700
+      published: "59700"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
@@ -88,9 +98,12 @@ services:
   command:
     container_name: edgex-core-command
     depends_on:
-    - consul
-    - database
-    - metadata
+      consul:
+        condition: service_started
+      database:
+        condition: service_started
+      metadata:
+        condition: service_started
     environment:
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
@@ -106,37 +119,64 @@ services:
     hostname: edgex-core-command
     image: nexus3.edgexfoundry.org:10004/core-command-arm64:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59882:59882/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59882
+      published: "59882"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
   consul:
-    command: agent -ui -bootstrap -server -client 0.0.0.0
+    command:
+    - agent
+    - -ui
+    - -bootstrap
+    - -server
+    - -client
+    - 0.0.0.0
     container_name: edgex-core-consul
     hostname: edgex-core-consul
     image: consul:1.13
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:8500:8500/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 8500
+      published: "8500"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: root:root
     volumes:
-    - consul-config:/consul/config:z
-    - consul-data:/consul/data:z
+    - type: volume
+      source: consul-config
+      target: /consul/config
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: consul-data
+      target: /consul/data
+      bind:
+        selinux: z
+      volume: {}
   data:
     container_name: edgex-core-data
     depends_on:
-    - consul
-    - database
-    - metadata
+      consul:
+        condition: service_started
+      database:
+        condition: service_started
+      metadata:
+        condition: service_started
     environment:
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
@@ -151,10 +191,18 @@ services:
     hostname: edgex-core-data
     image: nexus3.edgexfoundry.org:10004/core-data-arm64:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:5563:5563/tcp
-    - 127.0.0.1:59880:59880/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59880
+      published: "59880"
+      protocol: tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 5563
+      published: "5563"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
@@ -174,22 +222,34 @@ services:
     hostname: edgex-redis
     image: redis:7.0-alpine
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:6379:6379/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 6379
+      published: "6379"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: root:root
     volumes:
-    - db-data:/data:z
+    - type: volume
+      source: db-data
+      target: /data
+      bind:
+        selinux: z
+      volume: {}
   device-rest:
     container_name: edgex-device-rest
     depends_on:
-    - consul
-    - data
-    - metadata
+      consul:
+        condition: service_started
+      data:
+        condition: service_started
+      metadata:
+        condition: service_started
     environment:
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
@@ -204,9 +264,13 @@ services:
     hostname: edgex-device-rest
     image: nexus3.edgexfoundry.org:10004/device-rest-arm64:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59986:59986/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59986
+      published: "59986"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
@@ -215,9 +279,12 @@ services:
   device-virtual:
     container_name: edgex-device-virtual
     depends_on:
-    - consul
-    - data
-    - metadata
+      consul:
+        condition: service_started
+      data:
+        condition: service_started
+      metadata:
+        condition: service_started
     environment:
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
@@ -232,9 +299,13 @@ services:
     hostname: edgex-device-virtual
     image: nexus3.edgexfoundry.org:10004/device-virtual-arm64:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59900:59900/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59900
+      published: "59900"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
@@ -243,9 +314,12 @@ services:
   metadata:
     container_name: edgex-core-metadata
     depends_on:
-    - consul
-    - database
-    - notifications
+      consul:
+        condition: service_started
+      database:
+        condition: service_started
+      notifications:
+        condition: service_started
     environment:
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
@@ -261,9 +335,13 @@ services:
     hostname: edgex-core-metadata
     image: nexus3.edgexfoundry.org:10004/core-metadata-arm64:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59881:59881/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59881
+      published: "59881"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
@@ -272,8 +350,10 @@ services:
   notifications:
     container_name: edgex-support-notifications
     depends_on:
-    - consul
-    - database
+      consul:
+        condition: service_started
+      database:
+        condition: service_started
     environment:
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
@@ -288,9 +368,13 @@ services:
     hostname: edgex-support-notifications
     image: nexus3.edgexfoundry.org:10004/support-notifications-arm64:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59860:59860/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59860
+      published: "59860"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
@@ -299,37 +383,49 @@ services:
   rulesengine:
     container_name: edgex-kuiper
     depends_on:
-    - database
+      database:
+        condition: service_started
     environment:
-      CONNECTION__EDGEX__REDISMSGBUS__PORT: 6379
+      CONNECTION__EDGEX__REDISMSGBUS__PORT: "6379"
       CONNECTION__EDGEX__REDISMSGBUS__PROTOCOL: redis
       CONNECTION__EDGEX__REDISMSGBUS__SERVER: edgex-redis
       CONNECTION__EDGEX__REDISMSGBUS__TYPE: redis
-      EDGEX__DEFAULT__PORT: 6379
+      EDGEX__DEFAULT__PORT: "6379"
       EDGEX__DEFAULT__PROTOCOL: redis
       EDGEX__DEFAULT__SERVER: edgex-redis
       EDGEX__DEFAULT__TOPIC: rules-events
       EDGEX__DEFAULT__TYPE: redis
       KUIPER__BASIC__CONSOLELOG: "true"
-      KUIPER__BASIC__RESTPORT: 59720
+      KUIPER__BASIC__RESTPORT: "59720"
     hostname: edgex-kuiper
     image: lfedge/ekuiper:1.7-alpine
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59720:59720/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59720
+      published: "59720"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: kuiper:kuiper
     volumes:
-    - kuiper-data:/kuiper/data:z
+    - type: volume
+      source: kuiper-data
+      target: /kuiper/data
+      bind:
+        selinux: z
+      volume: {}
   scheduler:
     container_name: edgex-support-scheduler
     depends_on:
-    - consul
-    - database
+      consul:
+        condition: service_started
+      database:
+        condition: service_started
     environment:
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
@@ -346,9 +442,13 @@ services:
     hostname: edgex-support-scheduler
     image: nexus3.edgexfoundry.org:10004/support-scheduler-arm64:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59861:59861/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59861
+      published: "59861"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
@@ -362,18 +462,27 @@ services:
     hostname: edgex-ui-go
     image: nexus3.edgexfoundry.org:10004/edgex-ui-arm64:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 4000:4000/tcp
+    - mode: ingress
+      target: 4000
+      published: "4000"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
-version: '3.7'
+networks:
+  edgex-network:
+    name: edgex_edgex-network
+    driver: bridge
 volumes:
-  consul-config: {}
-  consul-data: {}
-  db-data: {}
-  kuiper-data: {}
-
+  consul-config:
+    name: edgex_consul-config
+  consul-data:
+    name: edgex_consul-data
+  db-data:
+    name: edgex_db-data
+  kuiper-data:
+    name: edgex_kuiper-data

--- a/docker-compose-no-secty-with-app-sample.yml
+++ b/docker-compose-no-secty-with-app-sample.yml
@@ -24,15 +24,15 @@
 #
 # From the compose-builder folder use `make build` to regenerate all standard compose files variations
 #
-networks:
-  edgex-network:
-    driver: bridge
+name: edgex
 services:
   app-service-rules:
     container_name: edgex-app-rules-engine
     depends_on:
-    - consul
-    - data
+      consul:
+        condition: service_started
+      data:
+        condition: service_started
     environment:
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
@@ -48,9 +48,13 @@ services:
     hostname: edgex-app-rules-engine
     image: nexus3.edgexfoundry.org:10004/app-service-configurable:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59701:59701/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59701
+      published: "59701"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
@@ -59,16 +63,18 @@ services:
   app-service-sample:
     container_name: edgex-app-sample
     depends_on:
-    - consul
-    - data
+      consul:
+        condition: service_started
+      data:
+        condition: service_started
     environment:
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
       CLIENTS_SUPPORT_NOTIFICATIONS_HOST: edgex-support-notifications
       CLIENTS_SUPPORT_SCHEDULER_HOST: edgex-support-scheduler
-      DATABASES_PRIMARY_HOST: edgex-redis
       DATABASE_HOST: edgex-redis
+      DATABASES_PRIMARY_HOST: edgex-redis
       EDGEX_PROFILE: sample
       EDGEX_SECURITY_SECRET_STORE: "false"
       MESSAGEBUS_HOST: edgex-redis
@@ -77,9 +83,13 @@ services:
     hostname: edgex-app-sample
     image: nexus3.edgexfoundry.org:10004/app-service-configurable:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59700:59700/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59700
+      published: "59700"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
@@ -88,9 +98,12 @@ services:
   command:
     container_name: edgex-core-command
     depends_on:
-    - consul
-    - database
-    - metadata
+      consul:
+        condition: service_started
+      database:
+        condition: service_started
+      metadata:
+        condition: service_started
     environment:
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
@@ -106,37 +119,64 @@ services:
     hostname: edgex-core-command
     image: nexus3.edgexfoundry.org:10004/core-command:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59882:59882/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59882
+      published: "59882"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
   consul:
-    command: agent -ui -bootstrap -server -client 0.0.0.0
+    command:
+    - agent
+    - -ui
+    - -bootstrap
+    - -server
+    - -client
+    - 0.0.0.0
     container_name: edgex-core-consul
     hostname: edgex-core-consul
     image: consul:1.13
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:8500:8500/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 8500
+      published: "8500"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: root:root
     volumes:
-    - consul-config:/consul/config:z
-    - consul-data:/consul/data:z
+    - type: volume
+      source: consul-config
+      target: /consul/config
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: consul-data
+      target: /consul/data
+      bind:
+        selinux: z
+      volume: {}
   data:
     container_name: edgex-core-data
     depends_on:
-    - consul
-    - database
-    - metadata
+      consul:
+        condition: service_started
+      database:
+        condition: service_started
+      metadata:
+        condition: service_started
     environment:
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
@@ -151,10 +191,18 @@ services:
     hostname: edgex-core-data
     image: nexus3.edgexfoundry.org:10004/core-data:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:5563:5563/tcp
-    - 127.0.0.1:59880:59880/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59880
+      published: "59880"
+      protocol: tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 5563
+      published: "5563"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
@@ -174,22 +222,34 @@ services:
     hostname: edgex-redis
     image: redis:7.0-alpine
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:6379:6379/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 6379
+      published: "6379"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: root:root
     volumes:
-    - db-data:/data:z
+    - type: volume
+      source: db-data
+      target: /data
+      bind:
+        selinux: z
+      volume: {}
   device-rest:
     container_name: edgex-device-rest
     depends_on:
-    - consul
-    - data
-    - metadata
+      consul:
+        condition: service_started
+      data:
+        condition: service_started
+      metadata:
+        condition: service_started
     environment:
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
@@ -204,9 +264,13 @@ services:
     hostname: edgex-device-rest
     image: nexus3.edgexfoundry.org:10004/device-rest:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59986:59986/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59986
+      published: "59986"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
@@ -215,9 +279,12 @@ services:
   device-virtual:
     container_name: edgex-device-virtual
     depends_on:
-    - consul
-    - data
-    - metadata
+      consul:
+        condition: service_started
+      data:
+        condition: service_started
+      metadata:
+        condition: service_started
     environment:
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
@@ -232,9 +299,13 @@ services:
     hostname: edgex-device-virtual
     image: nexus3.edgexfoundry.org:10004/device-virtual:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59900:59900/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59900
+      published: "59900"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
@@ -243,9 +314,12 @@ services:
   metadata:
     container_name: edgex-core-metadata
     depends_on:
-    - consul
-    - database
-    - notifications
+      consul:
+        condition: service_started
+      database:
+        condition: service_started
+      notifications:
+        condition: service_started
     environment:
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
@@ -261,9 +335,13 @@ services:
     hostname: edgex-core-metadata
     image: nexus3.edgexfoundry.org:10004/core-metadata:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59881:59881/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59881
+      published: "59881"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
@@ -272,8 +350,10 @@ services:
   notifications:
     container_name: edgex-support-notifications
     depends_on:
-    - consul
-    - database
+      consul:
+        condition: service_started
+      database:
+        condition: service_started
     environment:
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
@@ -288,9 +368,13 @@ services:
     hostname: edgex-support-notifications
     image: nexus3.edgexfoundry.org:10004/support-notifications:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59860:59860/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59860
+      published: "59860"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
@@ -299,37 +383,49 @@ services:
   rulesengine:
     container_name: edgex-kuiper
     depends_on:
-    - database
+      database:
+        condition: service_started
     environment:
-      CONNECTION__EDGEX__REDISMSGBUS__PORT: 6379
+      CONNECTION__EDGEX__REDISMSGBUS__PORT: "6379"
       CONNECTION__EDGEX__REDISMSGBUS__PROTOCOL: redis
       CONNECTION__EDGEX__REDISMSGBUS__SERVER: edgex-redis
       CONNECTION__EDGEX__REDISMSGBUS__TYPE: redis
-      EDGEX__DEFAULT__PORT: 6379
+      EDGEX__DEFAULT__PORT: "6379"
       EDGEX__DEFAULT__PROTOCOL: redis
       EDGEX__DEFAULT__SERVER: edgex-redis
       EDGEX__DEFAULT__TOPIC: rules-events
       EDGEX__DEFAULT__TYPE: redis
       KUIPER__BASIC__CONSOLELOG: "true"
-      KUIPER__BASIC__RESTPORT: 59720
+      KUIPER__BASIC__RESTPORT: "59720"
     hostname: edgex-kuiper
     image: lfedge/ekuiper:1.7-alpine
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59720:59720/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59720
+      published: "59720"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: kuiper:kuiper
     volumes:
-    - kuiper-data:/kuiper/data:z
+    - type: volume
+      source: kuiper-data
+      target: /kuiper/data
+      bind:
+        selinux: z
+      volume: {}
   scheduler:
     container_name: edgex-support-scheduler
     depends_on:
-    - consul
-    - database
+      consul:
+        condition: service_started
+      database:
+        condition: service_started
     environment:
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
@@ -346,9 +442,13 @@ services:
     hostname: edgex-support-scheduler
     image: nexus3.edgexfoundry.org:10004/support-scheduler:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59861:59861/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59861
+      published: "59861"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
@@ -362,18 +462,27 @@ services:
     hostname: edgex-ui-go
     image: nexus3.edgexfoundry.org:10004/edgex-ui:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 4000:4000/tcp
+    - mode: ingress
+      target: 4000
+      published: "4000"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
-version: '3.7'
+networks:
+  edgex-network:
+    name: edgex_edgex-network
+    driver: bridge
 volumes:
-  consul-config: {}
-  consul-data: {}
-  db-data: {}
-  kuiper-data: {}
-
+  consul-config:
+    name: edgex_consul-config
+  consul-data:
+    name: edgex_consul-data
+  db-data:
+    name: edgex_db-data
+  kuiper-data:
+    name: edgex_kuiper-data

--- a/docker-compose-no-secty.yml
+++ b/docker-compose-no-secty.yml
@@ -24,15 +24,15 @@
 #
 # From the compose-builder folder use `make build` to regenerate all standard compose files variations
 #
-networks:
-  edgex-network:
-    driver: bridge
+name: edgex
 services:
   app-service-rules:
     container_name: edgex-app-rules-engine
     depends_on:
-    - consul
-    - data
+      consul:
+        condition: service_started
+      data:
+        condition: service_started
     environment:
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
@@ -48,9 +48,13 @@ services:
     hostname: edgex-app-rules-engine
     image: nexus3.edgexfoundry.org:10004/app-service-configurable:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59701:59701/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59701
+      published: "59701"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
@@ -59,9 +63,12 @@ services:
   command:
     container_name: edgex-core-command
     depends_on:
-    - consul
-    - database
-    - metadata
+      consul:
+        condition: service_started
+      database:
+        condition: service_started
+      metadata:
+        condition: service_started
     environment:
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
@@ -77,37 +84,64 @@ services:
     hostname: edgex-core-command
     image: nexus3.edgexfoundry.org:10004/core-command:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59882:59882/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59882
+      published: "59882"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
   consul:
-    command: agent -ui -bootstrap -server -client 0.0.0.0
+    command:
+    - agent
+    - -ui
+    - -bootstrap
+    - -server
+    - -client
+    - 0.0.0.0
     container_name: edgex-core-consul
     hostname: edgex-core-consul
     image: consul:1.13
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:8500:8500/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 8500
+      published: "8500"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: root:root
     volumes:
-    - consul-config:/consul/config:z
-    - consul-data:/consul/data:z
+    - type: volume
+      source: consul-config
+      target: /consul/config
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: consul-data
+      target: /consul/data
+      bind:
+        selinux: z
+      volume: {}
   data:
     container_name: edgex-core-data
     depends_on:
-    - consul
-    - database
-    - metadata
+      consul:
+        condition: service_started
+      database:
+        condition: service_started
+      metadata:
+        condition: service_started
     environment:
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
@@ -122,10 +156,18 @@ services:
     hostname: edgex-core-data
     image: nexus3.edgexfoundry.org:10004/core-data:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:5563:5563/tcp
-    - 127.0.0.1:59880:59880/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59880
+      published: "59880"
+      protocol: tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 5563
+      published: "5563"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
@@ -145,22 +187,34 @@ services:
     hostname: edgex-redis
     image: redis:7.0-alpine
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:6379:6379/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 6379
+      published: "6379"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: root:root
     volumes:
-    - db-data:/data:z
+    - type: volume
+      source: db-data
+      target: /data
+      bind:
+        selinux: z
+      volume: {}
   device-rest:
     container_name: edgex-device-rest
     depends_on:
-    - consul
-    - data
-    - metadata
+      consul:
+        condition: service_started
+      data:
+        condition: service_started
+      metadata:
+        condition: service_started
     environment:
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
@@ -175,9 +229,13 @@ services:
     hostname: edgex-device-rest
     image: nexus3.edgexfoundry.org:10004/device-rest:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59986:59986/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59986
+      published: "59986"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
@@ -186,9 +244,12 @@ services:
   device-virtual:
     container_name: edgex-device-virtual
     depends_on:
-    - consul
-    - data
-    - metadata
+      consul:
+        condition: service_started
+      data:
+        condition: service_started
+      metadata:
+        condition: service_started
     environment:
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
@@ -203,9 +264,13 @@ services:
     hostname: edgex-device-virtual
     image: nexus3.edgexfoundry.org:10004/device-virtual:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59900:59900/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59900
+      published: "59900"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
@@ -214,9 +279,12 @@ services:
   metadata:
     container_name: edgex-core-metadata
     depends_on:
-    - consul
-    - database
-    - notifications
+      consul:
+        condition: service_started
+      database:
+        condition: service_started
+      notifications:
+        condition: service_started
     environment:
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
@@ -232,9 +300,13 @@ services:
     hostname: edgex-core-metadata
     image: nexus3.edgexfoundry.org:10004/core-metadata:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59881:59881/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59881
+      published: "59881"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
@@ -243,8 +315,10 @@ services:
   notifications:
     container_name: edgex-support-notifications
     depends_on:
-    - consul
-    - database
+      consul:
+        condition: service_started
+      database:
+        condition: service_started
     environment:
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
@@ -259,9 +333,13 @@ services:
     hostname: edgex-support-notifications
     image: nexus3.edgexfoundry.org:10004/support-notifications:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59860:59860/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59860
+      published: "59860"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
@@ -270,37 +348,49 @@ services:
   rulesengine:
     container_name: edgex-kuiper
     depends_on:
-    - database
+      database:
+        condition: service_started
     environment:
-      CONNECTION__EDGEX__REDISMSGBUS__PORT: 6379
+      CONNECTION__EDGEX__REDISMSGBUS__PORT: "6379"
       CONNECTION__EDGEX__REDISMSGBUS__PROTOCOL: redis
       CONNECTION__EDGEX__REDISMSGBUS__SERVER: edgex-redis
       CONNECTION__EDGEX__REDISMSGBUS__TYPE: redis
-      EDGEX__DEFAULT__PORT: 6379
+      EDGEX__DEFAULT__PORT: "6379"
       EDGEX__DEFAULT__PROTOCOL: redis
       EDGEX__DEFAULT__SERVER: edgex-redis
       EDGEX__DEFAULT__TOPIC: rules-events
       EDGEX__DEFAULT__TYPE: redis
       KUIPER__BASIC__CONSOLELOG: "true"
-      KUIPER__BASIC__RESTPORT: 59720
+      KUIPER__BASIC__RESTPORT: "59720"
     hostname: edgex-kuiper
     image: lfedge/ekuiper:1.7-alpine
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59720:59720/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59720
+      published: "59720"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: kuiper:kuiper
     volumes:
-    - kuiper-data:/kuiper/data:z
+    - type: volume
+      source: kuiper-data
+      target: /kuiper/data
+      bind:
+        selinux: z
+      volume: {}
   scheduler:
     container_name: edgex-support-scheduler
     depends_on:
-    - consul
-    - database
+      consul:
+        condition: service_started
+      database:
+        condition: service_started
     environment:
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
@@ -317,9 +407,13 @@ services:
     hostname: edgex-support-scheduler
     image: nexus3.edgexfoundry.org:10004/support-scheduler:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59861:59861/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59861
+      published: "59861"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
@@ -333,18 +427,27 @@ services:
     hostname: edgex-ui-go
     image: nexus3.edgexfoundry.org:10004/edgex-ui:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 4000:4000/tcp
+    - mode: ingress
+      target: 4000
+      published: "4000"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
-version: '3.7'
+networks:
+  edgex-network:
+    name: edgex_edgex-network
+    driver: bridge
 volumes:
-  consul-config: {}
-  consul-data: {}
-  db-data: {}
-  kuiper-data: {}
-
+  consul-config:
+    name: edgex_consul-config
+  consul-data:
+    name: edgex_consul-data
+  db-data:
+    name: edgex_db-data
+  kuiper-data:
+    name: edgex_kuiper-data

--- a/docker-compose-with-app-sample-arm64.yml
+++ b/docker-compose-with-app-sample-arm64.yml
@@ -24,22 +24,26 @@
 #
 # From the compose-builder folder use `make build` to regenerate all standard compose files variations
 #
-networks:
-  edgex-network:
-    driver: bridge
+name: edgex
 services:
   app-service-rules:
-    command: /app-service-configurable -cp=consul.http://edgex-core-consul:8500 --registry
+    command:
+    - /app-service-configurable
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
     container_name: edgex-app-rules-engine
     depends_on:
-    - consul
-    - data
-    - security-bootstrapper
+      consul:
+        condition: service_started
+      data:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/ready_to_run_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
@@ -52,113 +56,159 @@ services:
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SERVICE_HOST: edgex-app-rules-engine
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-app-rules-engine
     image: nexus3.edgexfoundry.org:10004/app-service-configurable-arm64:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59701:59701/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59701
+      published: "59701"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - /tmp/edgex/secrets/app-rules-engine:/tmp/edgex/secrets/app-rules-engine:ro,z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/app-rules-engine
+      target: /tmp/edgex/secrets/app-rules-engine
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   app-service-sample:
-    command: /app-service-configurable -cp=consul.http://edgex-core-consul:8500 --registry
+    command:
+    - /app-service-configurable
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
     container_name: edgex-app-sample
     depends_on:
-    - consul
-    - data
-    - security-bootstrapper
+      consul:
+        condition: service_started
+      data:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/ready_to_run_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
       CLIENTS_SUPPORT_NOTIFICATIONS_HOST: edgex-support-notifications
       CLIENTS_SUPPORT_SCHEDULER_HOST: edgex-support-scheduler
-      DATABASES_PRIMARY_HOST: edgex-redis
       DATABASE_HOST: edgex-redis
+      DATABASES_PRIMARY_HOST: edgex-redis
       EDGEX_PROFILE: sample
       EDGEX_SECURITY_SECRET_STORE: "true"
       MESSAGEBUS_HOST: edgex-redis
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SERVICE_HOST: edgex-app-sample
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-app-sample
     image: nexus3.edgexfoundry.org:10004/app-service-configurable-arm64:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59700:59700/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59700
+      published: "59700"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - /tmp/edgex/secrets/app-sample:/tmp/edgex/secrets/app-sample:ro,z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/app-sample
+      target: /tmp/edgex/secrets/app-sample
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   command:
-    command: /core-command -cp=consul.http://edgex-core-consul:8500 --registry
+    command:
+    - /core-command
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
     container_name: edgex-core-command
     depends_on:
-    - consul
-    - database
-    - metadata
-    - secretstore-setup
-    - security-bootstrapper
+      consul:
+        condition: service_started
+      database:
+        condition: service_started
+      metadata:
+        condition: service_started
+      secretstore-setup:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/ready_to_run_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
@@ -171,110 +221,173 @@ services:
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SERVICE_HOST: edgex-core-command
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-core-command
     image: nexus3.edgexfoundry.org:10004/core-command-arm64:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59882:59882/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59882
+      published: "59882"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - /tmp/edgex/secrets/core-command:/tmp/edgex/secrets/core-command:ro,z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/core-command
+      target: /tmp/edgex/secrets/core-command
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   consul:
-    command: agent -ui -bootstrap -server -client 0.0.0.0
+    command:
+    - agent
+    - -ui
+    - -bootstrap
+    - -server
+    - -client
+    - 0.0.0.0
     container_name: edgex-core-consul
     depends_on:
-    - security-bootstrapper
-    - vault
+      security-bootstrapper:
+        condition: service_started
+      vault:
+        condition: service_started
     entrypoint:
     - /edgex-init/consul_wait_install.sh
     environment:
       ADD_REGISTRY_ACL_ROLES: app-sample
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
-      EDGEX_GROUP: '2001'
+      API_GATEWAY_STATUS_PORT: "8100"
+      EDGEX_GROUP: "2001"
       EDGEX_SECURITY_SECRET_STORE: "true"
-      EDGEX_USER: '2002'
+      EDGEX_USER: "2002"
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_ACL_BOOTSTRAPTOKENPATH: /tmp/edgex/secrets/consul-acl-token/bootstrap_token.json
       STAGEGATE_REGISTRY_ACL_MANAGEMENTTOKENPATH: /tmp/edgex/secrets/consul-acl-token/mgmt_token.json
       STAGEGATE_REGISTRY_ACL_SENTINELFILEPATH: /consul/config/consul_acl_done
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-core-consul
     image: consul:1.13
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:8500:8500/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 8500
+      published: "8500"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: root:root
     volumes:
-    - consul-config:/consul/config:z
-    - consul-data:/consul/data:z
-    - edgex-init:/edgex-init:ro,z
-    - consul-acl-token:/tmp/edgex/secrets/consul-acl-token:z
-    - /tmp/edgex/secrets/edgex-consul:/tmp/edgex/secrets/edgex-consul:ro,z
+    - type: volume
+      source: consul-config
+      target: /consul/config
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: consul-data
+      target: /consul/data
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: consul-acl-token
+      target: /tmp/edgex/secrets/consul-acl-token
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/edgex-consul
+      target: /tmp/edgex/secrets/edgex-consul
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   data:
-    command: /core-data -cp=consul.http://edgex-core-consul:8500 --registry
+    command:
+    - /core-data
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
     container_name: edgex-core-data
     depends_on:
-    - consul
-    - database
-    - metadata
-    - secretstore-setup
-    - security-bootstrapper
+      consul:
+        condition: service_started
+      database:
+        condition: service_started
+      metadata:
+        condition: service_started
+      secretstore-setup:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/ready_to_run_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
@@ -286,52 +399,74 @@ services:
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SECRETSTORE_TOKENFILE: /tmp/edgex/secrets/core-data/secrets-token.json
       SERVICE_HOST: edgex-core-data
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-core-data
     image: nexus3.edgexfoundry.org:10004/core-data-arm64:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:5563:5563/tcp
-    - 127.0.0.1:59880:59880/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 5563
+      published: "5563"
+      protocol: tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59880
+      published: "59880"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - /tmp/edgex/secrets/core-data:/tmp/edgex/secrets/core-data:ro,z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/core-data
+      target: /tmp/edgex/secrets/core-data
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   database:
     container_name: edgex-redis
     depends_on:
-    - secretstore-setup
-    - security-bootstrapper
+      secretstore-setup:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/redis_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
@@ -344,31 +479,35 @@ services:
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-redis
     image: redis:7.0-alpine
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:6379:6379/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 6379
+      published: "6379"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
@@ -377,23 +516,52 @@ services:
     - /run
     user: root:root
     volumes:
-    - db-data:/data:z
-    - edgex-init:/edgex-init:ro,z
-    - redis-config:/run/redis/conf:z
-    - /tmp/edgex/secrets/security-bootstrapper-redis:/tmp/edgex/secrets/security-bootstrapper-redis:ro,z
+    - type: volume
+      source: db-data
+      target: /data
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: redis-config
+      target: /run/redis/conf
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/security-bootstrapper-redis
+      target: /tmp/edgex/secrets/security-bootstrapper-redis
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   device-rest:
-    command: /device-rest -cp=consul.http://edgex-core-consul:8500 --registry
+    command:
+    - /device-rest
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
     container_name: edgex-device-rest
     depends_on:
-    - consul
-    - data
-    - metadata
-    - security-bootstrapper
+      consul:
+        condition: service_started
+      data:
+        condition: service_started
+      metadata:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/ready_to_run_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
@@ -405,53 +573,76 @@ services:
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SERVICE_HOST: edgex-device-rest
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-device-rest
     image: nexus3.edgexfoundry.org:10004/device-rest-arm64:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59986:59986/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59986
+      published: "59986"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - /tmp/edgex/secrets/device-rest:/tmp/edgex/secrets/device-rest:ro,z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/device-rest
+      target: /tmp/edgex/secrets/device-rest
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   device-virtual:
-    command: /device-virtual -cp=consul.http://edgex-core-consul:8500 --registry
+    command:
+    - /device-virtual
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
     container_name: edgex-device-virtual
     depends_on:
-    - consul
-    - data
-    - metadata
-    - security-bootstrapper
+      consul:
+        condition: service_started
+      data:
+        condition: service_started
+      metadata:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/ready_to_run_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
@@ -463,57 +654,75 @@ services:
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SERVICE_HOST: edgex-device-virtual
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-device-virtual
     image: nexus3.edgexfoundry.org:10004/device-virtual-arm64:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59900:59900/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59900
+      published: "59900"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - /tmp/edgex/secrets/device-virtual:/tmp/edgex/secrets/device-virtual:ro,z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/device-virtual
+      target: /tmp/edgex/secrets/device-virtual
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   kong:
     container_name: edgex-kong
     depends_on:
-    - kong-db
-    - security-bootstrapper
+      kong-db:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/kong_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       KONG_ADMIN_ACCESS_LOG: /dev/stdout
       KONG_ADMIN_ERROR_LOG: /dev/stderr
       KONG_ADMIN_LISTEN: 127.0.0.1:8001, 127.0.0.1:8444 ssl
       KONG_DATABASE: postgres
       KONG_DNS_ORDER: LAST,A,CNAME
-      KONG_DNS_VALID_TTL: '1'
-      KONG_NGINX_WORKER_PROCESSES: '1'
+      KONG_DNS_VALID_TTL: "1"
+      KONG_NGINX_WORKER_PROCESSES: "1"
       KONG_PG_HOST: edgex-kong-db
       KONG_PG_PASSWORD_FILE: /tmp/postgres-config/.pgpassword
       KONG_PROXY_ACCESS_LOG: /dev/stdout
@@ -522,28 +731,38 @@ services:
       KONG_STATUS_LISTEN: 0.0.0.0:8100
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-kong
     image: kong:2.8
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 8000:8000/tcp
-    - 127.0.0.1:8100:8100/tcp
-    - 8443:8443/tcp
+    - mode: ingress
+      target: 8000
+      published: "8000"
+      protocol: tcp
+    - mode: ingress
+      target: 8443
+      published: "8443"
+      protocol: tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 8100
+      published: "8100"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
@@ -554,50 +773,77 @@ services:
     tty: true
     user: kong:nogroup
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - /tmp/edgex/secrets/security-proxy-setup:/tmp/edgex/secrets/security-proxy-setup:ro,z
-    - postgres-config:/tmp/postgres-config:z
-    - kong:/usr/local/kong:z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: postgres-config
+      target: /tmp/postgres-config
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: kong
+      target: /usr/local/kong
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/security-proxy-setup
+      target: /tmp/edgex/secrets/security-proxy-setup
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   kong-db:
     container_name: edgex-kong-db
     depends_on:
-    - security-bootstrapper
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/postgres_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       EDGEX_SECURITY_SECRET_STORE: "true"
       POSTGRES_DB: kong
       POSTGRES_PASSWORD_FILE: /tmp/postgres-config/.pgpassword
       POSTGRES_USER: kong
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-kong-db
     image: postgres:13.8-alpine
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:5432:5432/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 5432
+      published: "5432"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
@@ -608,23 +854,47 @@ services:
     - /run
     user: root:root
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - postgres-config:/tmp/postgres-config:z
-    - postgres-data:/var/lib/postgresql/data:z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: postgres-data
+      target: /var/lib/postgresql/data
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: postgres-config
+      target: /tmp/postgres-config
+      bind:
+        selinux: z
+      volume: {}
   metadata:
-    command: /core-metadata -cp=consul.http://edgex-core-consul:8500 --registry
+    command:
+    - /core-metadata
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
     container_name: edgex-core-metadata
     depends_on:
-    - consul
-    - database
-    - notifications
-    - secretstore-setup
-    - security-bootstrapper
+      consul:
+        condition: service_started
+      database:
+        condition: service_started
+      notifications:
+        condition: service_started
+      secretstore-setup:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/ready_to_run_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
@@ -637,53 +907,76 @@ services:
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SERVICE_HOST: edgex-core-metadata
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-core-metadata
     image: nexus3.edgexfoundry.org:10004/core-metadata-arm64:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59881:59881/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59881
+      published: "59881"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - /tmp/edgex/secrets/core-metadata:/tmp/edgex/secrets/core-metadata:ro,z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/core-metadata
+      target: /tmp/edgex/secrets/core-metadata
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   notifications:
-    command: /support-notifications -cp=consul.http://edgex-core-consul:8500 --registry
+    command:
+    - /support-notifications
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
     container_name: edgex-support-notifications
     depends_on:
-    - consul
-    - database
-    - secretstore-setup
-    - security-bootstrapper
+      consul:
+        condition: service_started
+      database:
+        condition: service_started
+      secretstore-setup:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/ready_to_run_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
@@ -695,52 +988,71 @@ services:
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SERVICE_HOST: edgex-support-notifications
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-support-notifications
     image: nexus3.edgexfoundry.org:10004/support-notifications-arm64:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59860:59860/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59860
+      published: "59860"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - /tmp/edgex/secrets/support-notifications:/tmp/edgex/secrets/support-notifications:ro,z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/support-notifications
+      target: /tmp/edgex/secrets/support-notifications
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   proxy-setup:
     container_name: edgex-security-proxy-setup
     depends_on:
-    - kong
-    - secretstore-setup
-    - security-bootstrapper
+      kong:
+        condition: service_started
+      secretstore-setup:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/proxy_setup_wait_install.sh
     environment:
-      ADD_PROXY_ROUTE: ''
+      ADD_PROXY_ROUTE: ""
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       EDGEX_SECURITY_SECRET_STORE: "true"
       KONGURL_SERVER: edgex-kong
       PROXY_SETUP_HOST: edgex-security-proxy-setup
@@ -754,104 +1066,157 @@ services:
       ROUTES_SUPPORT_SCHEDULER_HOST: edgex-support-scheduler
       ROUTES_SYS_MGMT_AGENT_HOST: edgex-sys-mgmt-agent
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-security-proxy-setup
     image: nexus3.edgexfoundry.org:10004/security-proxy-setup-arm64:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     read_only: true
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - consul-acl-token:/tmp/edgex/secrets/consul-acl-token:ro,z
-    - /tmp/edgex/secrets/security-proxy-setup:/tmp/edgex/secrets/security-proxy-setup:ro,z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/security-proxy-setup
+      target: /tmp/edgex/secrets/security-proxy-setup
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
+    - type: volume
+      source: consul-acl-token
+      target: /tmp/edgex/secrets/consul-acl-token
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
   rulesengine:
     container_name: edgex-kuiper
     depends_on:
-    - database
-    - secretstore-setup
-    - security-bootstrapper
+      database:
+        condition: service_started
+      secretstore-setup:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/kuiper_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
-      CONNECTION__EDGEX__REDISMSGBUS__PORT: 6379
+      API_GATEWAY_STATUS_PORT: "8100"
+      CONNECTION__EDGEX__REDISMSGBUS__PORT: "6379"
       CONNECTION__EDGEX__REDISMSGBUS__PROTOCOL: redis
       CONNECTION__EDGEX__REDISMSGBUS__SERVER: edgex-redis
       CONNECTION__EDGEX__REDISMSGBUS__TYPE: redis
-      EDGEX__DEFAULT__PORT: 6379
+      EDGEX__DEFAULT__PORT: "6379"
       EDGEX__DEFAULT__PROTOCOL: redis
       EDGEX__DEFAULT__SERVER: edgex-redis
       EDGEX__DEFAULT__TOPIC: rules-events
       EDGEX__DEFAULT__TYPE: redis
       KUIPER__BASIC__CONSOLELOG: "true"
-      KUIPER__BASIC__RESTPORT: 59720
+      KUIPER__BASIC__RESTPORT: "59720"
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-kuiper
     image: lfedge/ekuiper:1.7-alpine
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59720:59720/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59720
+      published: "59720"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: kuiper:kuiper
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - kuiper-data:/kuiper/data:z
-    - kuiper-connections:/kuiper/etc/connections:z
-    - kuiper-sources:/kuiper/etc/sources:z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: kuiper-data
+      target: /kuiper/data
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: kuiper-connections
+      target: /kuiper/etc/connections
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: kuiper-sources
+      target: /kuiper/etc/sources
+      bind:
+        selinux: z
+      volume: {}
   scheduler:
-    command: /support-scheduler -cp=consul.http://edgex-core-consul:8500 --registry
+    command:
+    - /support-scheduler
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
     container_name: edgex-support-scheduler
     depends_on:
-    - consul
-    - database
-    - secretstore-setup
-    - security-bootstrapper
+      consul:
+        condition: service_started
+      database:
+        condition: service_started
+      secretstore-setup:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/ready_to_run_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
@@ -865,79 +1230,97 @@ services:
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SERVICE_HOST: edgex-support-scheduler
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-support-scheduler
     image: nexus3.edgexfoundry.org:10004/support-scheduler-arm64:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59861:59861/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59861
+      published: "59861"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - /tmp/edgex/secrets/support-scheduler:/tmp/edgex/secrets/support-scheduler:ro,z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/support-scheduler
+      target: /tmp/edgex/secrets/support-scheduler
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   secretstore-setup:
     container_name: edgex-security-secretstore-setup
     depends_on:
-    - security-bootstrapper
-    - vault
+      security-bootstrapper:
+        condition: service_started
+      vault:
+        condition: service_started
     environment:
       ADD_KNOWN_SECRETS: redisdb[app-rules-engine],redisdb[device-rest],message-bus[device-rest],redisdb[device-virtual],message-bus[device-virtual],redisdb[app-sample],message-bus[app-sample]
       ADD_SECRETSTORE_TOKENS: app-sample
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
-      EDGEX_GROUP: '2001'
+      API_GATEWAY_STATUS_PORT: "8100"
+      EDGEX_GROUP: "2001"
       EDGEX_SECURITY_SECRET_STORE: "true"
-      EDGEX_USER: '2002'
+      EDGEX_USER: "2002"
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SECUREMESSAGEBUS_TYPE: redis
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-security-secretstore-setup
     image: nexus3.edgexfoundry.org:10004/security-secretstore-setup-arm64:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     read_only: true
     restart: always
     security_opt:
@@ -947,46 +1330,82 @@ services:
     - /vault
     user: root:root
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - /tmp/edgex/secrets:/tmp/edgex/secrets:z
-    - kong:/tmp/kong:z
-    - kuiper-sources:/tmp/kuiper:z
-    - kuiper-connections:/tmp/kuiper-connections:z
-    - vault-config:/vault/config:z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets
+      target: /tmp/edgex/secrets
+      bind:
+        selinux: z
+        create_host_path: true
+    - type: volume
+      source: kong
+      target: /tmp/kong
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: kuiper-sources
+      target: /tmp/kuiper
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: kuiper-connections
+      target: /tmp/kuiper-connections
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: vault-config
+      target: /vault/config
+      bind:
+        selinux: z
+      volume: {}
   security-bootstrapper:
     container_name: edgex-security-bootstrapper
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
-      EDGEX_GROUP: '2001'
-      EDGEX_USER: '2002'
+      API_GATEWAY_STATUS_PORT: "8100"
+      EDGEX_GROUP: "2001"
+      EDGEX_USER: "2002"
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-security-bootstrapper
     image: nexus3.edgexfoundry.org:10004/security-bootstrapper-arm64:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: root:root
     volumes:
-    - edgex-init:/edgex-init:z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      bind:
+        selinux: z
+      volume: {}
   ui:
     container_name: edgex-ui-go
     environment:
@@ -995,9 +1414,12 @@ services:
     hostname: edgex-ui-go
     image: nexus3.edgexfoundry.org:10004/edgex-ui-arm64:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 4000:4000/tcp
+    - mode: ingress
+      target: 4000
+      published: "4000"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
@@ -1006,30 +1428,32 @@ services:
   vault:
     cap_add:
     - IPC_LOCK
-    command: server
+    command:
+    - server
     container_name: edgex-vault
     depends_on:
-    - security-bootstrapper
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/vault_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
       VAULT_ADDR: http://edgex-vault:8200
       VAULT_CONFIG_DIR: /vault/config
@@ -1037,32 +1461,69 @@ services:
     hostname: edgex-vault
     image: vault:1.11.5
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:8200:8200/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 8200
+      published: "8200"
+      protocol: tcp
     restart: always
     tmpfs:
     - /vault/config
     user: root:root
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - vault-file:/vault/file:z
-    - vault-logs:/vault/logs:z
-version: '3.7'
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: vault-file
+      target: /vault/file
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: vault-logs
+      target: /vault/logs
+      bind:
+        selinux: z
+      volume: {}
+networks:
+  edgex-network:
+    name: edgex_edgex-network
+    driver: bridge
 volumes:
-  consul-acl-token: {}
-  consul-config: {}
-  consul-data: {}
-  db-data: {}
-  edgex-init: {}
-  kong: {}
-  kuiper-connections: {}
-  kuiper-data: {}
-  kuiper-sources: {}
-  postgres-config: {}
-  postgres-data: {}
-  redis-config: {}
-  vault-config: {}
-  vault-file: {}
-  vault-logs: {}
-
+  consul-acl-token:
+    name: edgex_consul-acl-token
+  consul-config:
+    name: edgex_consul-config
+  consul-data:
+    name: edgex_consul-data
+  db-data:
+    name: edgex_db-data
+  edgex-init:
+    name: edgex_edgex-init
+  kong:
+    name: edgex_kong
+  kuiper-connections:
+    name: edgex_kuiper-connections
+  kuiper-data:
+    name: edgex_kuiper-data
+  kuiper-sources:
+    name: edgex_kuiper-sources
+  postgres-config:
+    name: edgex_postgres-config
+  postgres-data:
+    name: edgex_postgres-data
+  redis-config:
+    name: edgex_redis-config
+  vault-config:
+    name: edgex_vault-config
+  vault-file:
+    name: edgex_vault-file
+  vault-logs:
+    name: edgex_vault-logs

--- a/docker-compose-with-app-sample.yml
+++ b/docker-compose-with-app-sample.yml
@@ -24,22 +24,26 @@
 #
 # From the compose-builder folder use `make build` to regenerate all standard compose files variations
 #
-networks:
-  edgex-network:
-    driver: bridge
+name: edgex
 services:
   app-service-rules:
-    command: /app-service-configurable -cp=consul.http://edgex-core-consul:8500 --registry
+    command:
+    - /app-service-configurable
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
     container_name: edgex-app-rules-engine
     depends_on:
-    - consul
-    - data
-    - security-bootstrapper
+      consul:
+        condition: service_started
+      data:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/ready_to_run_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
@@ -52,113 +56,159 @@ services:
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SERVICE_HOST: edgex-app-rules-engine
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-app-rules-engine
     image: nexus3.edgexfoundry.org:10004/app-service-configurable:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59701:59701/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59701
+      published: "59701"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - /tmp/edgex/secrets/app-rules-engine:/tmp/edgex/secrets/app-rules-engine:ro,z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/app-rules-engine
+      target: /tmp/edgex/secrets/app-rules-engine
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   app-service-sample:
-    command: /app-service-configurable -cp=consul.http://edgex-core-consul:8500 --registry
+    command:
+    - /app-service-configurable
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
     container_name: edgex-app-sample
     depends_on:
-    - consul
-    - data
-    - security-bootstrapper
+      consul:
+        condition: service_started
+      data:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/ready_to_run_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
       CLIENTS_SUPPORT_NOTIFICATIONS_HOST: edgex-support-notifications
       CLIENTS_SUPPORT_SCHEDULER_HOST: edgex-support-scheduler
-      DATABASES_PRIMARY_HOST: edgex-redis
       DATABASE_HOST: edgex-redis
+      DATABASES_PRIMARY_HOST: edgex-redis
       EDGEX_PROFILE: sample
       EDGEX_SECURITY_SECRET_STORE: "true"
       MESSAGEBUS_HOST: edgex-redis
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SERVICE_HOST: edgex-app-sample
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-app-sample
     image: nexus3.edgexfoundry.org:10004/app-service-configurable:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59700:59700/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59700
+      published: "59700"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - /tmp/edgex/secrets/app-sample:/tmp/edgex/secrets/app-sample:ro,z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/app-sample
+      target: /tmp/edgex/secrets/app-sample
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   command:
-    command: /core-command -cp=consul.http://edgex-core-consul:8500 --registry
+    command:
+    - /core-command
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
     container_name: edgex-core-command
     depends_on:
-    - consul
-    - database
-    - metadata
-    - secretstore-setup
-    - security-bootstrapper
+      consul:
+        condition: service_started
+      database:
+        condition: service_started
+      metadata:
+        condition: service_started
+      secretstore-setup:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/ready_to_run_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
@@ -171,110 +221,173 @@ services:
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SERVICE_HOST: edgex-core-command
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-core-command
     image: nexus3.edgexfoundry.org:10004/core-command:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59882:59882/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59882
+      published: "59882"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - /tmp/edgex/secrets/core-command:/tmp/edgex/secrets/core-command:ro,z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/core-command
+      target: /tmp/edgex/secrets/core-command
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   consul:
-    command: agent -ui -bootstrap -server -client 0.0.0.0
+    command:
+    - agent
+    - -ui
+    - -bootstrap
+    - -server
+    - -client
+    - 0.0.0.0
     container_name: edgex-core-consul
     depends_on:
-    - security-bootstrapper
-    - vault
+      security-bootstrapper:
+        condition: service_started
+      vault:
+        condition: service_started
     entrypoint:
     - /edgex-init/consul_wait_install.sh
     environment:
       ADD_REGISTRY_ACL_ROLES: app-sample
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
-      EDGEX_GROUP: '2001'
+      API_GATEWAY_STATUS_PORT: "8100"
+      EDGEX_GROUP: "2001"
       EDGEX_SECURITY_SECRET_STORE: "true"
-      EDGEX_USER: '2002'
+      EDGEX_USER: "2002"
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_ACL_BOOTSTRAPTOKENPATH: /tmp/edgex/secrets/consul-acl-token/bootstrap_token.json
       STAGEGATE_REGISTRY_ACL_MANAGEMENTTOKENPATH: /tmp/edgex/secrets/consul-acl-token/mgmt_token.json
       STAGEGATE_REGISTRY_ACL_SENTINELFILEPATH: /consul/config/consul_acl_done
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-core-consul
     image: consul:1.13
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:8500:8500/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 8500
+      published: "8500"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: root:root
     volumes:
-    - consul-config:/consul/config:z
-    - consul-data:/consul/data:z
-    - edgex-init:/edgex-init:ro,z
-    - consul-acl-token:/tmp/edgex/secrets/consul-acl-token:z
-    - /tmp/edgex/secrets/edgex-consul:/tmp/edgex/secrets/edgex-consul:ro,z
+    - type: volume
+      source: consul-config
+      target: /consul/config
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: consul-data
+      target: /consul/data
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: consul-acl-token
+      target: /tmp/edgex/secrets/consul-acl-token
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/edgex-consul
+      target: /tmp/edgex/secrets/edgex-consul
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   data:
-    command: /core-data -cp=consul.http://edgex-core-consul:8500 --registry
+    command:
+    - /core-data
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
     container_name: edgex-core-data
     depends_on:
-    - consul
-    - database
-    - metadata
-    - secretstore-setup
-    - security-bootstrapper
+      consul:
+        condition: service_started
+      database:
+        condition: service_started
+      metadata:
+        condition: service_started
+      secretstore-setup:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/ready_to_run_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
@@ -286,52 +399,74 @@ services:
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SECRETSTORE_TOKENFILE: /tmp/edgex/secrets/core-data/secrets-token.json
       SERVICE_HOST: edgex-core-data
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-core-data
     image: nexus3.edgexfoundry.org:10004/core-data:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:5563:5563/tcp
-    - 127.0.0.1:59880:59880/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 5563
+      published: "5563"
+      protocol: tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59880
+      published: "59880"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - /tmp/edgex/secrets/core-data:/tmp/edgex/secrets/core-data:ro,z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/core-data
+      target: /tmp/edgex/secrets/core-data
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   database:
     container_name: edgex-redis
     depends_on:
-    - secretstore-setup
-    - security-bootstrapper
+      secretstore-setup:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/redis_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
@@ -344,31 +479,35 @@ services:
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-redis
     image: redis:7.0-alpine
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:6379:6379/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 6379
+      published: "6379"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
@@ -377,23 +516,52 @@ services:
     - /run
     user: root:root
     volumes:
-    - db-data:/data:z
-    - edgex-init:/edgex-init:ro,z
-    - redis-config:/run/redis/conf:z
-    - /tmp/edgex/secrets/security-bootstrapper-redis:/tmp/edgex/secrets/security-bootstrapper-redis:ro,z
+    - type: volume
+      source: db-data
+      target: /data
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: redis-config
+      target: /run/redis/conf
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/security-bootstrapper-redis
+      target: /tmp/edgex/secrets/security-bootstrapper-redis
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   device-rest:
-    command: /device-rest -cp=consul.http://edgex-core-consul:8500 --registry
+    command:
+    - /device-rest
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
     container_name: edgex-device-rest
     depends_on:
-    - consul
-    - data
-    - metadata
-    - security-bootstrapper
+      consul:
+        condition: service_started
+      data:
+        condition: service_started
+      metadata:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/ready_to_run_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
@@ -405,53 +573,76 @@ services:
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SERVICE_HOST: edgex-device-rest
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-device-rest
     image: nexus3.edgexfoundry.org:10004/device-rest:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59986:59986/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59986
+      published: "59986"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - /tmp/edgex/secrets/device-rest:/tmp/edgex/secrets/device-rest:ro,z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/device-rest
+      target: /tmp/edgex/secrets/device-rest
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   device-virtual:
-    command: /device-virtual -cp=consul.http://edgex-core-consul:8500 --registry
+    command:
+    - /device-virtual
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
     container_name: edgex-device-virtual
     depends_on:
-    - consul
-    - data
-    - metadata
-    - security-bootstrapper
+      consul:
+        condition: service_started
+      data:
+        condition: service_started
+      metadata:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/ready_to_run_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
@@ -463,57 +654,75 @@ services:
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SERVICE_HOST: edgex-device-virtual
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-device-virtual
     image: nexus3.edgexfoundry.org:10004/device-virtual:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59900:59900/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59900
+      published: "59900"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - /tmp/edgex/secrets/device-virtual:/tmp/edgex/secrets/device-virtual:ro,z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/device-virtual
+      target: /tmp/edgex/secrets/device-virtual
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   kong:
     container_name: edgex-kong
     depends_on:
-    - kong-db
-    - security-bootstrapper
+      kong-db:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/kong_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       KONG_ADMIN_ACCESS_LOG: /dev/stdout
       KONG_ADMIN_ERROR_LOG: /dev/stderr
       KONG_ADMIN_LISTEN: 127.0.0.1:8001, 127.0.0.1:8444 ssl
       KONG_DATABASE: postgres
       KONG_DNS_ORDER: LAST,A,CNAME
-      KONG_DNS_VALID_TTL: '1'
-      KONG_NGINX_WORKER_PROCESSES: '1'
+      KONG_DNS_VALID_TTL: "1"
+      KONG_NGINX_WORKER_PROCESSES: "1"
       KONG_PG_HOST: edgex-kong-db
       KONG_PG_PASSWORD_FILE: /tmp/postgres-config/.pgpassword
       KONG_PROXY_ACCESS_LOG: /dev/stdout
@@ -522,28 +731,38 @@ services:
       KONG_STATUS_LISTEN: 0.0.0.0:8100
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-kong
     image: kong:2.8
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 8000:8000/tcp
-    - 127.0.0.1:8100:8100/tcp
-    - 8443:8443/tcp
+    - mode: ingress
+      target: 8000
+      published: "8000"
+      protocol: tcp
+    - mode: ingress
+      target: 8443
+      published: "8443"
+      protocol: tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 8100
+      published: "8100"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
@@ -554,50 +773,77 @@ services:
     tty: true
     user: kong:nogroup
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - /tmp/edgex/secrets/security-proxy-setup:/tmp/edgex/secrets/security-proxy-setup:ro,z
-    - postgres-config:/tmp/postgres-config:z
-    - kong:/usr/local/kong:z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: postgres-config
+      target: /tmp/postgres-config
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: kong
+      target: /usr/local/kong
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/security-proxy-setup
+      target: /tmp/edgex/secrets/security-proxy-setup
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   kong-db:
     container_name: edgex-kong-db
     depends_on:
-    - security-bootstrapper
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/postgres_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       EDGEX_SECURITY_SECRET_STORE: "true"
       POSTGRES_DB: kong
       POSTGRES_PASSWORD_FILE: /tmp/postgres-config/.pgpassword
       POSTGRES_USER: kong
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-kong-db
     image: postgres:13.8-alpine
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:5432:5432/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 5432
+      published: "5432"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
@@ -608,23 +854,47 @@ services:
     - /run
     user: root:root
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - postgres-config:/tmp/postgres-config:z
-    - postgres-data:/var/lib/postgresql/data:z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: postgres-data
+      target: /var/lib/postgresql/data
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: postgres-config
+      target: /tmp/postgres-config
+      bind:
+        selinux: z
+      volume: {}
   metadata:
-    command: /core-metadata -cp=consul.http://edgex-core-consul:8500 --registry
+    command:
+    - /core-metadata
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
     container_name: edgex-core-metadata
     depends_on:
-    - consul
-    - database
-    - notifications
-    - secretstore-setup
-    - security-bootstrapper
+      consul:
+        condition: service_started
+      database:
+        condition: service_started
+      notifications:
+        condition: service_started
+      secretstore-setup:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/ready_to_run_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
@@ -637,53 +907,76 @@ services:
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SERVICE_HOST: edgex-core-metadata
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-core-metadata
     image: nexus3.edgexfoundry.org:10004/core-metadata:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59881:59881/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59881
+      published: "59881"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - /tmp/edgex/secrets/core-metadata:/tmp/edgex/secrets/core-metadata:ro,z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/core-metadata
+      target: /tmp/edgex/secrets/core-metadata
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   notifications:
-    command: /support-notifications -cp=consul.http://edgex-core-consul:8500 --registry
+    command:
+    - /support-notifications
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
     container_name: edgex-support-notifications
     depends_on:
-    - consul
-    - database
-    - secretstore-setup
-    - security-bootstrapper
+      consul:
+        condition: service_started
+      database:
+        condition: service_started
+      secretstore-setup:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/ready_to_run_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
@@ -695,52 +988,71 @@ services:
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SERVICE_HOST: edgex-support-notifications
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-support-notifications
     image: nexus3.edgexfoundry.org:10004/support-notifications:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59860:59860/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59860
+      published: "59860"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - /tmp/edgex/secrets/support-notifications:/tmp/edgex/secrets/support-notifications:ro,z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/support-notifications
+      target: /tmp/edgex/secrets/support-notifications
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   proxy-setup:
     container_name: edgex-security-proxy-setup
     depends_on:
-    - kong
-    - secretstore-setup
-    - security-bootstrapper
+      kong:
+        condition: service_started
+      secretstore-setup:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/proxy_setup_wait_install.sh
     environment:
-      ADD_PROXY_ROUTE: ''
+      ADD_PROXY_ROUTE: ""
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       EDGEX_SECURITY_SECRET_STORE: "true"
       KONGURL_SERVER: edgex-kong
       PROXY_SETUP_HOST: edgex-security-proxy-setup
@@ -754,104 +1066,157 @@ services:
       ROUTES_SUPPORT_SCHEDULER_HOST: edgex-support-scheduler
       ROUTES_SYS_MGMT_AGENT_HOST: edgex-sys-mgmt-agent
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-security-proxy-setup
     image: nexus3.edgexfoundry.org:10004/security-proxy-setup:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     read_only: true
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - consul-acl-token:/tmp/edgex/secrets/consul-acl-token:ro,z
-    - /tmp/edgex/secrets/security-proxy-setup:/tmp/edgex/secrets/security-proxy-setup:ro,z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/security-proxy-setup
+      target: /tmp/edgex/secrets/security-proxy-setup
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
+    - type: volume
+      source: consul-acl-token
+      target: /tmp/edgex/secrets/consul-acl-token
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
   rulesengine:
     container_name: edgex-kuiper
     depends_on:
-    - database
-    - secretstore-setup
-    - security-bootstrapper
+      database:
+        condition: service_started
+      secretstore-setup:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/kuiper_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
-      CONNECTION__EDGEX__REDISMSGBUS__PORT: 6379
+      API_GATEWAY_STATUS_PORT: "8100"
+      CONNECTION__EDGEX__REDISMSGBUS__PORT: "6379"
       CONNECTION__EDGEX__REDISMSGBUS__PROTOCOL: redis
       CONNECTION__EDGEX__REDISMSGBUS__SERVER: edgex-redis
       CONNECTION__EDGEX__REDISMSGBUS__TYPE: redis
-      EDGEX__DEFAULT__PORT: 6379
+      EDGEX__DEFAULT__PORT: "6379"
       EDGEX__DEFAULT__PROTOCOL: redis
       EDGEX__DEFAULT__SERVER: edgex-redis
       EDGEX__DEFAULT__TOPIC: rules-events
       EDGEX__DEFAULT__TYPE: redis
       KUIPER__BASIC__CONSOLELOG: "true"
-      KUIPER__BASIC__RESTPORT: 59720
+      KUIPER__BASIC__RESTPORT: "59720"
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-kuiper
     image: lfedge/ekuiper:1.7-alpine
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59720:59720/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59720
+      published: "59720"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: kuiper:kuiper
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - kuiper-data:/kuiper/data:z
-    - kuiper-connections:/kuiper/etc/connections:z
-    - kuiper-sources:/kuiper/etc/sources:z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: kuiper-data
+      target: /kuiper/data
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: kuiper-connections
+      target: /kuiper/etc/connections
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: kuiper-sources
+      target: /kuiper/etc/sources
+      bind:
+        selinux: z
+      volume: {}
   scheduler:
-    command: /support-scheduler -cp=consul.http://edgex-core-consul:8500 --registry
+    command:
+    - /support-scheduler
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
     container_name: edgex-support-scheduler
     depends_on:
-    - consul
-    - database
-    - secretstore-setup
-    - security-bootstrapper
+      consul:
+        condition: service_started
+      database:
+        condition: service_started
+      secretstore-setup:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/ready_to_run_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
@@ -865,79 +1230,97 @@ services:
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SERVICE_HOST: edgex-support-scheduler
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-support-scheduler
     image: nexus3.edgexfoundry.org:10004/support-scheduler:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59861:59861/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59861
+      published: "59861"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - /tmp/edgex/secrets/support-scheduler:/tmp/edgex/secrets/support-scheduler:ro,z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/support-scheduler
+      target: /tmp/edgex/secrets/support-scheduler
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   secretstore-setup:
     container_name: edgex-security-secretstore-setup
     depends_on:
-    - security-bootstrapper
-    - vault
+      security-bootstrapper:
+        condition: service_started
+      vault:
+        condition: service_started
     environment:
       ADD_KNOWN_SECRETS: redisdb[app-rules-engine],redisdb[device-rest],message-bus[device-rest],redisdb[device-virtual],message-bus[device-virtual],redisdb[app-sample],message-bus[app-sample]
       ADD_SECRETSTORE_TOKENS: app-sample
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
-      EDGEX_GROUP: '2001'
+      API_GATEWAY_STATUS_PORT: "8100"
+      EDGEX_GROUP: "2001"
       EDGEX_SECURITY_SECRET_STORE: "true"
-      EDGEX_USER: '2002'
+      EDGEX_USER: "2002"
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SECUREMESSAGEBUS_TYPE: redis
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-security-secretstore-setup
     image: nexus3.edgexfoundry.org:10004/security-secretstore-setup:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     read_only: true
     restart: always
     security_opt:
@@ -947,46 +1330,82 @@ services:
     - /vault
     user: root:root
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - /tmp/edgex/secrets:/tmp/edgex/secrets:z
-    - kong:/tmp/kong:z
-    - kuiper-sources:/tmp/kuiper:z
-    - kuiper-connections:/tmp/kuiper-connections:z
-    - vault-config:/vault/config:z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets
+      target: /tmp/edgex/secrets
+      bind:
+        selinux: z
+        create_host_path: true
+    - type: volume
+      source: kong
+      target: /tmp/kong
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: kuiper-sources
+      target: /tmp/kuiper
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: kuiper-connections
+      target: /tmp/kuiper-connections
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: vault-config
+      target: /vault/config
+      bind:
+        selinux: z
+      volume: {}
   security-bootstrapper:
     container_name: edgex-security-bootstrapper
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
-      EDGEX_GROUP: '2001'
-      EDGEX_USER: '2002'
+      API_GATEWAY_STATUS_PORT: "8100"
+      EDGEX_GROUP: "2001"
+      EDGEX_USER: "2002"
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-security-bootstrapper
     image: nexus3.edgexfoundry.org:10004/security-bootstrapper:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: root:root
     volumes:
-    - edgex-init:/edgex-init:z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      bind:
+        selinux: z
+      volume: {}
   ui:
     container_name: edgex-ui-go
     environment:
@@ -995,9 +1414,12 @@ services:
     hostname: edgex-ui-go
     image: nexus3.edgexfoundry.org:10004/edgex-ui:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 4000:4000/tcp
+    - mode: ingress
+      target: 4000
+      published: "4000"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
@@ -1006,30 +1428,32 @@ services:
   vault:
     cap_add:
     - IPC_LOCK
-    command: server
+    command:
+    - server
     container_name: edgex-vault
     depends_on:
-    - security-bootstrapper
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/vault_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
       VAULT_ADDR: http://edgex-vault:8200
       VAULT_CONFIG_DIR: /vault/config
@@ -1037,32 +1461,69 @@ services:
     hostname: edgex-vault
     image: vault:1.11.5
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:8200:8200/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 8200
+      published: "8200"
+      protocol: tcp
     restart: always
     tmpfs:
     - /vault/config
     user: root:root
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - vault-file:/vault/file:z
-    - vault-logs:/vault/logs:z
-version: '3.7'
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: vault-file
+      target: /vault/file
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: vault-logs
+      target: /vault/logs
+      bind:
+        selinux: z
+      volume: {}
+networks:
+  edgex-network:
+    name: edgex_edgex-network
+    driver: bridge
 volumes:
-  consul-acl-token: {}
-  consul-config: {}
-  consul-data: {}
-  db-data: {}
-  edgex-init: {}
-  kong: {}
-  kuiper-connections: {}
-  kuiper-data: {}
-  kuiper-sources: {}
-  postgres-config: {}
-  postgres-data: {}
-  redis-config: {}
-  vault-config: {}
-  vault-file: {}
-  vault-logs: {}
-
+  consul-acl-token:
+    name: edgex_consul-acl-token
+  consul-config:
+    name: edgex_consul-config
+  consul-data:
+    name: edgex_consul-data
+  db-data:
+    name: edgex_db-data
+  edgex-init:
+    name: edgex_edgex-init
+  kong:
+    name: edgex_kong
+  kuiper-connections:
+    name: edgex_kuiper-connections
+  kuiper-data:
+    name: edgex_kuiper-data
+  kuiper-sources:
+    name: edgex_kuiper-sources
+  postgres-config:
+    name: edgex_postgres-config
+  postgres-data:
+    name: edgex_postgres-data
+  redis-config:
+    name: edgex_redis-config
+  vault-config:
+    name: edgex_vault-config
+  vault-file:
+    name: edgex_vault-file
+  vault-logs:
+    name: edgex_vault-logs

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,22 +24,26 @@
 #
 # From the compose-builder folder use `make build` to regenerate all standard compose files variations
 #
-networks:
-  edgex-network:
-    driver: bridge
+name: edgex
 services:
   app-service-rules:
-    command: /app-service-configurable -cp=consul.http://edgex-core-consul:8500 --registry
+    command:
+    - /app-service-configurable
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
     container_name: edgex-app-rules-engine
     depends_on:
-    - consul
-    - data
-    - security-bootstrapper
+      consul:
+        condition: service_started
+      data:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/ready_to_run_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
@@ -52,54 +56,78 @@ services:
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SERVICE_HOST: edgex-app-rules-engine
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-app-rules-engine
     image: nexus3.edgexfoundry.org:10004/app-service-configurable:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59701:59701/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59701
+      published: "59701"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - /tmp/edgex/secrets/app-rules-engine:/tmp/edgex/secrets/app-rules-engine:ro,z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/app-rules-engine
+      target: /tmp/edgex/secrets/app-rules-engine
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   command:
-    command: /core-command -cp=consul.http://edgex-core-consul:8500 --registry
+    command:
+    - /core-command
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
     container_name: edgex-core-command
     depends_on:
-    - consul
-    - database
-    - metadata
-    - secretstore-setup
-    - security-bootstrapper
+      consul:
+        condition: service_started
+      database:
+        condition: service_started
+      metadata:
+        condition: service_started
+      secretstore-setup:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/ready_to_run_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
@@ -112,110 +140,173 @@ services:
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SERVICE_HOST: edgex-core-command
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-core-command
     image: nexus3.edgexfoundry.org:10004/core-command:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59882:59882/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59882
+      published: "59882"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - /tmp/edgex/secrets/core-command:/tmp/edgex/secrets/core-command:ro,z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/core-command
+      target: /tmp/edgex/secrets/core-command
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   consul:
-    command: agent -ui -bootstrap -server -client 0.0.0.0
+    command:
+    - agent
+    - -ui
+    - -bootstrap
+    - -server
+    - -client
+    - 0.0.0.0
     container_name: edgex-core-consul
     depends_on:
-    - security-bootstrapper
-    - vault
+      security-bootstrapper:
+        condition: service_started
+      vault:
+        condition: service_started
     entrypoint:
     - /edgex-init/consul_wait_install.sh
     environment:
-      ADD_REGISTRY_ACL_ROLES: ''
+      ADD_REGISTRY_ACL_ROLES: ""
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
-      EDGEX_GROUP: '2001'
+      API_GATEWAY_STATUS_PORT: "8100"
+      EDGEX_GROUP: "2001"
       EDGEX_SECURITY_SECRET_STORE: "true"
-      EDGEX_USER: '2002'
+      EDGEX_USER: "2002"
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_ACL_BOOTSTRAPTOKENPATH: /tmp/edgex/secrets/consul-acl-token/bootstrap_token.json
       STAGEGATE_REGISTRY_ACL_MANAGEMENTTOKENPATH: /tmp/edgex/secrets/consul-acl-token/mgmt_token.json
       STAGEGATE_REGISTRY_ACL_SENTINELFILEPATH: /consul/config/consul_acl_done
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-core-consul
     image: consul:1.13
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:8500:8500/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 8500
+      published: "8500"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: root:root
     volumes:
-    - consul-config:/consul/config:z
-    - consul-data:/consul/data:z
-    - edgex-init:/edgex-init:ro,z
-    - consul-acl-token:/tmp/edgex/secrets/consul-acl-token:z
-    - /tmp/edgex/secrets/edgex-consul:/tmp/edgex/secrets/edgex-consul:ro,z
+    - type: volume
+      source: consul-config
+      target: /consul/config
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: consul-data
+      target: /consul/data
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: consul-acl-token
+      target: /tmp/edgex/secrets/consul-acl-token
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/edgex-consul
+      target: /tmp/edgex/secrets/edgex-consul
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   data:
-    command: /core-data -cp=consul.http://edgex-core-consul:8500 --registry
+    command:
+    - /core-data
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
     container_name: edgex-core-data
     depends_on:
-    - consul
-    - database
-    - metadata
-    - secretstore-setup
-    - security-bootstrapper
+      consul:
+        condition: service_started
+      database:
+        condition: service_started
+      metadata:
+        condition: service_started
+      secretstore-setup:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/ready_to_run_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
@@ -227,52 +318,74 @@ services:
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SECRETSTORE_TOKENFILE: /tmp/edgex/secrets/core-data/secrets-token.json
       SERVICE_HOST: edgex-core-data
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-core-data
     image: nexus3.edgexfoundry.org:10004/core-data:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:5563:5563/tcp
-    - 127.0.0.1:59880:59880/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 5563
+      published: "5563"
+      protocol: tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59880
+      published: "59880"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - /tmp/edgex/secrets/core-data:/tmp/edgex/secrets/core-data:ro,z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/core-data
+      target: /tmp/edgex/secrets/core-data
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   database:
     container_name: edgex-redis
     depends_on:
-    - secretstore-setup
-    - security-bootstrapper
+      secretstore-setup:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/redis_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
@@ -285,31 +398,35 @@ services:
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-redis
     image: redis:7.0-alpine
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:6379:6379/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 6379
+      published: "6379"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
@@ -318,23 +435,52 @@ services:
     - /run
     user: root:root
     volumes:
-    - db-data:/data:z
-    - edgex-init:/edgex-init:ro,z
-    - redis-config:/run/redis/conf:z
-    - /tmp/edgex/secrets/security-bootstrapper-redis:/tmp/edgex/secrets/security-bootstrapper-redis:ro,z
+    - type: volume
+      source: db-data
+      target: /data
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: redis-config
+      target: /run/redis/conf
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/security-bootstrapper-redis
+      target: /tmp/edgex/secrets/security-bootstrapper-redis
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   device-rest:
-    command: /device-rest -cp=consul.http://edgex-core-consul:8500 --registry
+    command:
+    - /device-rest
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
     container_name: edgex-device-rest
     depends_on:
-    - consul
-    - data
-    - metadata
-    - security-bootstrapper
+      consul:
+        condition: service_started
+      data:
+        condition: service_started
+      metadata:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/ready_to_run_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
@@ -346,53 +492,76 @@ services:
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SERVICE_HOST: edgex-device-rest
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-device-rest
     image: nexus3.edgexfoundry.org:10004/device-rest:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59986:59986/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59986
+      published: "59986"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - /tmp/edgex/secrets/device-rest:/tmp/edgex/secrets/device-rest:ro,z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/device-rest
+      target: /tmp/edgex/secrets/device-rest
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   device-virtual:
-    command: /device-virtual -cp=consul.http://edgex-core-consul:8500 --registry
+    command:
+    - /device-virtual
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
     container_name: edgex-device-virtual
     depends_on:
-    - consul
-    - data
-    - metadata
-    - security-bootstrapper
+      consul:
+        condition: service_started
+      data:
+        condition: service_started
+      metadata:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/ready_to_run_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
@@ -404,57 +573,75 @@ services:
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SERVICE_HOST: edgex-device-virtual
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-device-virtual
     image: nexus3.edgexfoundry.org:10004/device-virtual:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59900:59900/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59900
+      published: "59900"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - /tmp/edgex/secrets/device-virtual:/tmp/edgex/secrets/device-virtual:ro,z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/device-virtual
+      target: /tmp/edgex/secrets/device-virtual
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   kong:
     container_name: edgex-kong
     depends_on:
-    - kong-db
-    - security-bootstrapper
+      kong-db:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/kong_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       KONG_ADMIN_ACCESS_LOG: /dev/stdout
       KONG_ADMIN_ERROR_LOG: /dev/stderr
       KONG_ADMIN_LISTEN: 127.0.0.1:8001, 127.0.0.1:8444 ssl
       KONG_DATABASE: postgres
       KONG_DNS_ORDER: LAST,A,CNAME
-      KONG_DNS_VALID_TTL: '1'
-      KONG_NGINX_WORKER_PROCESSES: '1'
+      KONG_DNS_VALID_TTL: "1"
+      KONG_NGINX_WORKER_PROCESSES: "1"
       KONG_PG_HOST: edgex-kong-db
       KONG_PG_PASSWORD_FILE: /tmp/postgres-config/.pgpassword
       KONG_PROXY_ACCESS_LOG: /dev/stdout
@@ -463,28 +650,38 @@ services:
       KONG_STATUS_LISTEN: 0.0.0.0:8100
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-kong
     image: kong:2.8
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 8000:8000/tcp
-    - 127.0.0.1:8100:8100/tcp
-    - 8443:8443/tcp
+    - mode: ingress
+      target: 8000
+      published: "8000"
+      protocol: tcp
+    - mode: ingress
+      target: 8443
+      published: "8443"
+      protocol: tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 8100
+      published: "8100"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
@@ -495,50 +692,77 @@ services:
     tty: true
     user: kong:nogroup
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - /tmp/edgex/secrets/security-proxy-setup:/tmp/edgex/secrets/security-proxy-setup:ro,z
-    - postgres-config:/tmp/postgres-config:z
-    - kong:/usr/local/kong:z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: postgres-config
+      target: /tmp/postgres-config
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: kong
+      target: /usr/local/kong
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/security-proxy-setup
+      target: /tmp/edgex/secrets/security-proxy-setup
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   kong-db:
     container_name: edgex-kong-db
     depends_on:
-    - security-bootstrapper
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/postgres_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       EDGEX_SECURITY_SECRET_STORE: "true"
       POSTGRES_DB: kong
       POSTGRES_PASSWORD_FILE: /tmp/postgres-config/.pgpassword
       POSTGRES_USER: kong
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-kong-db
     image: postgres:13.8-alpine
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:5432:5432/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 5432
+      published: "5432"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
@@ -549,23 +773,47 @@ services:
     - /run
     user: root:root
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - postgres-config:/tmp/postgres-config:z
-    - postgres-data:/var/lib/postgresql/data:z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: postgres-data
+      target: /var/lib/postgresql/data
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: postgres-config
+      target: /tmp/postgres-config
+      bind:
+        selinux: z
+      volume: {}
   metadata:
-    command: /core-metadata -cp=consul.http://edgex-core-consul:8500 --registry
+    command:
+    - /core-metadata
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
     container_name: edgex-core-metadata
     depends_on:
-    - consul
-    - database
-    - notifications
-    - secretstore-setup
-    - security-bootstrapper
+      consul:
+        condition: service_started
+      database:
+        condition: service_started
+      notifications:
+        condition: service_started
+      secretstore-setup:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/ready_to_run_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
@@ -578,53 +826,76 @@ services:
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SERVICE_HOST: edgex-core-metadata
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-core-metadata
     image: nexus3.edgexfoundry.org:10004/core-metadata:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59881:59881/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59881
+      published: "59881"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - /tmp/edgex/secrets/core-metadata:/tmp/edgex/secrets/core-metadata:ro,z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/core-metadata
+      target: /tmp/edgex/secrets/core-metadata
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   notifications:
-    command: /support-notifications -cp=consul.http://edgex-core-consul:8500 --registry
+    command:
+    - /support-notifications
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
     container_name: edgex-support-notifications
     depends_on:
-    - consul
-    - database
-    - secretstore-setup
-    - security-bootstrapper
+      consul:
+        condition: service_started
+      database:
+        condition: service_started
+      secretstore-setup:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/ready_to_run_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
@@ -636,52 +907,71 @@ services:
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SERVICE_HOST: edgex-support-notifications
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-support-notifications
     image: nexus3.edgexfoundry.org:10004/support-notifications:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59860:59860/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59860
+      published: "59860"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - /tmp/edgex/secrets/support-notifications:/tmp/edgex/secrets/support-notifications:ro,z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/support-notifications
+      target: /tmp/edgex/secrets/support-notifications
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   proxy-setup:
     container_name: edgex-security-proxy-setup
     depends_on:
-    - kong
-    - secretstore-setup
-    - security-bootstrapper
+      kong:
+        condition: service_started
+      secretstore-setup:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/proxy_setup_wait_install.sh
     environment:
-      ADD_PROXY_ROUTE: ''
+      ADD_PROXY_ROUTE: ""
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       EDGEX_SECURITY_SECRET_STORE: "true"
       KONGURL_SERVER: edgex-kong
       PROXY_SETUP_HOST: edgex-security-proxy-setup
@@ -695,104 +985,157 @@ services:
       ROUTES_SUPPORT_SCHEDULER_HOST: edgex-support-scheduler
       ROUTES_SYS_MGMT_AGENT_HOST: edgex-sys-mgmt-agent
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-security-proxy-setup
     image: nexus3.edgexfoundry.org:10004/security-proxy-setup:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     read_only: true
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - consul-acl-token:/tmp/edgex/secrets/consul-acl-token:ro,z
-    - /tmp/edgex/secrets/security-proxy-setup:/tmp/edgex/secrets/security-proxy-setup:ro,z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/security-proxy-setup
+      target: /tmp/edgex/secrets/security-proxy-setup
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
+    - type: volume
+      source: consul-acl-token
+      target: /tmp/edgex/secrets/consul-acl-token
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
   rulesengine:
     container_name: edgex-kuiper
     depends_on:
-    - database
-    - secretstore-setup
-    - security-bootstrapper
+      database:
+        condition: service_started
+      secretstore-setup:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/kuiper_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
-      CONNECTION__EDGEX__REDISMSGBUS__PORT: 6379
+      API_GATEWAY_STATUS_PORT: "8100"
+      CONNECTION__EDGEX__REDISMSGBUS__PORT: "6379"
       CONNECTION__EDGEX__REDISMSGBUS__PROTOCOL: redis
       CONNECTION__EDGEX__REDISMSGBUS__SERVER: edgex-redis
       CONNECTION__EDGEX__REDISMSGBUS__TYPE: redis
-      EDGEX__DEFAULT__PORT: 6379
+      EDGEX__DEFAULT__PORT: "6379"
       EDGEX__DEFAULT__PROTOCOL: redis
       EDGEX__DEFAULT__SERVER: edgex-redis
       EDGEX__DEFAULT__TOPIC: rules-events
       EDGEX__DEFAULT__TYPE: redis
       KUIPER__BASIC__CONSOLELOG: "true"
-      KUIPER__BASIC__RESTPORT: 59720
+      KUIPER__BASIC__RESTPORT: "59720"
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-kuiper
     image: lfedge/ekuiper:1.7-alpine
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59720:59720/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59720
+      published: "59720"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: kuiper:kuiper
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - kuiper-data:/kuiper/data:z
-    - kuiper-connections:/kuiper/etc/connections:z
-    - kuiper-sources:/kuiper/etc/sources:z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: kuiper-data
+      target: /kuiper/data
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: kuiper-connections
+      target: /kuiper/etc/connections
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: kuiper-sources
+      target: /kuiper/etc/sources
+      bind:
+        selinux: z
+      volume: {}
   scheduler:
-    command: /support-scheduler -cp=consul.http://edgex-core-consul:8500 --registry
+    command:
+    - /support-scheduler
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
     container_name: edgex-support-scheduler
     depends_on:
-    - consul
-    - database
-    - secretstore-setup
-    - security-bootstrapper
+      consul:
+        condition: service_started
+      database:
+        condition: service_started
+      secretstore-setup:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/ready_to_run_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
@@ -806,79 +1149,97 @@ services:
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SERVICE_HOST: edgex-support-scheduler
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-support-scheduler
     image: nexus3.edgexfoundry.org:10004/support-scheduler:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59861:59861/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59861
+      published: "59861"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - /tmp/edgex/secrets/support-scheduler:/tmp/edgex/secrets/support-scheduler:ro,z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/support-scheduler
+      target: /tmp/edgex/secrets/support-scheduler
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   secretstore-setup:
     container_name: edgex-security-secretstore-setup
     depends_on:
-    - security-bootstrapper
-    - vault
+      security-bootstrapper:
+        condition: service_started
+      vault:
+        condition: service_started
     environment:
       ADD_KNOWN_SECRETS: redisdb[app-rules-engine],redisdb[device-rest],message-bus[device-rest],redisdb[device-virtual],message-bus[device-virtual]
-      ADD_SECRETSTORE_TOKENS: ''
+      ADD_SECRETSTORE_TOKENS: ""
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
-      EDGEX_GROUP: '2001'
+      API_GATEWAY_STATUS_PORT: "8100"
+      EDGEX_GROUP: "2001"
       EDGEX_SECURITY_SECRET_STORE: "true"
-      EDGEX_USER: '2002'
+      EDGEX_USER: "2002"
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SECUREMESSAGEBUS_TYPE: redis
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-security-secretstore-setup
     image: nexus3.edgexfoundry.org:10004/security-secretstore-setup:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     read_only: true
     restart: always
     security_opt:
@@ -888,46 +1249,82 @@ services:
     - /vault
     user: root:root
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - /tmp/edgex/secrets:/tmp/edgex/secrets:z
-    - kong:/tmp/kong:z
-    - kuiper-sources:/tmp/kuiper:z
-    - kuiper-connections:/tmp/kuiper-connections:z
-    - vault-config:/vault/config:z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets
+      target: /tmp/edgex/secrets
+      bind:
+        selinux: z
+        create_host_path: true
+    - type: volume
+      source: kong
+      target: /tmp/kong
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: kuiper-sources
+      target: /tmp/kuiper
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: kuiper-connections
+      target: /tmp/kuiper-connections
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: vault-config
+      target: /vault/config
+      bind:
+        selinux: z
+      volume: {}
   security-bootstrapper:
     container_name: edgex-security-bootstrapper
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
-      EDGEX_GROUP: '2001'
-      EDGEX_USER: '2002'
+      API_GATEWAY_STATUS_PORT: "8100"
+      EDGEX_GROUP: "2001"
+      EDGEX_USER: "2002"
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-security-bootstrapper
     image: nexus3.edgexfoundry.org:10004/security-bootstrapper:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: root:root
     volumes:
-    - edgex-init:/edgex-init:z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      bind:
+        selinux: z
+      volume: {}
   ui:
     container_name: edgex-ui-go
     environment:
@@ -936,9 +1333,12 @@ services:
     hostname: edgex-ui-go
     image: nexus3.edgexfoundry.org:10004/edgex-ui:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 4000:4000/tcp
+    - mode: ingress
+      target: 4000
+      published: "4000"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
@@ -947,30 +1347,32 @@ services:
   vault:
     cap_add:
     - IPC_LOCK
-    command: server
+    command:
+    - server
     container_name: edgex-vault
     depends_on:
-    - security-bootstrapper
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/vault_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
       VAULT_ADDR: http://edgex-vault:8200
       VAULT_CONFIG_DIR: /vault/config
@@ -978,32 +1380,69 @@ services:
     hostname: edgex-vault
     image: vault:1.11.5
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:8200:8200/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 8200
+      published: "8200"
+      protocol: tcp
     restart: always
     tmpfs:
     - /vault/config
     user: root:root
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - vault-file:/vault/file:z
-    - vault-logs:/vault/logs:z
-version: '3.7'
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: vault-file
+      target: /vault/file
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: vault-logs
+      target: /vault/logs
+      bind:
+        selinux: z
+      volume: {}
+networks:
+  edgex-network:
+    name: edgex_edgex-network
+    driver: bridge
 volumes:
-  consul-acl-token: {}
-  consul-config: {}
-  consul-data: {}
-  db-data: {}
-  edgex-init: {}
-  kong: {}
-  kuiper-connections: {}
-  kuiper-data: {}
-  kuiper-sources: {}
-  postgres-config: {}
-  postgres-data: {}
-  redis-config: {}
-  vault-config: {}
-  vault-file: {}
-  vault-logs: {}
-
+  consul-acl-token:
+    name: edgex_consul-acl-token
+  consul-config:
+    name: edgex_consul-config
+  consul-data:
+    name: edgex_consul-data
+  db-data:
+    name: edgex_db-data
+  edgex-init:
+    name: edgex_edgex-init
+  kong:
+    name: edgex_kong
+  kuiper-connections:
+    name: edgex_kuiper-connections
+  kuiper-data:
+    name: edgex_kuiper-data
+  kuiper-sources:
+    name: edgex_kuiper-sources
+  postgres-config:
+    name: edgex_postgres-config
+  postgres-data:
+    name: edgex_postgres-data
+  redis-config:
+    name: edgex_redis-config
+  vault-config:
+    name: edgex_vault-config
+  vault-file:
+    name: edgex_vault-file
+  vault-logs:
+    name: edgex_vault-logs

--- a/taf/docker-compose-taf-arm64.yml
+++ b/taf/docker-compose-taf-arm64.yml
@@ -24,54 +24,58 @@
 #
 # From the compose-builder folder use `make build` to regenerate all standard compose files variations
 #
-networks:
-  edgex-network:
-    driver: bridge
+name: edgex
 services:
   app-service-external-mqtt-trigger:
-    command: /app-service-configurable -cp=consul.http://edgex-core-consul:8500 --registry
+    command:
+    - /app-service-configurable
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
     container_name: edgex-app-external-mqtt-trigger
     depends_on:
-    - consul
-    - data
-    - security-bootstrapper
+      consul:
+        condition: service_started
+      data:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/ready_to_run_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
       CLIENTS_SUPPORT_NOTIFICATIONS_HOST: edgex-support-notifications
       CLIENTS_SUPPORT_SCHEDULER_HOST: edgex-support-scheduler
-      DATABASES_PRIMARY_HOST: edgex-redis
       DATABASE_HOST: edgex-redis
+      DATABASES_PRIMARY_HOST: edgex-redis
       EDGEX_PROFILE: external-mqtt-trigger
       EDGEX_SECURITY_SECRET_STORE: "true"
       MESSAGEBUS_HOST: edgex-redis
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SERVICE_HOST: edgex-app-external-mqtt-trigger
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
       TRIGGER_EXTERNALMQTT_URL: MQTT_BROKER_ADDRESS_PLACE_HOLDER
       WRITABLE_LOGLEVEL: INFO
@@ -80,180 +84,245 @@ services:
     hostname: edgex-app-external-mqtt-trigger
     image: nexus3.edgexfoundry.org:10004/app-service-configurable-arm64:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59706:59706/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59706
+      published: "59706"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - /tmp/edgex/secrets/app-external-mqtt-trigger:/tmp/edgex/secrets/app-external-mqtt-trigger:ro,z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/app-external-mqtt-trigger
+      target: /tmp/edgex/secrets/app-external-mqtt-trigger
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   app-service-functional-tests:
-    command: /app-service-configurable -cp=consul.http://edgex-core-consul:8500 --registry
+    command:
+    - /app-service-configurable
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
     container_name: app-functional-tests
     depends_on:
-    - consul
-    - data
-    - security-bootstrapper
+      consul:
+        condition: service_started
+      data:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/ready_to_run_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
       CLIENTS_SUPPORT_NOTIFICATIONS_HOST: edgex-support-notifications
       CLIENTS_SUPPORT_SCHEDULER_HOST: edgex-support-scheduler
-      DATABASES_PRIMARY_HOST: edgex-redis
       DATABASE_HOST: edgex-redis
+      DATABASES_PRIMARY_HOST: edgex-redis
       EDGEX_PROFILE: functional-tests
       EDGEX_SECURITY_SECRET_STORE: "true"
       MESSAGEBUS_HOST: edgex-redis
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SERVICE_HOST: app-functional-tests
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: app-functional-tests
     image: nexus3.edgexfoundry.org:10004/app-service-configurable-arm64:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 59705:59705/tcp
+    - mode: ingress
+      target: 59705
+      published: "59705"
+      protocol: tcp
     read_only: true
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - /tmp/edgex/secrets/app-functional-tests:/tmp/edgex/secrets/app-functional-tests:ro,z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/app-functional-tests
+      target: /tmp/edgex/secrets/app-functional-tests
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   app-service-http-export:
-    command: /app-service-configurable -cp=consul.http://edgex-core-consul:8500 --registry
+    command:
+    - /app-service-configurable
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
     container_name: edgex-app-http-export
     depends_on:
-    - consul
-    - data
-    - security-bootstrapper
+      consul:
+        condition: service_started
+      data:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/ready_to_run_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
       CLIENTS_SUPPORT_NOTIFICATIONS_HOST: edgex-support-notifications
       CLIENTS_SUPPORT_SCHEDULER_HOST: edgex-support-scheduler
-      DATABASES_PRIMARY_HOST: edgex-redis
       DATABASE_HOST: edgex-redis
+      DATABASES_PRIMARY_HOST: edgex-redis
       EDGEX_PROFILE: http-export
       EDGEX_SECURITY_SECRET_STORE: "true"
       MESSAGEBUS_HOST: edgex-redis
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SERVICE_HOST: edgex-app-http-export
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
       WRITABLE_LOGLEVEL: INFO
       WRITABLE_PIPELINE_FUNCTIONS_HTTPEXPORT_PARAMETERS_URL: http://EXPORT_HOST_PLACE_HOLDER:7770
     hostname: edgex-app-http-export
     image: nexus3.edgexfoundry.org:10004/app-service-configurable-arm64:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59704:59704/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59704
+      published: "59704"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - /tmp/edgex/secrets/app-http-export:/tmp/edgex/secrets/app-http-export:ro,z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/app-http-export
+      target: /tmp/edgex/secrets/app-http-export
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   app-service-mqtt-export:
-    command: /app-service-configurable -cp=consul.http://edgex-core-consul:8500 --registry
+    command:
+    - /app-service-configurable
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
     container_name: edgex-app-mqtt-export
     depends_on:
-    - consul
-    - data
-    - security-bootstrapper
+      consul:
+        condition: service_started
+      data:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/ready_to_run_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
       CLIENTS_SUPPORT_NOTIFICATIONS_HOST: edgex-support-notifications
       CLIENTS_SUPPORT_SCHEDULER_HOST: edgex-support-scheduler
-      DATABASES_PRIMARY_HOST: edgex-redis
       DATABASE_HOST: edgex-redis
+      DATABASES_PRIMARY_HOST: edgex-redis
       EDGEX_PROFILE: mqtt-export
       EDGEX_SECURITY_SECRET_STORE: "true"
       MESSAGEBUS_HOST: edgex-redis
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SERVICE_HOST: edgex-app-mqtt-export
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
       WRITABLE_LOGLEVEL: INFO
       WRITABLE_PIPELINE_FUNCTIONS_MQTTEXPORT_PARAMETERS_BROKERADDRESS: MQTT_BROKER_ADDRESS_PLACE_HOLDER
@@ -261,29 +330,51 @@ services:
     hostname: edgex-app-mqtt-export
     image: nexus3.edgexfoundry.org:10004/app-service-configurable-arm64:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59703:59703/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59703
+      published: "59703"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - /tmp/edgex/secrets/app-mqtt-export:/tmp/edgex/secrets/app-mqtt-export:ro,z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/app-mqtt-export
+      target: /tmp/edgex/secrets/app-mqtt-export
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   app-service-rules:
-    command: /app-service-configurable -cp=consul.http://edgex-core-consul:8500 --registry
+    command:
+    - /app-service-configurable
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
     container_name: edgex-app-rules-engine
     depends_on:
-    - consul
-    - data
-    - security-bootstrapper
+      consul:
+        condition: service_started
+      data:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/ready_to_run_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
@@ -296,113 +387,159 @@ services:
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SERVICE_HOST: edgex-app-rules-engine
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-app-rules-engine
     image: nexus3.edgexfoundry.org:10004/app-service-configurable-arm64:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59701:59701/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59701
+      published: "59701"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - /tmp/edgex/secrets/app-rules-engine:/tmp/edgex/secrets/app-rules-engine:ro,z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/app-rules-engine
+      target: /tmp/edgex/secrets/app-rules-engine
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   app-service-sample:
-    command: /app-service-configurable -cp=consul.http://edgex-core-consul:8500 --registry
+    command:
+    - /app-service-configurable
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
     container_name: edgex-app-sample
     depends_on:
-    - consul
-    - data
-    - security-bootstrapper
+      consul:
+        condition: service_started
+      data:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/ready_to_run_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
       CLIENTS_SUPPORT_NOTIFICATIONS_HOST: edgex-support-notifications
       CLIENTS_SUPPORT_SCHEDULER_HOST: edgex-support-scheduler
-      DATABASES_PRIMARY_HOST: edgex-redis
       DATABASE_HOST: edgex-redis
+      DATABASES_PRIMARY_HOST: edgex-redis
       EDGEX_PROFILE: sample
       EDGEX_SECURITY_SECRET_STORE: "true"
       MESSAGEBUS_HOST: edgex-redis
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SERVICE_HOST: edgex-app-sample
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-app-sample
     image: nexus3.edgexfoundry.org:10004/app-service-configurable-arm64:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59700:59700/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59700
+      published: "59700"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - /tmp/edgex/secrets/app-sample:/tmp/edgex/secrets/app-sample:ro,z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/app-sample
+      target: /tmp/edgex/secrets/app-sample
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   command:
-    command: /core-command -cp=consul.http://edgex-core-consul:8500 --registry
+    command:
+    - /core-command
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
     container_name: edgex-core-command
     depends_on:
-    - consul
-    - database
-    - metadata
-    - secretstore-setup
-    - security-bootstrapper
+      consul:
+        condition: service_started
+      database:
+        condition: service_started
+      metadata:
+        condition: service_started
+      secretstore-setup:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/ready_to_run_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
@@ -415,110 +552,173 @@ services:
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SERVICE_HOST: edgex-core-command
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-core-command
     image: nexus3.edgexfoundry.org:10004/core-command-arm64:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59882:59882/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59882
+      published: "59882"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - /tmp/edgex/secrets/core-command:/tmp/edgex/secrets/core-command:ro,z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/core-command
+      target: /tmp/edgex/secrets/core-command
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   consul:
-    command: agent -ui -bootstrap -server -client 0.0.0.0
+    command:
+    - agent
+    - -ui
+    - -bootstrap
+    - -server
+    - -client
+    - 0.0.0.0
     container_name: edgex-core-consul
     depends_on:
-    - security-bootstrapper
-    - vault
+      security-bootstrapper:
+        condition: service_started
+      vault:
+        condition: service_started
     entrypoint:
     - /edgex-init/consul_wait_install.sh
     environment:
       ADD_REGISTRY_ACL_ROLES: app-http-export,app-mqtt-export,app-functional-tests,app-scalability-test-mqtt-export,app-sample,device-modbus,app-external-mqtt-trigger,device-onvif-camera
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
-      EDGEX_GROUP: '2001'
+      API_GATEWAY_STATUS_PORT: "8100"
+      EDGEX_GROUP: "2001"
       EDGEX_SECURITY_SECRET_STORE: "true"
-      EDGEX_USER: '2002'
+      EDGEX_USER: "2002"
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_ACL_BOOTSTRAPTOKENPATH: /tmp/edgex/secrets/consul-acl-token/bootstrap_token.json
       STAGEGATE_REGISTRY_ACL_MANAGEMENTTOKENPATH: /tmp/edgex/secrets/consul-acl-token/mgmt_token.json
       STAGEGATE_REGISTRY_ACL_SENTINELFILEPATH: /consul/config/consul_acl_done
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-core-consul
     image: consul:1.13
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:8500:8500/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 8500
+      published: "8500"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: root:root
     volumes:
-    - consul-config:/consul/config:z
-    - consul-data:/consul/data:z
-    - edgex-init:/edgex-init:ro,z
-    - consul-acl-token:/tmp/edgex/secrets/consul-acl-token:z
-    - /tmp/edgex/secrets/edgex-consul:/tmp/edgex/secrets/edgex-consul:ro,z
+    - type: volume
+      source: consul-config
+      target: /consul/config
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: consul-data
+      target: /consul/data
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: consul-acl-token
+      target: /tmp/edgex/secrets/consul-acl-token
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/edgex-consul
+      target: /tmp/edgex/secrets/edgex-consul
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   data:
-    command: /core-data -cp=consul.http://edgex-core-consul:8500 --registry
+    command:
+    - /core-data
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
     container_name: edgex-core-data
     depends_on:
-    - consul
-    - database
-    - metadata
-    - secretstore-setup
-    - security-bootstrapper
+      consul:
+        condition: service_started
+      database:
+        condition: service_started
+      metadata:
+        condition: service_started
+      secretstore-setup:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/ready_to_run_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
@@ -530,52 +730,74 @@ services:
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SECRETSTORE_TOKENFILE: /tmp/edgex/secrets/core-data/secrets-token.json
       SERVICE_HOST: edgex-core-data
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-core-data
     image: nexus3.edgexfoundry.org:10004/core-data-arm64:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:5563:5563/tcp
-    - 127.0.0.1:59880:59880/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 5563
+      published: "5563"
+      protocol: tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59880
+      published: "59880"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - /tmp/edgex/secrets/core-data:/tmp/edgex/secrets/core-data:ro,z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/core-data
+      target: /tmp/edgex/secrets/core-data
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   database:
     container_name: edgex-redis
     depends_on:
-    - secretstore-setup
-    - security-bootstrapper
+      secretstore-setup:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/redis_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
@@ -588,31 +810,35 @@ services:
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-redis
     image: redis:7.0-alpine
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:6379:6379/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 6379
+      published: "6379"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
@@ -621,24 +847,55 @@ services:
     - /run
     user: root:root
     volumes:
-    - db-data:/data:z
-    - edgex-init:/edgex-init:ro,z
-    - redis-config:/run/redis/conf:z
-    - /tmp/edgex/secrets/security-bootstrapper-redis:/tmp/edgex/secrets/security-bootstrapper-redis:ro,z
+    - type: volume
+      source: db-data
+      target: /data
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: redis-config
+      target: /run/redis/conf
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/security-bootstrapper-redis
+      target: /tmp/edgex/secrets/security-bootstrapper-redis
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   device-modbus:
-    command: /device-modbus -cp=consul.http://edgex-core-consul:8500 --registry --configDir=CONFIG_DIR_PLACE_HOLDER
+    command:
+    - /device-modbus
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
+    - --configDir=CONFIG_DIR_PLACE_HOLDER
     container_name: edgex-device-modbus
     depends_on:
-    - consul
-    - data
-    - metadata
-    - modbus-simulator
-    - security-bootstrapper
+      consul:
+        condition: service_started
+      data:
+        condition: service_started
+      metadata:
+        condition: service_started
+      modbus-simulator:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/ready_to_run_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
@@ -650,54 +907,82 @@ services:
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SERVICE_HOST: edgex-device-modbus
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-device-modbus
     image: nexus3.edgexfoundry.org:10004/device-modbus-arm64:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59901:59901/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59901
+      published: "59901"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - /tmp/edgex/secrets/device-modbus:/tmp/edgex/secrets/device-modbus:ro,z
-    - PROFILE_VOLUME_PLACE_HOLDER:CONFIG_DIR_PLACE_HOLDER:z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/device-modbus
+      target: /tmp/edgex/secrets/device-modbus
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
+    - type: bind
+      source: /PROFILE_VOLUME_PLACE_HOLDER
+      target: CONFIG_DIR_PLACE_HOLDER
+      bind:
+        selinux: z
+        create_host_path: true
   device-onvif-camera:
-    command: /device-onvif-camera -cp=consul.http://edgex-core-consul:8500 --registry
+    command:
+    - /device-onvif-camera
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
     container_name: edgex-device-onvif-camera
     depends_on:
-    - consul
-    - data
-    - metadata
-    - security-bootstrapper
+      consul:
+        condition: service_started
+      data:
+        condition: service_started
+      metadata:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/ready_to_run_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
@@ -709,53 +994,76 @@ services:
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SERVICE_HOST: edgex-device-onvif-camera
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-device-onvif-camera
     image: nexus3.edgexfoundry.org:10004/device-onvif-camera-arm64:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59984:59984/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59984
+      published: "59984"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - /tmp/edgex/secrets/device-onvif-camera:/tmp/edgex/secrets/device-onvif-camera:ro,z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/device-onvif-camera
+      target: /tmp/edgex/secrets/device-onvif-camera
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   device-rest:
-    command: /device-rest -cp=consul.http://edgex-core-consul:8500 --registry
+    command:
+    - /device-rest
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
     container_name: edgex-device-rest
     depends_on:
-    - consul
-    - data
-    - metadata
-    - security-bootstrapper
+      consul:
+        condition: service_started
+      data:
+        condition: service_started
+      metadata:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/ready_to_run_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
@@ -767,53 +1075,77 @@ services:
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SERVICE_HOST: edgex-device-rest
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-device-rest
     image: nexus3.edgexfoundry.org:10004/device-rest-arm64:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59986:59986/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59986
+      published: "59986"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - /tmp/edgex/secrets/device-rest:/tmp/edgex/secrets/device-rest:ro,z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/device-rest
+      target: /tmp/edgex/secrets/device-rest
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   device-virtual:
-    command: /device-virtual -cp=consul.http://edgex-core-consul:8500 --registry --configDir=CONFIG_DIR_PLACE_HOLDER
+    command:
+    - /device-virtual
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
+    - --configDir=CONFIG_DIR_PLACE_HOLDER
     container_name: edgex-device-virtual
     depends_on:
-    - consul
-    - data
-    - metadata
-    - security-bootstrapper
+      consul:
+        condition: service_started
+      data:
+        condition: service_started
+      metadata:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/ready_to_run_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
@@ -825,58 +1157,81 @@ services:
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SERVICE_HOST: edgex-device-virtual
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-device-virtual
     image: nexus3.edgexfoundry.org:10004/device-virtual-arm64:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59900:59900/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59900
+      published: "59900"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - /tmp/edgex/secrets/device-virtual:/tmp/edgex/secrets/device-virtual:ro,z
-    - PROFILE_VOLUME_PLACE_HOLDER:CONFIG_DIR_PLACE_HOLDER:z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/device-virtual
+      target: /tmp/edgex/secrets/device-virtual
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
+    - type: bind
+      source: /PROFILE_VOLUME_PLACE_HOLDER
+      target: CONFIG_DIR_PLACE_HOLDER
+      bind:
+        selinux: z
+        create_host_path: true
   kong:
     container_name: edgex-kong
     depends_on:
-    - kong-db
-    - security-bootstrapper
+      kong-db:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/kong_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       KONG_ADMIN_ACCESS_LOG: /dev/stdout
       KONG_ADMIN_ERROR_LOG: /dev/stderr
       KONG_ADMIN_LISTEN: 127.0.0.1:8001, 127.0.0.1:8444 ssl
       KONG_DATABASE: postgres
       KONG_DNS_ORDER: LAST,A,CNAME
-      KONG_DNS_VALID_TTL: '1'
-      KONG_NGINX_WORKER_PROCESSES: '1'
+      KONG_DNS_VALID_TTL: "1"
+      KONG_NGINX_WORKER_PROCESSES: "1"
       KONG_PG_HOST: edgex-kong-db
       KONG_PG_PASSWORD_FILE: /tmp/postgres-config/.pgpassword
       KONG_PROXY_ACCESS_LOG: /dev/stdout
@@ -885,28 +1240,38 @@ services:
       KONG_STATUS_LISTEN: 0.0.0.0:8100
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-kong
     image: kong:2.8
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 8000:8000/tcp
-    - 127.0.0.1:8100:8100/tcp
-    - 8443:8443/tcp
+    - mode: ingress
+      target: 8000
+      published: "8000"
+      protocol: tcp
+    - mode: ingress
+      target: 8443
+      published: "8443"
+      protocol: tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 8100
+      published: "8100"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
@@ -917,50 +1282,77 @@ services:
     tty: true
     user: kong:nogroup
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - /tmp/edgex/secrets/security-proxy-setup:/tmp/edgex/secrets/security-proxy-setup:ro,z
-    - postgres-config:/tmp/postgres-config:z
-    - kong:/usr/local/kong:z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: postgres-config
+      target: /tmp/postgres-config
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: kong
+      target: /usr/local/kong
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/security-proxy-setup
+      target: /tmp/edgex/secrets/security-proxy-setup
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   kong-db:
     container_name: edgex-kong-db
     depends_on:
-    - security-bootstrapper
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/postgres_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       EDGEX_SECURITY_SECRET_STORE: "true"
       POSTGRES_DB: kong
       POSTGRES_PASSWORD_FILE: /tmp/postgres-config/.pgpassword
       POSTGRES_USER: kong
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-kong-db
     image: postgres:13.8-alpine
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:5432:5432/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 5432
+      published: "5432"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
@@ -971,23 +1363,47 @@ services:
     - /run
     user: root:root
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - postgres-config:/tmp/postgres-config:z
-    - postgres-data:/var/lib/postgresql/data:z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: postgres-data
+      target: /var/lib/postgresql/data
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: postgres-config
+      target: /tmp/postgres-config
+      bind:
+        selinux: z
+      volume: {}
   metadata:
-    command: /core-metadata -cp=consul.http://edgex-core-consul:8500 --registry
+    command:
+    - /core-metadata
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
     container_name: edgex-core-metadata
     depends_on:
-    - consul
-    - database
-    - notifications
-    - secretstore-setup
-    - security-bootstrapper
+      consul:
+        condition: service_started
+      database:
+        condition: service_started
+      notifications:
+        condition: service_started
+      secretstore-setup:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/ready_to_run_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
@@ -1000,94 +1416,136 @@ services:
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SERVICE_HOST: edgex-core-metadata
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-core-metadata
     image: nexus3.edgexfoundry.org:10004/core-metadata-arm64:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59881:59881/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59881
+      published: "59881"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - /tmp/edgex/secrets/core-metadata:/tmp/edgex/secrets/core-metadata:ro,z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/core-metadata
+      target: /tmp/edgex/secrets/core-metadata
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   modbus-simulator:
     container_name: edgex-modbus-simulator
     hostname: edgex-modbus-simulator
     image: nexus3.edgexfoundry.org:10003/edgex-devops/edgex-modbus-simulator-arm64:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:1502:1502/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 1502
+      published: "1502"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
   mqtt-broker:
-    command: /usr/sbin/mosquitto -c /mosquitto-no-auth.conf
+    command:
+    - /usr/sbin/mosquitto
+    - -c
+    - /mosquitto-no-auth.conf
+    - -v
     container_name: edgex-mqtt-broker
     hostname: edgex-mqtt-broker
     image: eclipse-mosquitto:2.0
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:1883:1883/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 1883
+      published: "1883"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
   mqtt-taf-broker:
-    command: /usr/sbin/mosquitto -c /mosquitto-no-auth.conf
+    command:
+    - /usr/sbin/mosquitto
+    - -c
+    - /mosquitto-no-auth.conf
     container_name: edgex-taf-mqtt-broker
     hostname: edgex-taf-mqtt-broker
     image: eclipse-mosquitto:2.0
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:1884:1883/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 1883
+      published: "1884"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
   notifications:
-    command: /support-notifications -cp=consul.http://edgex-core-consul:8500 --registry
+    command:
+    - /support-notifications
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
     container_name: edgex-support-notifications
     depends_on:
-    - consul
-    - database
-    - secretstore-setup
-    - security-bootstrapper
+      consul:
+        condition: service_started
+      database:
+        condition: service_started
+      secretstore-setup:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/ready_to_run_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
@@ -1099,52 +1557,71 @@ services:
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SERVICE_HOST: edgex-support-notifications
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-support-notifications
     image: nexus3.edgexfoundry.org:10004/support-notifications-arm64:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59860:59860/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59860
+      published: "59860"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - /tmp/edgex/secrets/support-notifications:/tmp/edgex/secrets/support-notifications:ro,z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/support-notifications
+      target: /tmp/edgex/secrets/support-notifications
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   proxy-setup:
     container_name: edgex-security-proxy-setup
     depends_on:
-    - kong
-    - secretstore-setup
-    - security-bootstrapper
+      kong:
+        condition: service_started
+      secretstore-setup:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/proxy_setup_wait_install.sh
     environment:
       ADD_PROXY_ROUTE: device-modbus.http://edgex-device-modbus:59901
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       EDGEX_SECURITY_SECRET_STORE: "true"
       KONGURL_SERVER: edgex-kong
       PROXY_SETUP_HOST: edgex-security-proxy-setup
@@ -1158,110 +1635,162 @@ services:
       ROUTES_SUPPORT_SCHEDULER_HOST: edgex-support-scheduler
       ROUTES_SYS_MGMT_AGENT_HOST: edgex-sys-mgmt-agent
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-security-proxy-setup
     image: nexus3.edgexfoundry.org:10004/security-proxy-setup-arm64:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     read_only: true
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - consul-acl-token:/tmp/edgex/secrets/consul-acl-token:ro,z
-    - /tmp/edgex/secrets/security-proxy-setup:/tmp/edgex/secrets/security-proxy-setup:ro,z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: consul-acl-token
+      target: /tmp/edgex/secrets/consul-acl-token
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/security-proxy-setup
+      target: /tmp/edgex/secrets/security-proxy-setup
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   rulesengine:
     container_name: edgex-kuiper
     depends_on:
-    - database
-    - secretstore-setup
-    - security-bootstrapper
+      database:
+        condition: service_started
+      secretstore-setup:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/kuiper_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
-      CONNECTION__EDGEX__REDISMSGBUS__PORT: 6379
+      API_GATEWAY_STATUS_PORT: "8100"
+      CONNECTION__EDGEX__REDISMSGBUS__PORT: "6379"
       CONNECTION__EDGEX__REDISMSGBUS__PROTOCOL: redis
       CONNECTION__EDGEX__REDISMSGBUS__SERVER: edgex-redis
       CONNECTION__EDGEX__REDISMSGBUS__TYPE: redis
-      EDGEX__DEFAULT__PORT: 6379
+      EDGEX__DEFAULT__PORT: "6379"
       EDGEX__DEFAULT__PROTOCOL: redis
       EDGEX__DEFAULT__SERVER: edgex-redis
       EDGEX__DEFAULT__TOPIC: rules-events
       EDGEX__DEFAULT__TYPE: redis
       KUIPER__BASIC__CONSOLELOG: "true"
-      KUIPER__BASIC__RESTPORT: 59720
+      KUIPER__BASIC__RESTPORT: "59720"
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-kuiper
     image: lfedge/ekuiper:1.7-alpine
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59720:59720/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59720
+      published: "59720"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: kuiper:kuiper
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - kuiper-data:/kuiper/data:z
-    - kuiper-connections:/kuiper/etc/connections:z
-    - kuiper-sources:/kuiper/etc/sources:z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: kuiper-data
+      target: /kuiper/data
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: kuiper-connections
+      target: /kuiper/etc/connections
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: kuiper-sources
+      target: /kuiper/etc/sources
+      bind:
+        selinux: z
+      volume: {}
   scalability-test-mqtt-export:
-    command: /app-service-configurable -cp=consul.http://edgex-core-consul:8500 --registry
+    command:
+    - /app-service-configurable
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
     container_name: edgex-scalability-test-mqtt-export
     depends_on:
-    - consul
-    - data
-    - security-bootstrapper
+      consul:
+        condition: service_started
+      data:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/ready_to_run_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
       CLIENTS_SUPPORT_NOTIFICATIONS_HOST: edgex-support-notifications
       CLIENTS_SUPPORT_SCHEDULER_HOST: edgex-support-scheduler
-      DATABASES_PRIMARY_HOST: edgex-redis
       DATABASE_HOST: edgex-redis
+      DATABASES_PRIMARY_HOST: edgex-redis
       EDGEX_PROFILE: mqtt-export
       EDGEX_SECURITY_SECRET_STORE: "true"
       EDGEX_SERVICE_KEY: app-scalability-test-mqtt-export
@@ -1271,26 +1800,26 @@ services:
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault
       SECRETSTORE_PATH: /app-scalability-test-mqtt-export
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SECRETSTORE_TOKENFILE: /tmp/edgex/secrets/app-scalability-test-mqtt-export/secrets-token.json
       SERVICE_HOST: edgex-scalability-test-mqtt-export
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
       WRITABLE_LOGLEVEL: DEBUG
       WRITABLE_PIPELINE_FUNCTIONS_MQTTEXPORT_PARAMETERS_BROKERADDRESS: MQTT_BROKER_ADDRESS_PLACE_HOLDER
@@ -1299,29 +1828,51 @@ services:
     hostname: edgex-scalability-test-mqtt-export
     image: nexus3.edgexfoundry.org:10004/app-service-configurable-arm64:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 59710:59703/tcp
+    - mode: ingress
+      target: 59703
+      published: "59710"
+      protocol: tcp
     read_only: true
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - /tmp/edgex/secrets/app-scalability-test-mqtt-export:/tmp/edgex/secrets/app-scalability-test-mqtt-export:ro,z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/app-scalability-test-mqtt-export
+      target: /tmp/edgex/secrets/app-scalability-test-mqtt-export
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   scheduler:
-    command: /support-scheduler -cp=consul.http://edgex-core-consul:8500 --registry
+    command:
+    - /support-scheduler
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
     container_name: edgex-support-scheduler
     depends_on:
-    - consul
-    - database
-    - secretstore-setup
-    - security-bootstrapper
+      consul:
+        condition: service_started
+      database:
+        condition: service_started
+      secretstore-setup:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/ready_to_run_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
@@ -1335,79 +1886,97 @@ services:
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SERVICE_HOST: edgex-support-scheduler
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-support-scheduler
     image: nexus3.edgexfoundry.org:10004/support-scheduler-arm64:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59861:59861/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59861
+      published: "59861"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - /tmp/edgex/secrets/support-scheduler:/tmp/edgex/secrets/support-scheduler:ro,z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/support-scheduler
+      target: /tmp/edgex/secrets/support-scheduler
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   secretstore-setup:
     container_name: edgex-security-secretstore-setup
     depends_on:
-    - security-bootstrapper
-    - vault
+      security-bootstrapper:
+        condition: service_started
+      vault:
+        condition: service_started
     environment:
       ADD_KNOWN_SECRETS: redisdb[app-rules-engine],redisdb[app-http-export],redisdb[app-mqtt-export],redisdb[app-scalability-test-mqtt-export],redisdb[app-sample],redisdb[device-modbus],redisdb[device-rest],redisdb[device-virtual],redisdb[device-onvif-camera],message-bus[app-rules-engine],message-bus[app-http-export],message-bus[app-mqtt-export],message-bus[app-external-mqtt-trigger],message-bus[app-scalability-test-mqtt-export],message-bus[app-sample],message-bus[device-modbus],message-bus[device-rest],message-bus[device-virtual],message-bus[device-onvif-camera]
       ADD_SECRETSTORE_TOKENS: app-http-export,app-mqtt-export,app-functional-tests,app-scalability-test-mqtt-export,app-sample,device-modbus,app-external-mqtt-trigger,device-onvif-camera
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
-      EDGEX_GROUP: '2001'
+      API_GATEWAY_STATUS_PORT: "8100"
+      EDGEX_GROUP: "2001"
       EDGEX_SECURITY_SECRET_STORE: "true"
-      EDGEX_USER: '2002'
+      EDGEX_USER: "2002"
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SECUREMESSAGEBUS_TYPE: redis
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-security-secretstore-setup
     image: nexus3.edgexfoundry.org:10004/security-secretstore-setup-arm64:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     read_only: true
     restart: always
     security_opt:
@@ -1417,59 +1986,100 @@ services:
     - /vault
     user: root:root
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - /tmp/edgex/secrets:/tmp/edgex/secrets:z
-    - kong:/tmp/kong:z
-    - kuiper-sources:/tmp/kuiper:z
-    - kuiper-connections:/tmp/kuiper-connections:z
-    - vault-config:/vault/config:z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets
+      target: /tmp/edgex/secrets
+      bind:
+        selinux: z
+        create_host_path: true
+    - type: volume
+      source: kong
+      target: /tmp/kong
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: kuiper-sources
+      target: /tmp/kuiper
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: kuiper-connections
+      target: /tmp/kuiper-connections
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: vault-config
+      target: /vault/config
+      bind:
+        selinux: z
+      volume: {}
   security-bootstrapper:
     container_name: edgex-security-bootstrapper
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
-      EDGEX_GROUP: '2001'
-      EDGEX_USER: '2002'
+      API_GATEWAY_STATUS_PORT: "8100"
+      EDGEX_GROUP: "2001"
+      EDGEX_USER: "2002"
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-security-bootstrapper
     image: nexus3.edgexfoundry.org:10004/security-bootstrapper-arm64:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: root:root
     volumes:
-    - edgex-init:/edgex-init:z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      bind:
+        selinux: z
+      volume: {}
   security-spiffe-token-provider:
-    command: /security-spiffe-token-provider -cp=consul.http://edgex-core-consul:8500
-      --registry
+    command:
+    - /security-spiffe-token-provider
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
     container_name: edgex-security-spiffe-token-provider
     depends_on:
-    - consul
-    - security-bootstrapper
-    - security-spire-agent
+      consul:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
+      security-spire-agent:
+        condition: service_started
     entrypoint:
     - /edgex-init/ready_to_run_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
@@ -1480,32 +2090,36 @@ services:
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SERVICE_HOST: edgex-security-spiffe-token-provider
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-security-spiffe-token-provider
     image: nexus3.edgexfoundry.org:10004/security-spiffe-token-provider-arm64:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59841:59841/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59841
+      published: "59841"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
@@ -1514,19 +2128,36 @@ services:
     - /run
     user: root:root
     volumes:
-    - edgex-init:/edgex-init:z
-    - /tmp/edgex/secrets/security-spiffe-token-provider:/tmp/edgex/secrets/security-spiffe-token-provider:z
-    - /tmp/edgex/secrets/spiffe:/tmp/edgex/secrets/spiffe:z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/spiffe
+      target: /tmp/edgex/secrets/spiffe
+      bind:
+        selinux: z
+        create_host_path: true
+    - type: bind
+      source: /tmp/edgex/secrets/security-spiffe-token-provider
+      target: /tmp/edgex/secrets/security-spiffe-token-provider
+      bind:
+        selinux: z
+        create_host_path: true
   security-spire-agent:
-    command: docker-entrypoint.sh
+    command:
+    - docker-entrypoint.sh
     container_name: edgex-security-spire-agent
     depends_on:
-    - security-spire-server
+      security-spire-server:
+        condition: service_started
     entrypoint:
     - /edgex-init/ready_to_run_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
@@ -1537,29 +2168,29 @@ services:
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-security-spire-agent
     image: nexus3.edgexfoundry.org:10004/security-spire-agent-arm64:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     pid: host
     privileged: true
     read_only: true
@@ -1570,21 +2201,47 @@ services:
     - /run
     user: root:root
     volumes:
-    - edgex-init:/edgex-init:z
-    - spire-agent:/srv/spiffe/agent:z
-    - spire-ca:/srv/spiffe/ca:z
-    - /tmp/edgex/secrets/spiffe:/tmp/edgex/secrets/spiffe:z
-    - /var/run/docker.sock:/var/run/docker.sock:rw
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: spire-ca
+      target: /srv/spiffe/ca
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: spire-agent
+      target: /srv/spiffe/agent
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/spiffe
+      target: /tmp/edgex/secrets/spiffe
+      bind:
+        selinux: z
+        create_host_path: true
+    - type: bind
+      source: /var/run/docker.sock
+      target: /var/run/docker.sock
+      bind:
+        create_host_path: true
   security-spire-config:
-    command: docker-entrypoint.sh
+    command:
+    - docker-entrypoint.sh
     container_name: edgex-security-spire-config
     depends_on:
-    - security-spire-agent
+      security-spire-agent:
+        condition: service_started
     entrypoint:
     - /edgex-init/ready_to_run_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
@@ -1595,29 +2252,29 @@ services:
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-security-spire-config
     image: nexus3.edgexfoundry.org:10004/security-spire-config-arm64:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     read_only: true
     restart: always
     security_opt:
@@ -1626,18 +2283,30 @@ services:
     - /run
     user: root:root
     volumes:
-    - edgex-init:/edgex-init:z
-    - /tmp/edgex/secrets/spiffe:/tmp/edgex/secrets/spiffe:z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/spiffe
+      target: /tmp/edgex/secrets/spiffe
+      bind:
+        selinux: z
+        create_host_path: true
   security-spire-server:
-    command: docker-entrypoint.sh
+    command:
+    - docker-entrypoint.sh
     container_name: edgex-security-spire-server
     depends_on:
-    - security-bootstrapper
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/ready_to_run_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
@@ -1648,32 +2317,36 @@ services:
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-security-spire-server
     image: nexus3.edgexfoundry.org:10004/security-spire-server-arm64:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     pid: host
     ports:
-    - 127.0.0.1:59840:59840/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59840
+      published: "59840"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
@@ -1682,10 +2355,30 @@ services:
     - /run
     user: root:root
     volumes:
-    - edgex-init:/edgex-init:z
-    - spire-ca:/srv/spiffe/ca:z
-    - spire-server:/srv/spiffe/server:z
-    - /tmp/edgex/secrets/spiffe:/tmp/edgex/secrets/spiffe:z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: spire-ca
+      target: /srv/spiffe/ca
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: spire-server
+      target: /srv/spiffe/server
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/spiffe
+      target: /tmp/edgex/secrets/spiffe
+      bind:
+        selinux: z
+        create_host_path: true
   ui:
     container_name: edgex-ui-go
     environment:
@@ -1694,9 +2387,12 @@ services:
     hostname: edgex-ui-go
     image: nexus3.edgexfoundry.org:10004/edgex-ui-arm64:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 4000:4000/tcp
+    - mode: ingress
+      target: 4000
+      published: "4000"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
@@ -1705,30 +2401,32 @@ services:
   vault:
     cap_add:
     - IPC_LOCK
-    command: server
+    command:
+    - server
     container_name: edgex-vault
     depends_on:
-    - security-bootstrapper
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/vault_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
       VAULT_ADDR: http://edgex-vault:8200
       VAULT_CONFIG_DIR: /vault/config
@@ -1736,36 +2434,75 @@ services:
     hostname: edgex-vault
     image: vault:1.11.5
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:8200:8200/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 8200
+      published: "8200"
+      protocol: tcp
     restart: always
     tmpfs:
     - /vault/config
     user: root:root
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - vault-file:/vault/file:z
-    - vault-logs:/vault/logs:z
-version: '3.7'
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: vault-file
+      target: /vault/file
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: vault-logs
+      target: /vault/logs
+      bind:
+        selinux: z
+      volume: {}
+networks:
+  edgex-network:
+    name: edgex_edgex-network
+    driver: bridge
 volumes:
-  PROFILE_VOLUME_PLACE_HOLDER: {}
-  consul-acl-token: {}
-  consul-config: {}
-  consul-data: {}
-  db-data: {}
-  edgex-init: {}
-  kong: {}
-  kuiper-connections: {}
-  kuiper-data: {}
-  kuiper-sources: {}
-  postgres-config: {}
-  postgres-data: {}
-  redis-config: {}
-  spire-agent: {}
-  spire-ca: {}
-  spire-server: {}
-  vault-config: {}
-  vault-file: {}
-  vault-logs: {}
-
+  consul-acl-token:
+    name: edgex_consul-acl-token
+  consul-config:
+    name: edgex_consul-config
+  consul-data:
+    name: edgex_consul-data
+  db-data:
+    name: edgex_db-data
+  edgex-init:
+    name: edgex_edgex-init
+  kong:
+    name: edgex_kong
+  kuiper-connections:
+    name: edgex_kuiper-connections
+  kuiper-data:
+    name: edgex_kuiper-data
+  kuiper-sources:
+    name: edgex_kuiper-sources
+  postgres-config:
+    name: edgex_postgres-config
+  postgres-data:
+    name: edgex_postgres-data
+  redis-config:
+    name: edgex_redis-config
+  spire-agent:
+    name: edgex_spire-agent
+  spire-ca:
+    name: edgex_spire-ca
+  spire-server:
+    name: edgex_spire-server
+  vault-config:
+    name: edgex_vault-config
+  vault-file:
+    name: edgex_vault-file
+  vault-logs:
+    name: edgex_vault-logs

--- a/taf/docker-compose-taf-arm64.yml
+++ b/taf/docker-compose-taf-arm64.yml
@@ -1488,7 +1488,6 @@ services:
     - /usr/sbin/mosquitto
     - -c
     - /mosquitto-no-auth.conf
-    - -v
     container_name: edgex-mqtt-broker
     hostname: edgex-mqtt-broker
     image: eclipse-mosquitto:2.0

--- a/taf/docker-compose-taf-mqtt-bus-arm64.yml
+++ b/taf/docker-compose-taf-mqtt-bus-arm64.yml
@@ -24,54 +24,58 @@
 #
 # From the compose-builder folder use `make build` to regenerate all standard compose files variations
 #
-networks:
-  edgex-network:
-    driver: bridge
+name: edgex
 services:
   app-service-external-mqtt-trigger:
-    command: /app-service-configurable -cp=consul.http://edgex-core-consul:8500 --registry
+    command:
+    - /app-service-configurable
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
     container_name: edgex-app-external-mqtt-trigger
     depends_on:
-    - consul
-    - data
-    - security-bootstrapper
+      consul:
+        condition: service_started
+      data:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/ready_to_run_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
       CLIENTS_SUPPORT_NOTIFICATIONS_HOST: edgex-support-notifications
       CLIENTS_SUPPORT_SCHEDULER_HOST: edgex-support-scheduler
-      DATABASES_PRIMARY_HOST: edgex-redis
       DATABASE_HOST: edgex-redis
+      DATABASES_PRIMARY_HOST: edgex-redis
       EDGEX_PROFILE: external-mqtt-trigger
       EDGEX_SECURITY_SECRET_STORE: "true"
       MESSAGEBUS_HOST: edgex-redis
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SERVICE_HOST: edgex-app-external-mqtt-trigger
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
       TRIGGER_EXTERNALMQTT_URL: MQTT_BROKER_ADDRESS_PLACE_HOLDER
       WRITABLE_LOGLEVEL: INFO
@@ -80,192 +84,259 @@ services:
     hostname: edgex-app-external-mqtt-trigger
     image: nexus3.edgexfoundry.org:10004/app-service-configurable-arm64:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59706:59706/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59706
+      published: "59706"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - /tmp/edgex/secrets/app-external-mqtt-trigger:/tmp/edgex/secrets/app-external-mqtt-trigger:ro,z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/app-external-mqtt-trigger
+      target: /tmp/edgex/secrets/app-external-mqtt-trigger
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   app-service-functional-tests:
-    command: /app-service-configurable -cp=consul.http://edgex-core-consul:8500 --registry
+    command:
+    - /app-service-configurable
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
     container_name: app-functional-tests
     depends_on:
-    - consul
-    - data
-    - security-bootstrapper
+      consul:
+        condition: service_started
+      data:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/ready_to_run_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
       CLIENTS_SUPPORT_NOTIFICATIONS_HOST: edgex-support-notifications
       CLIENTS_SUPPORT_SCHEDULER_HOST: edgex-support-scheduler
-      DATABASES_PRIMARY_HOST: edgex-redis
       DATABASE_HOST: edgex-redis
+      DATABASES_PRIMARY_HOST: edgex-redis
       EDGEX_PROFILE: functional-tests
       EDGEX_SECURITY_SECRET_STORE: "true"
       MESSAGEBUS_HOST: edgex-redis
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SERVICE_HOST: app-functional-tests
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: app-functional-tests
     image: nexus3.edgexfoundry.org:10004/app-service-configurable-arm64:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 59705:59705/tcp
+    - mode: ingress
+      target: 59705
+      published: "59705"
+      protocol: tcp
     read_only: true
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - /tmp/edgex/secrets/app-functional-tests:/tmp/edgex/secrets/app-functional-tests:ro,z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/app-functional-tests
+      target: /tmp/edgex/secrets/app-functional-tests
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   app-service-http-export:
-    command: /app-service-configurable -cp=consul.http://edgex-core-consul:8500 --registry
+    command:
+    - /app-service-configurable
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
     container_name: edgex-app-http-export
     depends_on:
-    - consul
-    - data
-    - mqtt-broker
-    - security-bootstrapper
+      consul:
+        condition: service_started
+      data:
+        condition: service_started
+      mqtt-broker:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/ready_to_run_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
       CLIENTS_SUPPORT_NOTIFICATIONS_HOST: edgex-support-notifications
       CLIENTS_SUPPORT_SCHEDULER_HOST: edgex-support-scheduler
-      DATABASES_PRIMARY_HOST: edgex-redis
       DATABASE_HOST: edgex-redis
+      DATABASES_PRIMARY_HOST: edgex-redis
       EDGEX_PROFILE: http-export
       EDGEX_SECURITY_SECRET_STORE: "true"
       MESSAGEBUS_AUTHMODE: usernamepassword
       MESSAGEBUS_HOST: edgex-mqtt-broker
-      MESSAGEBUS_PORT: '1883'
+      MESSAGEBUS_PORT: "1883"
       MESSAGEBUS_PROTOCOL: tcp
       MESSAGEBUS_SECRETNAME: message-bus
       MESSAGEBUS_TYPE: mqtt
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SERVICE_HOST: edgex-app-http-export
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
       WRITABLE_LOGLEVEL: INFO
       WRITABLE_PIPELINE_FUNCTIONS_HTTPEXPORT_PARAMETERS_URL: http://EXPORT_HOST_PLACE_HOLDER:7770
     hostname: edgex-app-http-export
     image: nexus3.edgexfoundry.org:10004/app-service-configurable-arm64:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59704:59704/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59704
+      published: "59704"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - /tmp/edgex/secrets/app-http-export:/tmp/edgex/secrets/app-http-export:ro,z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/app-http-export
+      target: /tmp/edgex/secrets/app-http-export
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   app-service-mqtt-export:
-    command: /app-service-configurable -cp=consul.http://edgex-core-consul:8500 --registry
+    command:
+    - /app-service-configurable
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
     container_name: edgex-app-mqtt-export
     depends_on:
-    - consul
-    - data
-    - mqtt-broker
-    - security-bootstrapper
+      consul:
+        condition: service_started
+      data:
+        condition: service_started
+      mqtt-broker:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/ready_to_run_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
       CLIENTS_SUPPORT_NOTIFICATIONS_HOST: edgex-support-notifications
       CLIENTS_SUPPORT_SCHEDULER_HOST: edgex-support-scheduler
-      DATABASES_PRIMARY_HOST: edgex-redis
       DATABASE_HOST: edgex-redis
+      DATABASES_PRIMARY_HOST: edgex-redis
       EDGEX_PROFILE: mqtt-export
       EDGEX_SECURITY_SECRET_STORE: "true"
       MESSAGEBUS_AUTHMODE: usernamepassword
       MESSAGEBUS_HOST: edgex-mqtt-broker
-      MESSAGEBUS_PORT: '1883'
+      MESSAGEBUS_PORT: "1883"
       MESSAGEBUS_PROTOCOL: tcp
       MESSAGEBUS_SECRETNAME: message-bus
       MESSAGEBUS_TYPE: mqtt
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SERVICE_HOST: edgex-app-mqtt-export
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
       WRITABLE_INSECURESECRETS_MQTT_SECRETS_PASSWORD: PASSWORD_PLACE_HOLDER
       WRITABLE_INSECURESECRETS_MQTT_SECRETS_USERNAME: USERNAME_PLACEH_OLDER
@@ -275,30 +346,53 @@ services:
     hostname: edgex-app-mqtt-export
     image: nexus3.edgexfoundry.org:10004/app-service-configurable-arm64:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59703:59703/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59703
+      published: "59703"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - /tmp/edgex/secrets/app-mqtt-export:/tmp/edgex/secrets/app-mqtt-export:ro,z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/app-mqtt-export
+      target: /tmp/edgex/secrets/app-mqtt-export
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   app-service-rules:
-    command: /app-service-configurable -cp=consul.http://edgex-core-consul:8500 --registry
+    command:
+    - /app-service-configurable
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
     container_name: edgex-app-rules-engine
     depends_on:
-    - consul
-    - data
-    - mqtt-broker
-    - security-bootstrapper
+      consul:
+        condition: service_started
+      data:
+        condition: service_started
+      mqtt-broker:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/ready_to_run_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
@@ -309,127 +403,175 @@ services:
       EDGEX_SECURITY_SECRET_STORE: "true"
       MESSAGEBUS_AUTHMODE: usernamepassword
       MESSAGEBUS_HOST: edgex-mqtt-broker
-      MESSAGEBUS_PORT: 1883
+      MESSAGEBUS_PORT: "1883"
       MESSAGEBUS_PROTOCOL: tcp
       MESSAGEBUS_SECRETNAME: message-bus
       MESSAGEBUS_TYPE: mqtt
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SERVICE_HOST: edgex-app-rules-engine
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-app-rules-engine
     image: nexus3.edgexfoundry.org:10004/app-service-configurable-arm64:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59701:59701/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59701
+      published: "59701"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - /tmp/edgex/secrets/app-rules-engine:/tmp/edgex/secrets/app-rules-engine:ro,z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/app-rules-engine
+      target: /tmp/edgex/secrets/app-rules-engine
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   app-service-sample:
-    command: /app-service-configurable -cp=consul.http://edgex-core-consul:8500 --registry
+    command:
+    - /app-service-configurable
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
     container_name: edgex-app-sample
     depends_on:
-    - consul
-    - data
-    - mqtt-broker
-    - security-bootstrapper
+      consul:
+        condition: service_started
+      data:
+        condition: service_started
+      mqtt-broker:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/ready_to_run_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
       CLIENTS_SUPPORT_NOTIFICATIONS_HOST: edgex-support-notifications
       CLIENTS_SUPPORT_SCHEDULER_HOST: edgex-support-scheduler
-      DATABASES_PRIMARY_HOST: edgex-redis
       DATABASE_HOST: edgex-redis
+      DATABASES_PRIMARY_HOST: edgex-redis
       EDGEX_PROFILE: sample
       EDGEX_SECURITY_SECRET_STORE: "true"
       MESSAGEBUS_AUTHMODE: usernamepassword
       MESSAGEBUS_HOST: edgex-mqtt-broker
-      MESSAGEBUS_PORT: '1883'
+      MESSAGEBUS_PORT: "1883"
       MESSAGEBUS_PROTOCOL: tcp
       MESSAGEBUS_SECRETNAME: message-bus
       MESSAGEBUS_TYPE: mqtt
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SERVICE_HOST: edgex-app-sample
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-app-sample
     image: nexus3.edgexfoundry.org:10004/app-service-configurable-arm64:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59700:59700/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59700
+      published: "59700"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - /tmp/edgex/secrets/app-sample:/tmp/edgex/secrets/app-sample:ro,z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/app-sample
+      target: /tmp/edgex/secrets/app-sample
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   command:
-    command: /core-command -cp=consul.http://edgex-core-consul:8500 --registry
+    command:
+    - /core-command
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
     container_name: edgex-core-command
     depends_on:
-    - consul
-    - database
-    - metadata
-    - mqtt-broker
-    - secretstore-setup
-    - security-bootstrapper
+      consul:
+        condition: service_started
+      database:
+        condition: service_started
+      metadata:
+        condition: service_started
+      mqtt-broker:
+        condition: service_started
+      secretstore-setup:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/ready_to_run_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
@@ -441,118 +583,182 @@ services:
       MESSAGEBUS_EXTERNAL_URL: tcp://edgex-mqtt-broker:1883
       MESSAGEBUS_INTERNAL_AUTHMODE: usernamepassword
       MESSAGEBUS_INTERNAL_HOST: edgex-mqtt-broker
-      MESSAGEBUS_INTERNAL_PORT: 1883
+      MESSAGEBUS_INTERNAL_PORT: "1883"
       MESSAGEBUS_INTERNAL_PROTOCOL: tcp
       MESSAGEBUS_INTERNAL_SECRETNAME: message-bus
       MESSAGEBUS_INTERNAL_TYPE: mqtt
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SERVICE_HOST: edgex-core-command
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-core-command
     image: nexus3.edgexfoundry.org:10004/core-command-arm64:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59882:59882/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59882
+      published: "59882"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - /tmp/edgex/secrets/core-command:/tmp/edgex/secrets/core-command:ro,z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/core-command
+      target: /tmp/edgex/secrets/core-command
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   consul:
-    command: agent -ui -bootstrap -server -client 0.0.0.0
+    command:
+    - agent
+    - -ui
+    - -bootstrap
+    - -server
+    - -client
+    - 0.0.0.0
     container_name: edgex-core-consul
     depends_on:
-    - security-bootstrapper
-    - vault
+      security-bootstrapper:
+        condition: service_started
+      vault:
+        condition: service_started
     entrypoint:
     - /edgex-init/consul_wait_install.sh
     environment:
       ADD_REGISTRY_ACL_ROLES: app-http-export,app-mqtt-export,app-functional-tests,app-scalability-test-mqtt-export,app-sample,device-modbus,app-external-mqtt-trigger,device-onvif-camera
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
-      EDGEX_GROUP: '2001'
+      API_GATEWAY_STATUS_PORT: "8100"
+      EDGEX_GROUP: "2001"
       EDGEX_SECURITY_SECRET_STORE: "true"
-      EDGEX_USER: '2002'
+      EDGEX_USER: "2002"
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_ACL_BOOTSTRAPTOKENPATH: /tmp/edgex/secrets/consul-acl-token/bootstrap_token.json
       STAGEGATE_REGISTRY_ACL_MANAGEMENTTOKENPATH: /tmp/edgex/secrets/consul-acl-token/mgmt_token.json
       STAGEGATE_REGISTRY_ACL_SENTINELFILEPATH: /consul/config/consul_acl_done
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-core-consul
     image: consul:1.13
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:8500:8500/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 8500
+      published: "8500"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: root:root
     volumes:
-    - consul-config:/consul/config:z
-    - consul-data:/consul/data:z
-    - edgex-init:/edgex-init:ro,z
-    - consul-acl-token:/tmp/edgex/secrets/consul-acl-token:z
-    - /tmp/edgex/secrets/edgex-consul:/tmp/edgex/secrets/edgex-consul:ro,z
+    - type: volume
+      source: consul-config
+      target: /consul/config
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: consul-data
+      target: /consul/data
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: consul-acl-token
+      target: /tmp/edgex/secrets/consul-acl-token
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/edgex-consul
+      target: /tmp/edgex/secrets/edgex-consul
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   data:
-    command: /core-data -cp=consul.http://edgex-core-consul:8500 --registry
+    command:
+    - /core-data
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
     container_name: edgex-core-data
     depends_on:
-    - consul
-    - database
-    - metadata
-    - mqtt-broker
-    - secretstore-setup
-    - security-bootstrapper
+      consul:
+        condition: service_started
+      database:
+        condition: service_started
+      metadata:
+        condition: service_started
+      mqtt-broker:
+        condition: service_started
+      secretstore-setup:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/ready_to_run_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
@@ -563,59 +769,81 @@ services:
       MESSAGEBUS_AUTHMODE: usernamepassword
       MESSAGEBUS_HOST: edgex-mqtt-broker
       MESSAGEBUS_OPTIONAL_CLIENTID: core-data
-      MESSAGEBUS_PORT: '1883'
+      MESSAGEBUS_PORT: "1883"
       MESSAGEBUS_PROTOCOL: tcp
       MESSAGEBUS_SECRETNAME: message-bus
       MESSAGEBUS_TYPE: mqtt
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SECRETSTORE_TOKENFILE: /tmp/edgex/secrets/core-data/secrets-token.json
       SERVICE_HOST: edgex-core-data
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-core-data
     image: nexus3.edgexfoundry.org:10004/core-data-arm64:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:5563:5563/tcp
-    - 127.0.0.1:59880:59880/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 5563
+      published: "5563"
+      protocol: tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59880
+      published: "59880"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - /tmp/edgex/secrets/core-data:/tmp/edgex/secrets/core-data:ro,z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/core-data
+      target: /tmp/edgex/secrets/core-data
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   database:
     container_name: edgex-redis
     depends_on:
-    - secretstore-setup
-    - security-bootstrapper
+      secretstore-setup:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/redis_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
@@ -628,31 +856,35 @@ services:
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-redis
     image: redis:7.0-alpine
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:6379:6379/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 6379
+      published: "6379"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
@@ -661,25 +893,57 @@ services:
     - /run
     user: root:root
     volumes:
-    - db-data:/data:z
-    - edgex-init:/edgex-init:ro,z
-    - redis-config:/run/redis/conf:z
-    - /tmp/edgex/secrets/security-bootstrapper-redis:/tmp/edgex/secrets/security-bootstrapper-redis:ro,z
+    - type: volume
+      source: db-data
+      target: /data
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: redis-config
+      target: /run/redis/conf
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/security-bootstrapper-redis
+      target: /tmp/edgex/secrets/security-bootstrapper-redis
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   device-modbus:
-    command: /device-modbus -cp=consul.http://edgex-core-consul:8500 --registry --configDir=CONFIG_DIR_PLACE_HOLDER
+    command:
+    - /device-modbus
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
+    - --configDir=CONFIG_DIR_PLACE_HOLDER
     container_name: edgex-device-modbus
     depends_on:
-    - consul
-    - data
-    - metadata
-    - modbus-simulator
-    - mqtt-broker
-    - security-bootstrapper
+      consul:
+        condition: service_started
+      data:
+        condition: service_started
+      metadata:
+        condition: service_started
+      modbus-simulator:
+        condition: service_started
+      mqtt-broker:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/ready_to_run_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
@@ -689,62 +953,91 @@ services:
       EDGEX_SECURITY_SECRET_STORE: "true"
       MESSAGEBUS_AUTHMODE: usernamepassword
       MESSAGEBUS_HOST: edgex-mqtt-broker
-      MESSAGEBUS_PORT: '1883'
+      MESSAGEBUS_PORT: "1883"
       MESSAGEBUS_PROTOCOL: tcp
       MESSAGEBUS_SECRETNAME: message-bus
       MESSAGEBUS_TYPE: mqtt
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SERVICE_HOST: edgex-device-modbus
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-device-modbus
     image: nexus3.edgexfoundry.org:10004/device-modbus-arm64:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59901:59901/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59901
+      published: "59901"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - /tmp/edgex/secrets/device-modbus:/tmp/edgex/secrets/device-modbus:ro,z
-    - PROFILE_VOLUME_PLACE_HOLDER:CONFIG_DIR_PLACE_HOLDER:z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/device-modbus
+      target: /tmp/edgex/secrets/device-modbus
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
+    - type: bind
+      source: /PROFILE_VOLUME_PLACE_HOLDER
+      target: CONFIG_DIR_PLACE_HOLDER
+      bind:
+        selinux: z
+        create_host_path: true
   device-onvif-camera:
-    command: /device-onvif-camera -cp=consul.http://edgex-core-consul:8500 --registry
+    command:
+    - /device-onvif-camera
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
     container_name: edgex-device-onvif-camera
     depends_on:
-    - consul
-    - data
-    - metadata
-    - mqtt-broker
-    - security-bootstrapper
+      consul:
+        condition: service_started
+      data:
+        condition: service_started
+      metadata:
+        condition: service_started
+      mqtt-broker:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/ready_to_run_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
@@ -754,61 +1047,85 @@ services:
       EDGEX_SECURITY_SECRET_STORE: "true"
       MESSAGEBUS_AUTHMODE: usernamepassword
       MESSAGEBUS_HOST: edgex-mqtt-broker
-      MESSAGEBUS_PORT: '1883'
+      MESSAGEBUS_PORT: "1883"
       MESSAGEBUS_PROTOCOL: tcp
       MESSAGEBUS_SECRETNAME: message-bus
       MESSAGEBUS_TYPE: mqtt
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SERVICE_HOST: edgex-device-onvif-camera
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-device-onvif-camera
     image: nexus3.edgexfoundry.org:10004/device-onvif-camera-arm64:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59984:59984/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59984
+      published: "59984"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - /tmp/edgex/secrets/device-onvif-camera:/tmp/edgex/secrets/device-onvif-camera:ro,z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/device-onvif-camera
+      target: /tmp/edgex/secrets/device-onvif-camera
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   device-rest:
-    command: /device-rest -cp=consul.http://edgex-core-consul:8500 --registry
+    command:
+    - /device-rest
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
     container_name: edgex-device-rest
     depends_on:
-    - consul
-    - data
-    - metadata
-    - mqtt-broker
-    - security-bootstrapper
+      consul:
+        condition: service_started
+      data:
+        condition: service_started
+      metadata:
+        condition: service_started
+      mqtt-broker:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/ready_to_run_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
@@ -818,61 +1135,86 @@ services:
       EDGEX_SECURITY_SECRET_STORE: "true"
       MESSAGEBUS_AUTHMODE: usernamepassword
       MESSAGEBUS_HOST: edgex-mqtt-broker
-      MESSAGEBUS_PORT: '1883'
+      MESSAGEBUS_PORT: "1883"
       MESSAGEBUS_PROTOCOL: tcp
       MESSAGEBUS_SECRETNAME: message-bus
       MESSAGEBUS_TYPE: mqtt
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SERVICE_HOST: edgex-device-rest
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-device-rest
     image: nexus3.edgexfoundry.org:10004/device-rest-arm64:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59986:59986/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59986
+      published: "59986"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - /tmp/edgex/secrets/device-rest:/tmp/edgex/secrets/device-rest:ro,z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/device-rest
+      target: /tmp/edgex/secrets/device-rest
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   device-virtual:
-    command: /device-virtual -cp=consul.http://edgex-core-consul:8500 --registry --configDir=CONFIG_DIR_PLACE_HOLDER
+    command:
+    - /device-virtual
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
+    - --configDir=CONFIG_DIR_PLACE_HOLDER
     container_name: edgex-device-virtual
     depends_on:
-    - consul
-    - data
-    - metadata
-    - mqtt-broker
-    - security-bootstrapper
+      consul:
+        condition: service_started
+      data:
+        condition: service_started
+      metadata:
+        condition: service_started
+      mqtt-broker:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/ready_to_run_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
@@ -882,65 +1224,88 @@ services:
       EDGEX_SECURITY_SECRET_STORE: "true"
       MESSAGEBUS_AUTHMODE: usernamepassword
       MESSAGEBUS_HOST: edgex-mqtt-broker
-      MESSAGEBUS_PORT: '1883'
+      MESSAGEBUS_PORT: "1883"
       MESSAGEBUS_PROTOCOL: tcp
       MESSAGEBUS_SECRETNAME: message-bus
       MESSAGEBUS_TYPE: mqtt
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SERVICE_HOST: edgex-device-virtual
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-device-virtual
     image: nexus3.edgexfoundry.org:10004/device-virtual-arm64:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59900:59900/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59900
+      published: "59900"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - /tmp/edgex/secrets/device-virtual:/tmp/edgex/secrets/device-virtual:ro,z
-    - PROFILE_VOLUME_PLACE_HOLDER:CONFIG_DIR_PLACE_HOLDER:z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/device-virtual
+      target: /tmp/edgex/secrets/device-virtual
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
+    - type: bind
+      source: /PROFILE_VOLUME_PLACE_HOLDER
+      target: CONFIG_DIR_PLACE_HOLDER
+      bind:
+        selinux: z
+        create_host_path: true
   kong:
     container_name: edgex-kong
     depends_on:
-    - kong-db
-    - security-bootstrapper
+      kong-db:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/kong_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       KONG_ADMIN_ACCESS_LOG: /dev/stdout
       KONG_ADMIN_ERROR_LOG: /dev/stderr
       KONG_ADMIN_LISTEN: 127.0.0.1:8001, 127.0.0.1:8444 ssl
       KONG_DATABASE: postgres
       KONG_DNS_ORDER: LAST,A,CNAME
-      KONG_DNS_VALID_TTL: '1'
-      KONG_NGINX_WORKER_PROCESSES: '1'
+      KONG_DNS_VALID_TTL: "1"
+      KONG_NGINX_WORKER_PROCESSES: "1"
       KONG_PG_HOST: edgex-kong-db
       KONG_PG_PASSWORD_FILE: /tmp/postgres-config/.pgpassword
       KONG_PROXY_ACCESS_LOG: /dev/stdout
@@ -949,28 +1314,38 @@ services:
       KONG_STATUS_LISTEN: 0.0.0.0:8100
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-kong
     image: kong:2.8
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 8000:8000/tcp
-    - 127.0.0.1:8100:8100/tcp
-    - 8443:8443/tcp
+    - mode: ingress
+      target: 8000
+      published: "8000"
+      protocol: tcp
+    - mode: ingress
+      target: 8443
+      published: "8443"
+      protocol: tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 8100
+      published: "8100"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
@@ -981,50 +1356,77 @@ services:
     tty: true
     user: kong:nogroup
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - /tmp/edgex/secrets/security-proxy-setup:/tmp/edgex/secrets/security-proxy-setup:ro,z
-    - postgres-config:/tmp/postgres-config:z
-    - kong:/usr/local/kong:z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: postgres-config
+      target: /tmp/postgres-config
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: kong
+      target: /usr/local/kong
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/security-proxy-setup
+      target: /tmp/edgex/secrets/security-proxy-setup
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   kong-db:
     container_name: edgex-kong-db
     depends_on:
-    - security-bootstrapper
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/postgres_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       EDGEX_SECURITY_SECRET_STORE: "true"
       POSTGRES_DB: kong
       POSTGRES_PASSWORD_FILE: /tmp/postgres-config/.pgpassword
       POSTGRES_USER: kong
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-kong-db
     image: postgres:13.8-alpine
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:5432:5432/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 5432
+      published: "5432"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
@@ -1035,24 +1437,49 @@ services:
     - /run
     user: root:root
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - postgres-config:/tmp/postgres-config:z
-    - postgres-data:/var/lib/postgresql/data:z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: postgres-data
+      target: /var/lib/postgresql/data
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: postgres-config
+      target: /tmp/postgres-config
+      bind:
+        selinux: z
+      volume: {}
   metadata:
-    command: /core-metadata -cp=consul.http://edgex-core-consul:8500 --registry
+    command:
+    - /core-metadata
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
     container_name: edgex-core-metadata
     depends_on:
-    - consul
-    - database
-    - mqtt-broker
-    - notifications
-    - secretstore-setup
-    - security-bootstrapper
+      consul:
+        condition: service_started
+      database:
+        condition: service_started
+      mqtt-broker:
+        condition: service_started
+      notifications:
+        condition: service_started
+      secretstore-setup:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/ready_to_run_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
@@ -1063,7 +1490,7 @@ services:
       MESSAGEBUS_AUTHMODE: usernamepassword
       MESSAGEBUS_HOST: edgex-mqtt-broker
       MESSAGEBUS_OPTIONAL_CLIENTID: core-metadata
-      MESSAGEBUS_PORT: '1883'
+      MESSAGEBUS_PORT: "1883"
       MESSAGEBUS_PROTOCOL: tcp
       MESSAGEBUS_SECRETNAME: message-bus
       MESSAGEBUS_TYPE: mqtt
@@ -1071,132 +1498,193 @@ services:
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SERVICE_HOST: edgex-core-metadata
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-core-metadata
     image: nexus3.edgexfoundry.org:10004/core-metadata-arm64:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59881:59881/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59881
+      published: "59881"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - /tmp/edgex/secrets/core-metadata:/tmp/edgex/secrets/core-metadata:ro,z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/core-metadata
+      target: /tmp/edgex/secrets/core-metadata
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   modbus-simulator:
     container_name: edgex-modbus-simulator
     hostname: edgex-modbus-simulator
     image: nexus3.edgexfoundry.org:10003/edgex-devops/edgex-modbus-simulator-arm64:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:1502:1502/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 1502
+      published: "1502"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
   mqtt-broker:
-    command: /usr/sbin/mosquitto -c /mosquitto/config/mosquitto.conf
+    command:
+    - /usr/sbin/mosquitto
+    - -c
+    - /mosquitto/config/mosquitto.conf
     container_name: edgex-mqtt-broker
     depends_on:
-    - secretstore-setup
-    - security-bootstrapper
+      secretstore-setup:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/messagebus_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       BROKER_TYPE: mosquitto
       CONF_DIR: /edgex-init/bootstrap-mosquitto/res
       EDGEX_SECURITY_SECRET_STORE: "true"
       ENTRYPOINT: /docker-entrypoint.sh /usr/sbin/mosquitto -c /mosquitto/config/mosquitto.conf
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-mqtt-broker
     image: eclipse-mosquitto:2.0
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:1883:1883/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 1883
+      published: "1883"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: root:root
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - mqtt:/mosquitto:z
-    - /tmp/edgex/secrets/security-bootstrapper-messagebus:/tmp/edgex/secrets/security-bootstrapper-messagebus:ro,z
+    - type: volume
+      source: mqtt
+      target: /mosquitto
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/security-bootstrapper-messagebus
+      target: /tmp/edgex/secrets/security-bootstrapper-messagebus
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   mqtt-taf-broker:
-    command: /usr/sbin/mosquitto -c /mosquitto-no-auth.conf
+    command:
+    - /usr/sbin/mosquitto
+    - -c
+    - /mosquitto-no-auth.conf
     container_name: edgex-taf-mqtt-broker
     hostname: edgex-taf-mqtt-broker
     image: eclipse-mosquitto:2.0
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:1884:1883/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 1883
+      published: "1884"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
   notifications:
-    command: /support-notifications -cp=consul.http://edgex-core-consul:8500 --registry
+    command:
+    - /support-notifications
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
     container_name: edgex-support-notifications
     depends_on:
-    - consul
-    - database
-    - mqtt-broker
-    - secretstore-setup
-    - security-bootstrapper
+      consul:
+        condition: service_started
+      database:
+        condition: service_started
+      mqtt-broker:
+        condition: service_started
+      secretstore-setup:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/ready_to_run_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
@@ -1207,59 +1695,78 @@ services:
       MESSAGEBUS_AUTHMODE: usernamepassword
       MESSAGEBUS_HOST: edgex-mqtt-broker
       MESSAGEBUS_OPTIONAL_CLIENTID: support-notifications
-      MESSAGEBUS_PORT: '1883'
+      MESSAGEBUS_PORT: "1883"
       MESSAGEBUS_PROTOCOL: tcp
       MESSAGEBUS_SECRETNAME: message-bus
       MESSAGEBUS_TYPE: mqtt
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SERVICE_HOST: edgex-support-notifications
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-support-notifications
     image: nexus3.edgexfoundry.org:10004/support-notifications-arm64:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59860:59860/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59860
+      published: "59860"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - /tmp/edgex/secrets/support-notifications:/tmp/edgex/secrets/support-notifications:ro,z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/support-notifications
+      target: /tmp/edgex/secrets/support-notifications
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   proxy-setup:
     container_name: edgex-security-proxy-setup
     depends_on:
-    - kong
-    - secretstore-setup
-    - security-bootstrapper
+      kong:
+        condition: service_started
+      secretstore-setup:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/proxy_setup_wait_install.sh
     environment:
       ADD_PROXY_ROUTE: device-modbus.http://edgex-device-modbus:59901
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       EDGEX_SECURITY_SECRET_STORE: "true"
       KONGURL_SERVER: edgex-kong
       PROXY_SETUP_HOST: edgex-security-proxy-setup
@@ -1273,127 +1780,181 @@ services:
       ROUTES_SUPPORT_SCHEDULER_HOST: edgex-support-scheduler
       ROUTES_SYS_MGMT_AGENT_HOST: edgex-sys-mgmt-agent
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-security-proxy-setup
     image: nexus3.edgexfoundry.org:10004/security-proxy-setup-arm64:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     read_only: true
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - consul-acl-token:/tmp/edgex/secrets/consul-acl-token:ro,z
-    - /tmp/edgex/secrets/security-proxy-setup:/tmp/edgex/secrets/security-proxy-setup:ro,z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: consul-acl-token
+      target: /tmp/edgex/secrets/consul-acl-token
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/security-proxy-setup
+      target: /tmp/edgex/secrets/security-proxy-setup
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   rulesengine:
     container_name: edgex-kuiper
     depends_on:
-    - database
-    - mqtt-broker
-    - secretstore-setup
-    - security-bootstrapper
+      database:
+        condition: service_started
+      mqtt-broker:
+        condition: service_started
+      secretstore-setup:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/kuiper_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       CONNECTION__EDGEX__MQTTMSGBUS__OPTIONAL__CLIENTID: kuiper-rules-engine
-      CONNECTION__EDGEX__MQTTMSGBUS__OPTIONAL__KEEPALIVE: 500
-      CONNECTION__EDGEX__MQTTMSGBUS__PORT: 1883
+      CONNECTION__EDGEX__MQTTMSGBUS__OPTIONAL__KEEPALIVE: "500"
+      CONNECTION__EDGEX__MQTTMSGBUS__PORT: "1883"
       CONNECTION__EDGEX__MQTTMSGBUS__PROTOCOL: tcp
       CONNECTION__EDGEX__MQTTMSGBUS__SERVER: edgex-mqtt-broker
       CONNECTION__EDGEX__MQTTMSGBUS__TYPE: mqtt
-      CONNECTION__EDGEX__REDISMSGBUS__PORT: 6379
+      CONNECTION__EDGEX__REDISMSGBUS__PORT: "6379"
       CONNECTION__EDGEX__REDISMSGBUS__PROTOCOL: redis
       CONNECTION__EDGEX__REDISMSGBUS__SERVER: edgex-redis
       CONNECTION__EDGEX__REDISMSGBUS__TYPE: redis
       EDGEX__DEFAULT__OPTIONAL__CLIENTID: kuiper-rules-engine
-      EDGEX__DEFAULT__OPTIONAL__KEEPALIVE: 500
-      EDGEX__DEFAULT__PORT: 1883
+      EDGEX__DEFAULT__OPTIONAL__KEEPALIVE: "500"
+      EDGEX__DEFAULT__PORT: "1883"
       EDGEX__DEFAULT__PROTOCOL: tcp
       EDGEX__DEFAULT__SERVER: edgex-mqtt-broker
       EDGEX__DEFAULT__TOPIC: rules-events
       EDGEX__DEFAULT__TYPE: mqtt
       KUIPER__BASIC__CONSOLELOG: "true"
-      KUIPER__BASIC__RESTPORT: 59720
+      KUIPER__BASIC__RESTPORT: "59720"
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-kuiper
     image: lfedge/ekuiper:1.7-alpine
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59720:59720/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59720
+      published: "59720"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: kuiper:kuiper
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - kuiper-data:/kuiper/data:z
-    - kuiper-connections:/kuiper/etc/connections:z
-    - kuiper-sources:/kuiper/etc/sources:z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: kuiper-data
+      target: /kuiper/data
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: kuiper-connections
+      target: /kuiper/etc/connections
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: kuiper-sources
+      target: /kuiper/etc/sources
+      bind:
+        selinux: z
+      volume: {}
   scalability-test-mqtt-export:
-    command: /app-service-configurable -cp=consul.http://edgex-core-consul:8500 --registry
+    command:
+    - /app-service-configurable
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
     container_name: edgex-scalability-test-mqtt-export
     depends_on:
-    - consul
-    - data
-    - mqtt-broker
-    - security-bootstrapper
+      consul:
+        condition: service_started
+      data:
+        condition: service_started
+      mqtt-broker:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/ready_to_run_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
       CLIENTS_SUPPORT_NOTIFICATIONS_HOST: edgex-support-notifications
       CLIENTS_SUPPORT_SCHEDULER_HOST: edgex-support-scheduler
-      DATABASES_PRIMARY_HOST: edgex-redis
       DATABASE_HOST: edgex-redis
+      DATABASES_PRIMARY_HOST: edgex-redis
       EDGEX_PROFILE: mqtt-export
       EDGEX_SECURITY_SECRET_STORE: "true"
       EDGEX_SERVICE_KEY: app-scalability-test-mqtt-export
       MESSAGEBUS_AUTHMODE: usernamepassword
       MESSAGEBUS_HOST: edgex-mqtt-broker
       MESSAGEBUS_OPTIONAL_CLIENTID: app-scalability-test-mqtt-export
-      MESSAGEBUS_PORT: '1883'
+      MESSAGEBUS_PORT: "1883"
       MESSAGEBUS_PROTOCOL: tcp
       MESSAGEBUS_SECRETNAME: message-bus
       MESSAGEBUS_TYPE: mqtt
@@ -1401,26 +1962,26 @@ services:
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault
       SECRETSTORE_PATH: /app-scalability-test-mqtt-export
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SECRETSTORE_TOKENFILE: /tmp/edgex/secrets/app-scalability-test-mqtt-export/secrets-token.json
       SERVICE_HOST: edgex-scalability-test-mqtt-export
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
       WRITABLE_INSECURESECRETS_MQTT_SECRETS_PASSWORD: PASSWORD_PLACE_HOLDER
       WRITABLE_INSECURESECRETS_MQTT_SECRETS_USERNAME: USERNAME_PLACEH_OLDER
@@ -1431,30 +1992,53 @@ services:
     hostname: edgex-scalability-test-mqtt-export
     image: nexus3.edgexfoundry.org:10004/app-service-configurable-arm64:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 59710:59703/tcp
+    - mode: ingress
+      target: 59703
+      published: "59710"
+      protocol: tcp
     read_only: true
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - /tmp/edgex/secrets/app-scalability-test-mqtt-export:/tmp/edgex/secrets/app-scalability-test-mqtt-export:ro,z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/app-scalability-test-mqtt-export
+      target: /tmp/edgex/secrets/app-scalability-test-mqtt-export
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   scheduler:
-    command: /support-scheduler -cp=consul.http://edgex-core-consul:8500 --registry
+    command:
+    - /support-scheduler
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
     container_name: edgex-support-scheduler
     depends_on:
-    - consul
-    - database
-    - mqtt-broker
-    - secretstore-setup
-    - security-bootstrapper
+      consul:
+        condition: service_started
+      database:
+        condition: service_started
+      mqtt-broker:
+        condition: service_started
+      secretstore-setup:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/ready_to_run_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
@@ -1467,86 +2051,104 @@ services:
       MESSAGEBUS_AUTHMODE: usernamepassword
       MESSAGEBUS_HOST: edgex-mqtt-broker
       MESSAGEBUS_OPTIONAL_CLIENTID: support-scheduler
-      MESSAGEBUS_PORT: '1883'
+      MESSAGEBUS_PORT: "1883"
       MESSAGEBUS_PROTOCOL: tcp
       MESSAGEBUS_SECRETNAME: message-bus
       MESSAGEBUS_TYPE: mqtt
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SERVICE_HOST: edgex-support-scheduler
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-support-scheduler
     image: nexus3.edgexfoundry.org:10004/support-scheduler-arm64:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59861:59861/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59861
+      published: "59861"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - /tmp/edgex/secrets/support-scheduler:/tmp/edgex/secrets/support-scheduler:ro,z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/support-scheduler
+      target: /tmp/edgex/secrets/support-scheduler
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   secretstore-setup:
     container_name: edgex-security-secretstore-setup
     depends_on:
-    - security-bootstrapper
-    - vault
+      security-bootstrapper:
+        condition: service_started
+      vault:
+        condition: service_started
     environment:
       ADD_KNOWN_SECRETS: redisdb[app-rules-engine],redisdb[app-http-export],redisdb[app-mqtt-export],redisdb[app-scalability-test-mqtt-export],redisdb[app-sample],redisdb[device-modbus],redisdb[device-rest],redisdb[device-virtual],redisdb[device-onvif-camera],message-bus[app-rules-engine],message-bus[app-http-export],message-bus[app-mqtt-export],message-bus[app-external-mqtt-trigger],message-bus[app-scalability-test-mqtt-export],message-bus[app-sample],message-bus[device-modbus],message-bus[device-rest],message-bus[device-virtual],message-bus[device-onvif-camera]
       ADD_SECRETSTORE_TOKENS: app-http-export,app-mqtt-export,app-functional-tests,app-scalability-test-mqtt-export,app-sample,device-modbus,app-external-mqtt-trigger,device-onvif-camera
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
-      EDGEX_GROUP: '2001'
+      API_GATEWAY_STATUS_PORT: "8100"
+      EDGEX_GROUP: "2001"
       EDGEX_SECURITY_SECRET_STORE: "true"
-      EDGEX_USER: '2002'
+      EDGEX_USER: "2002"
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SECUREMESSAGEBUS_TYPE: mqtt
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-security-secretstore-setup
     image: nexus3.edgexfoundry.org:10004/security-secretstore-setup-arm64:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     read_only: true
     restart: always
     security_opt:
@@ -1556,59 +2158,100 @@ services:
     - /vault
     user: root:root
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - /tmp/edgex/secrets:/tmp/edgex/secrets:z
-    - kong:/tmp/kong:z
-    - kuiper-sources:/tmp/kuiper:z
-    - kuiper-connections:/tmp/kuiper-connections:z
-    - vault-config:/vault/config:z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets
+      target: /tmp/edgex/secrets
+      bind:
+        selinux: z
+        create_host_path: true
+    - type: volume
+      source: kong
+      target: /tmp/kong
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: kuiper-sources
+      target: /tmp/kuiper
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: kuiper-connections
+      target: /tmp/kuiper-connections
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: vault-config
+      target: /vault/config
+      bind:
+        selinux: z
+      volume: {}
   security-bootstrapper:
     container_name: edgex-security-bootstrapper
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
-      EDGEX_GROUP: '2001'
-      EDGEX_USER: '2002'
+      API_GATEWAY_STATUS_PORT: "8100"
+      EDGEX_GROUP: "2001"
+      EDGEX_USER: "2002"
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-security-bootstrapper
     image: nexus3.edgexfoundry.org:10004/security-bootstrapper-arm64:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: root:root
     volumes:
-    - edgex-init:/edgex-init:z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      bind:
+        selinux: z
+      volume: {}
   security-spiffe-token-provider:
-    command: /security-spiffe-token-provider -cp=consul.http://edgex-core-consul:8500
-      --registry
+    command:
+    - /security-spiffe-token-provider
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
     container_name: edgex-security-spiffe-token-provider
     depends_on:
-    - consul
-    - security-bootstrapper
-    - security-spire-agent
+      consul:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
+      security-spire-agent:
+        condition: service_started
     entrypoint:
     - /edgex-init/ready_to_run_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
@@ -1619,32 +2262,36 @@ services:
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SERVICE_HOST: edgex-security-spiffe-token-provider
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-security-spiffe-token-provider
     image: nexus3.edgexfoundry.org:10004/security-spiffe-token-provider-arm64:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59841:59841/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59841
+      published: "59841"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
@@ -1653,19 +2300,36 @@ services:
     - /run
     user: root:root
     volumes:
-    - edgex-init:/edgex-init:z
-    - /tmp/edgex/secrets/security-spiffe-token-provider:/tmp/edgex/secrets/security-spiffe-token-provider:z
-    - /tmp/edgex/secrets/spiffe:/tmp/edgex/secrets/spiffe:z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/spiffe
+      target: /tmp/edgex/secrets/spiffe
+      bind:
+        selinux: z
+        create_host_path: true
+    - type: bind
+      source: /tmp/edgex/secrets/security-spiffe-token-provider
+      target: /tmp/edgex/secrets/security-spiffe-token-provider
+      bind:
+        selinux: z
+        create_host_path: true
   security-spire-agent:
-    command: docker-entrypoint.sh
+    command:
+    - docker-entrypoint.sh
     container_name: edgex-security-spire-agent
     depends_on:
-    - security-spire-server
+      security-spire-server:
+        condition: service_started
     entrypoint:
     - /edgex-init/ready_to_run_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
@@ -1676,29 +2340,29 @@ services:
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-security-spire-agent
     image: nexus3.edgexfoundry.org:10004/security-spire-agent-arm64:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     pid: host
     privileged: true
     read_only: true
@@ -1709,21 +2373,47 @@ services:
     - /run
     user: root:root
     volumes:
-    - edgex-init:/edgex-init:z
-    - spire-agent:/srv/spiffe/agent:z
-    - spire-ca:/srv/spiffe/ca:z
-    - /tmp/edgex/secrets/spiffe:/tmp/edgex/secrets/spiffe:z
-    - /var/run/docker.sock:/var/run/docker.sock:rw
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: spire-ca
+      target: /srv/spiffe/ca
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: spire-agent
+      target: /srv/spiffe/agent
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/spiffe
+      target: /tmp/edgex/secrets/spiffe
+      bind:
+        selinux: z
+        create_host_path: true
+    - type: bind
+      source: /var/run/docker.sock
+      target: /var/run/docker.sock
+      bind:
+        create_host_path: true
   security-spire-config:
-    command: docker-entrypoint.sh
+    command:
+    - docker-entrypoint.sh
     container_name: edgex-security-spire-config
     depends_on:
-    - security-spire-agent
+      security-spire-agent:
+        condition: service_started
     entrypoint:
     - /edgex-init/ready_to_run_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
@@ -1734,29 +2424,29 @@ services:
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-security-spire-config
     image: nexus3.edgexfoundry.org:10004/security-spire-config-arm64:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     read_only: true
     restart: always
     security_opt:
@@ -1765,18 +2455,30 @@ services:
     - /run
     user: root:root
     volumes:
-    - edgex-init:/edgex-init:z
-    - /tmp/edgex/secrets/spiffe:/tmp/edgex/secrets/spiffe:z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/spiffe
+      target: /tmp/edgex/secrets/spiffe
+      bind:
+        selinux: z
+        create_host_path: true
   security-spire-server:
-    command: docker-entrypoint.sh
+    command:
+    - docker-entrypoint.sh
     container_name: edgex-security-spire-server
     depends_on:
-    - security-bootstrapper
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/ready_to_run_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
@@ -1787,32 +2489,36 @@ services:
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-security-spire-server
     image: nexus3.edgexfoundry.org:10004/security-spire-server-arm64:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     pid: host
     ports:
-    - 127.0.0.1:59840:59840/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59840
+      published: "59840"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
@@ -1821,10 +2527,30 @@ services:
     - /run
     user: root:root
     volumes:
-    - edgex-init:/edgex-init:z
-    - spire-ca:/srv/spiffe/ca:z
-    - spire-server:/srv/spiffe/server:z
-    - /tmp/edgex/secrets/spiffe:/tmp/edgex/secrets/spiffe:z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: spire-ca
+      target: /srv/spiffe/ca
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: spire-server
+      target: /srv/spiffe/server
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/spiffe
+      target: /tmp/edgex/secrets/spiffe
+      bind:
+        selinux: z
+        create_host_path: true
   ui:
     container_name: edgex-ui-go
     environment:
@@ -1833,9 +2559,12 @@ services:
     hostname: edgex-ui-go
     image: nexus3.edgexfoundry.org:10004/edgex-ui-arm64:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 4000:4000/tcp
+    - mode: ingress
+      target: 4000
+      published: "4000"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
@@ -1844,30 +2573,32 @@ services:
   vault:
     cap_add:
     - IPC_LOCK
-    command: server
+    command:
+    - server
     container_name: edgex-vault
     depends_on:
-    - security-bootstrapper
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/vault_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
       VAULT_ADDR: http://edgex-vault:8200
       VAULT_CONFIG_DIR: /vault/config
@@ -1875,37 +2606,77 @@ services:
     hostname: edgex-vault
     image: vault:1.11.5
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:8200:8200/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 8200
+      published: "8200"
+      protocol: tcp
     restart: always
     tmpfs:
     - /vault/config
     user: root:root
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - vault-file:/vault/file:z
-    - vault-logs:/vault/logs:z
-version: '3.7'
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: vault-file
+      target: /vault/file
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: vault-logs
+      target: /vault/logs
+      bind:
+        selinux: z
+      volume: {}
+networks:
+  edgex-network:
+    name: edgex_edgex-network
+    driver: bridge
 volumes:
-  PROFILE_VOLUME_PLACE_HOLDER: {}
-  consul-acl-token: {}
-  consul-config: {}
-  consul-data: {}
-  db-data: {}
-  edgex-init: {}
-  kong: {}
-  kuiper-connections: {}
-  kuiper-data: {}
-  kuiper-sources: {}
-  mqtt: {}
-  postgres-config: {}
-  postgres-data: {}
-  redis-config: {}
-  spire-agent: {}
-  spire-ca: {}
-  spire-server: {}
-  vault-config: {}
-  vault-file: {}
-  vault-logs: {}
-
+  consul-acl-token:
+    name: edgex_consul-acl-token
+  consul-config:
+    name: edgex_consul-config
+  consul-data:
+    name: edgex_consul-data
+  db-data:
+    name: edgex_db-data
+  edgex-init:
+    name: edgex_edgex-init
+  kong:
+    name: edgex_kong
+  kuiper-connections:
+    name: edgex_kuiper-connections
+  kuiper-data:
+    name: edgex_kuiper-data
+  kuiper-sources:
+    name: edgex_kuiper-sources
+  mqtt:
+    name: edgex_mqtt
+  postgres-config:
+    name: edgex_postgres-config
+  postgres-data:
+    name: edgex_postgres-data
+  redis-config:
+    name: edgex_redis-config
+  spire-agent:
+    name: edgex_spire-agent
+  spire-ca:
+    name: edgex_spire-ca
+  spire-server:
+    name: edgex_spire-server
+  vault-config:
+    name: edgex_vault-config
+  vault-file:
+    name: edgex_vault-file
+  vault-logs:
+    name: edgex_vault-logs

--- a/taf/docker-compose-taf-mqtt-bus-arm64.yml
+++ b/taf/docker-compose-taf-mqtt-bus-arm64.yml
@@ -1568,6 +1568,7 @@ services:
   mqtt-broker:
     command:
     - /usr/sbin/mosquitto
+    - -v
     - -c
     - /mosquitto/config/mosquitto.conf
     container_name: edgex-mqtt-broker
@@ -1584,7 +1585,7 @@ services:
       BROKER_TYPE: mosquitto
       CONF_DIR: /edgex-init/bootstrap-mosquitto/res
       EDGEX_SECURITY_SECRET_STORE: "true"
-      ENTRYPOINT: /docker-entrypoint.sh /usr/sbin/mosquitto -c /mosquitto/config/mosquitto.conf
+      ENTRYPOINT: /docker-entrypoint.sh /usr/sbin/mosquitto -v -c  /mosquitto/config/mosquitto.conf
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       SECRETSTORE_HOST: edgex-vault
       SECRETSTORE_PORT: "8200"

--- a/taf/docker-compose-taf-mqtt-bus.yml
+++ b/taf/docker-compose-taf-mqtt-bus.yml
@@ -24,54 +24,58 @@
 #
 # From the compose-builder folder use `make build` to regenerate all standard compose files variations
 #
-networks:
-  edgex-network:
-    driver: bridge
+name: edgex
 services:
   app-service-external-mqtt-trigger:
-    command: /app-service-configurable -cp=consul.http://edgex-core-consul:8500 --registry
+    command:
+    - /app-service-configurable
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
     container_name: edgex-app-external-mqtt-trigger
     depends_on:
-    - consul
-    - data
-    - security-bootstrapper
+      consul:
+        condition: service_started
+      data:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/ready_to_run_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
       CLIENTS_SUPPORT_NOTIFICATIONS_HOST: edgex-support-notifications
       CLIENTS_SUPPORT_SCHEDULER_HOST: edgex-support-scheduler
-      DATABASES_PRIMARY_HOST: edgex-redis
       DATABASE_HOST: edgex-redis
+      DATABASES_PRIMARY_HOST: edgex-redis
       EDGEX_PROFILE: external-mqtt-trigger
       EDGEX_SECURITY_SECRET_STORE: "true"
       MESSAGEBUS_HOST: edgex-redis
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SERVICE_HOST: edgex-app-external-mqtt-trigger
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
       TRIGGER_EXTERNALMQTT_URL: MQTT_BROKER_ADDRESS_PLACE_HOLDER
       WRITABLE_LOGLEVEL: INFO
@@ -80,192 +84,259 @@ services:
     hostname: edgex-app-external-mqtt-trigger
     image: nexus3.edgexfoundry.org:10004/app-service-configurable:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59706:59706/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59706
+      published: "59706"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - /tmp/edgex/secrets/app-external-mqtt-trigger:/tmp/edgex/secrets/app-external-mqtt-trigger:ro,z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/app-external-mqtt-trigger
+      target: /tmp/edgex/secrets/app-external-mqtt-trigger
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   app-service-functional-tests:
-    command: /app-service-configurable -cp=consul.http://edgex-core-consul:8500 --registry
+    command:
+    - /app-service-configurable
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
     container_name: app-functional-tests
     depends_on:
-    - consul
-    - data
-    - security-bootstrapper
+      consul:
+        condition: service_started
+      data:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/ready_to_run_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
       CLIENTS_SUPPORT_NOTIFICATIONS_HOST: edgex-support-notifications
       CLIENTS_SUPPORT_SCHEDULER_HOST: edgex-support-scheduler
-      DATABASES_PRIMARY_HOST: edgex-redis
       DATABASE_HOST: edgex-redis
+      DATABASES_PRIMARY_HOST: edgex-redis
       EDGEX_PROFILE: functional-tests
       EDGEX_SECURITY_SECRET_STORE: "true"
       MESSAGEBUS_HOST: edgex-redis
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SERVICE_HOST: app-functional-tests
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: app-functional-tests
     image: nexus3.edgexfoundry.org:10004/app-service-configurable:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 59705:59705/tcp
+    - mode: ingress
+      target: 59705
+      published: "59705"
+      protocol: tcp
     read_only: true
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - /tmp/edgex/secrets/app-functional-tests:/tmp/edgex/secrets/app-functional-tests:ro,z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/app-functional-tests
+      target: /tmp/edgex/secrets/app-functional-tests
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   app-service-http-export:
-    command: /app-service-configurable -cp=consul.http://edgex-core-consul:8500 --registry
+    command:
+    - /app-service-configurable
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
     container_name: edgex-app-http-export
     depends_on:
-    - consul
-    - data
-    - mqtt-broker
-    - security-bootstrapper
+      consul:
+        condition: service_started
+      data:
+        condition: service_started
+      mqtt-broker:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/ready_to_run_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
       CLIENTS_SUPPORT_NOTIFICATIONS_HOST: edgex-support-notifications
       CLIENTS_SUPPORT_SCHEDULER_HOST: edgex-support-scheduler
-      DATABASES_PRIMARY_HOST: edgex-redis
       DATABASE_HOST: edgex-redis
+      DATABASES_PRIMARY_HOST: edgex-redis
       EDGEX_PROFILE: http-export
       EDGEX_SECURITY_SECRET_STORE: "true"
       MESSAGEBUS_AUTHMODE: usernamepassword
       MESSAGEBUS_HOST: edgex-mqtt-broker
-      MESSAGEBUS_PORT: '1883'
+      MESSAGEBUS_PORT: "1883"
       MESSAGEBUS_PROTOCOL: tcp
       MESSAGEBUS_SECRETNAME: message-bus
       MESSAGEBUS_TYPE: mqtt
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SERVICE_HOST: edgex-app-http-export
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
       WRITABLE_LOGLEVEL: INFO
       WRITABLE_PIPELINE_FUNCTIONS_HTTPEXPORT_PARAMETERS_URL: http://EXPORT_HOST_PLACE_HOLDER:7770
     hostname: edgex-app-http-export
     image: nexus3.edgexfoundry.org:10004/app-service-configurable:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59704:59704/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59704
+      published: "59704"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - /tmp/edgex/secrets/app-http-export:/tmp/edgex/secrets/app-http-export:ro,z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/app-http-export
+      target: /tmp/edgex/secrets/app-http-export
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   app-service-mqtt-export:
-    command: /app-service-configurable -cp=consul.http://edgex-core-consul:8500 --registry
+    command:
+    - /app-service-configurable
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
     container_name: edgex-app-mqtt-export
     depends_on:
-    - consul
-    - data
-    - mqtt-broker
-    - security-bootstrapper
+      consul:
+        condition: service_started
+      data:
+        condition: service_started
+      mqtt-broker:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/ready_to_run_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
       CLIENTS_SUPPORT_NOTIFICATIONS_HOST: edgex-support-notifications
       CLIENTS_SUPPORT_SCHEDULER_HOST: edgex-support-scheduler
-      DATABASES_PRIMARY_HOST: edgex-redis
       DATABASE_HOST: edgex-redis
+      DATABASES_PRIMARY_HOST: edgex-redis
       EDGEX_PROFILE: mqtt-export
       EDGEX_SECURITY_SECRET_STORE: "true"
       MESSAGEBUS_AUTHMODE: usernamepassword
       MESSAGEBUS_HOST: edgex-mqtt-broker
-      MESSAGEBUS_PORT: '1883'
+      MESSAGEBUS_PORT: "1883"
       MESSAGEBUS_PROTOCOL: tcp
       MESSAGEBUS_SECRETNAME: message-bus
       MESSAGEBUS_TYPE: mqtt
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SERVICE_HOST: edgex-app-mqtt-export
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
       WRITABLE_INSECURESECRETS_MQTT_SECRETS_PASSWORD: PASSWORD_PLACE_HOLDER
       WRITABLE_INSECURESECRETS_MQTT_SECRETS_USERNAME: USERNAME_PLACEH_OLDER
@@ -275,30 +346,53 @@ services:
     hostname: edgex-app-mqtt-export
     image: nexus3.edgexfoundry.org:10004/app-service-configurable:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59703:59703/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59703
+      published: "59703"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - /tmp/edgex/secrets/app-mqtt-export:/tmp/edgex/secrets/app-mqtt-export:ro,z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/app-mqtt-export
+      target: /tmp/edgex/secrets/app-mqtt-export
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   app-service-rules:
-    command: /app-service-configurable -cp=consul.http://edgex-core-consul:8500 --registry
+    command:
+    - /app-service-configurable
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
     container_name: edgex-app-rules-engine
     depends_on:
-    - consul
-    - data
-    - mqtt-broker
-    - security-bootstrapper
+      consul:
+        condition: service_started
+      data:
+        condition: service_started
+      mqtt-broker:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/ready_to_run_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
@@ -309,127 +403,175 @@ services:
       EDGEX_SECURITY_SECRET_STORE: "true"
       MESSAGEBUS_AUTHMODE: usernamepassword
       MESSAGEBUS_HOST: edgex-mqtt-broker
-      MESSAGEBUS_PORT: 1883
+      MESSAGEBUS_PORT: "1883"
       MESSAGEBUS_PROTOCOL: tcp
       MESSAGEBUS_SECRETNAME: message-bus
       MESSAGEBUS_TYPE: mqtt
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SERVICE_HOST: edgex-app-rules-engine
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-app-rules-engine
     image: nexus3.edgexfoundry.org:10004/app-service-configurable:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59701:59701/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59701
+      published: "59701"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - /tmp/edgex/secrets/app-rules-engine:/tmp/edgex/secrets/app-rules-engine:ro,z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/app-rules-engine
+      target: /tmp/edgex/secrets/app-rules-engine
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   app-service-sample:
-    command: /app-service-configurable -cp=consul.http://edgex-core-consul:8500 --registry
+    command:
+    - /app-service-configurable
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
     container_name: edgex-app-sample
     depends_on:
-    - consul
-    - data
-    - mqtt-broker
-    - security-bootstrapper
+      consul:
+        condition: service_started
+      data:
+        condition: service_started
+      mqtt-broker:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/ready_to_run_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
       CLIENTS_SUPPORT_NOTIFICATIONS_HOST: edgex-support-notifications
       CLIENTS_SUPPORT_SCHEDULER_HOST: edgex-support-scheduler
-      DATABASES_PRIMARY_HOST: edgex-redis
       DATABASE_HOST: edgex-redis
+      DATABASES_PRIMARY_HOST: edgex-redis
       EDGEX_PROFILE: sample
       EDGEX_SECURITY_SECRET_STORE: "true"
       MESSAGEBUS_AUTHMODE: usernamepassword
       MESSAGEBUS_HOST: edgex-mqtt-broker
-      MESSAGEBUS_PORT: '1883'
+      MESSAGEBUS_PORT: "1883"
       MESSAGEBUS_PROTOCOL: tcp
       MESSAGEBUS_SECRETNAME: message-bus
       MESSAGEBUS_TYPE: mqtt
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SERVICE_HOST: edgex-app-sample
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-app-sample
     image: nexus3.edgexfoundry.org:10004/app-service-configurable:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59700:59700/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59700
+      published: "59700"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - /tmp/edgex/secrets/app-sample:/tmp/edgex/secrets/app-sample:ro,z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/app-sample
+      target: /tmp/edgex/secrets/app-sample
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   command:
-    command: /core-command -cp=consul.http://edgex-core-consul:8500 --registry
+    command:
+    - /core-command
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
     container_name: edgex-core-command
     depends_on:
-    - consul
-    - database
-    - metadata
-    - mqtt-broker
-    - secretstore-setup
-    - security-bootstrapper
+      consul:
+        condition: service_started
+      database:
+        condition: service_started
+      metadata:
+        condition: service_started
+      mqtt-broker:
+        condition: service_started
+      secretstore-setup:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/ready_to_run_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
@@ -441,118 +583,182 @@ services:
       MESSAGEBUS_EXTERNAL_URL: tcp://edgex-mqtt-broker:1883
       MESSAGEBUS_INTERNAL_AUTHMODE: usernamepassword
       MESSAGEBUS_INTERNAL_HOST: edgex-mqtt-broker
-      MESSAGEBUS_INTERNAL_PORT: 1883
+      MESSAGEBUS_INTERNAL_PORT: "1883"
       MESSAGEBUS_INTERNAL_PROTOCOL: tcp
       MESSAGEBUS_INTERNAL_SECRETNAME: message-bus
       MESSAGEBUS_INTERNAL_TYPE: mqtt
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SERVICE_HOST: edgex-core-command
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-core-command
     image: nexus3.edgexfoundry.org:10004/core-command:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59882:59882/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59882
+      published: "59882"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - /tmp/edgex/secrets/core-command:/tmp/edgex/secrets/core-command:ro,z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/core-command
+      target: /tmp/edgex/secrets/core-command
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   consul:
-    command: agent -ui -bootstrap -server -client 0.0.0.0
+    command:
+    - agent
+    - -ui
+    - -bootstrap
+    - -server
+    - -client
+    - 0.0.0.0
     container_name: edgex-core-consul
     depends_on:
-    - security-bootstrapper
-    - vault
+      security-bootstrapper:
+        condition: service_started
+      vault:
+        condition: service_started
     entrypoint:
     - /edgex-init/consul_wait_install.sh
     environment:
       ADD_REGISTRY_ACL_ROLES: app-http-export,app-mqtt-export,app-functional-tests,app-scalability-test-mqtt-export,app-sample,device-modbus,app-external-mqtt-trigger,device-onvif-camera
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
-      EDGEX_GROUP: '2001'
+      API_GATEWAY_STATUS_PORT: "8100"
+      EDGEX_GROUP: "2001"
       EDGEX_SECURITY_SECRET_STORE: "true"
-      EDGEX_USER: '2002'
+      EDGEX_USER: "2002"
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_ACL_BOOTSTRAPTOKENPATH: /tmp/edgex/secrets/consul-acl-token/bootstrap_token.json
       STAGEGATE_REGISTRY_ACL_MANAGEMENTTOKENPATH: /tmp/edgex/secrets/consul-acl-token/mgmt_token.json
       STAGEGATE_REGISTRY_ACL_SENTINELFILEPATH: /consul/config/consul_acl_done
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-core-consul
     image: consul:1.13
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:8500:8500/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 8500
+      published: "8500"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: root:root
     volumes:
-    - consul-config:/consul/config:z
-    - consul-data:/consul/data:z
-    - edgex-init:/edgex-init:ro,z
-    - consul-acl-token:/tmp/edgex/secrets/consul-acl-token:z
-    - /tmp/edgex/secrets/edgex-consul:/tmp/edgex/secrets/edgex-consul:ro,z
+    - type: volume
+      source: consul-config
+      target: /consul/config
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: consul-data
+      target: /consul/data
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: consul-acl-token
+      target: /tmp/edgex/secrets/consul-acl-token
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/edgex-consul
+      target: /tmp/edgex/secrets/edgex-consul
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   data:
-    command: /core-data -cp=consul.http://edgex-core-consul:8500 --registry
+    command:
+    - /core-data
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
     container_name: edgex-core-data
     depends_on:
-    - consul
-    - database
-    - metadata
-    - mqtt-broker
-    - secretstore-setup
-    - security-bootstrapper
+      consul:
+        condition: service_started
+      database:
+        condition: service_started
+      metadata:
+        condition: service_started
+      mqtt-broker:
+        condition: service_started
+      secretstore-setup:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/ready_to_run_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
@@ -563,59 +769,81 @@ services:
       MESSAGEBUS_AUTHMODE: usernamepassword
       MESSAGEBUS_HOST: edgex-mqtt-broker
       MESSAGEBUS_OPTIONAL_CLIENTID: core-data
-      MESSAGEBUS_PORT: '1883'
+      MESSAGEBUS_PORT: "1883"
       MESSAGEBUS_PROTOCOL: tcp
       MESSAGEBUS_SECRETNAME: message-bus
       MESSAGEBUS_TYPE: mqtt
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SECRETSTORE_TOKENFILE: /tmp/edgex/secrets/core-data/secrets-token.json
       SERVICE_HOST: edgex-core-data
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-core-data
     image: nexus3.edgexfoundry.org:10004/core-data:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:5563:5563/tcp
-    - 127.0.0.1:59880:59880/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 5563
+      published: "5563"
+      protocol: tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59880
+      published: "59880"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - /tmp/edgex/secrets/core-data:/tmp/edgex/secrets/core-data:ro,z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/core-data
+      target: /tmp/edgex/secrets/core-data
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   database:
     container_name: edgex-redis
     depends_on:
-    - secretstore-setup
-    - security-bootstrapper
+      secretstore-setup:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/redis_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
@@ -628,31 +856,35 @@ services:
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-redis
     image: redis:7.0-alpine
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:6379:6379/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 6379
+      published: "6379"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
@@ -661,25 +893,57 @@ services:
     - /run
     user: root:root
     volumes:
-    - db-data:/data:z
-    - edgex-init:/edgex-init:ro,z
-    - redis-config:/run/redis/conf:z
-    - /tmp/edgex/secrets/security-bootstrapper-redis:/tmp/edgex/secrets/security-bootstrapper-redis:ro,z
+    - type: volume
+      source: db-data
+      target: /data
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: redis-config
+      target: /run/redis/conf
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/security-bootstrapper-redis
+      target: /tmp/edgex/secrets/security-bootstrapper-redis
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   device-modbus:
-    command: /device-modbus -cp=consul.http://edgex-core-consul:8500 --registry --configDir=CONFIG_DIR_PLACE_HOLDER
+    command:
+    - /device-modbus
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
+    - --configDir=CONFIG_DIR_PLACE_HOLDER
     container_name: edgex-device-modbus
     depends_on:
-    - consul
-    - data
-    - metadata
-    - modbus-simulator
-    - mqtt-broker
-    - security-bootstrapper
+      consul:
+        condition: service_started
+      data:
+        condition: service_started
+      metadata:
+        condition: service_started
+      modbus-simulator:
+        condition: service_started
+      mqtt-broker:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/ready_to_run_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
@@ -689,62 +953,91 @@ services:
       EDGEX_SECURITY_SECRET_STORE: "true"
       MESSAGEBUS_AUTHMODE: usernamepassword
       MESSAGEBUS_HOST: edgex-mqtt-broker
-      MESSAGEBUS_PORT: '1883'
+      MESSAGEBUS_PORT: "1883"
       MESSAGEBUS_PROTOCOL: tcp
       MESSAGEBUS_SECRETNAME: message-bus
       MESSAGEBUS_TYPE: mqtt
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SERVICE_HOST: edgex-device-modbus
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-device-modbus
     image: nexus3.edgexfoundry.org:10004/device-modbus:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59901:59901/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59901
+      published: "59901"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - /tmp/edgex/secrets/device-modbus:/tmp/edgex/secrets/device-modbus:ro,z
-    - PROFILE_VOLUME_PLACE_HOLDER:CONFIG_DIR_PLACE_HOLDER:z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/device-modbus
+      target: /tmp/edgex/secrets/device-modbus
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
+    - type: bind
+      source: /PROFILE_VOLUME_PLACE_HOLDER
+      target: CONFIG_DIR_PLACE_HOLDER
+      bind:
+        selinux: z
+        create_host_path: true
   device-onvif-camera:
-    command: /device-onvif-camera -cp=consul.http://edgex-core-consul:8500 --registry
+    command:
+    - /device-onvif-camera
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
     container_name: edgex-device-onvif-camera
     depends_on:
-    - consul
-    - data
-    - metadata
-    - mqtt-broker
-    - security-bootstrapper
+      consul:
+        condition: service_started
+      data:
+        condition: service_started
+      metadata:
+        condition: service_started
+      mqtt-broker:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/ready_to_run_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
@@ -754,61 +1047,85 @@ services:
       EDGEX_SECURITY_SECRET_STORE: "true"
       MESSAGEBUS_AUTHMODE: usernamepassword
       MESSAGEBUS_HOST: edgex-mqtt-broker
-      MESSAGEBUS_PORT: '1883'
+      MESSAGEBUS_PORT: "1883"
       MESSAGEBUS_PROTOCOL: tcp
       MESSAGEBUS_SECRETNAME: message-bus
       MESSAGEBUS_TYPE: mqtt
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SERVICE_HOST: edgex-device-onvif-camera
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-device-onvif-camera
     image: nexus3.edgexfoundry.org:10004/device-onvif-camera:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59984:59984/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59984
+      published: "59984"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - /tmp/edgex/secrets/device-onvif-camera:/tmp/edgex/secrets/device-onvif-camera:ro,z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/device-onvif-camera
+      target: /tmp/edgex/secrets/device-onvif-camera
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   device-rest:
-    command: /device-rest -cp=consul.http://edgex-core-consul:8500 --registry
+    command:
+    - /device-rest
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
     container_name: edgex-device-rest
     depends_on:
-    - consul
-    - data
-    - metadata
-    - mqtt-broker
-    - security-bootstrapper
+      consul:
+        condition: service_started
+      data:
+        condition: service_started
+      metadata:
+        condition: service_started
+      mqtt-broker:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/ready_to_run_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
@@ -818,61 +1135,86 @@ services:
       EDGEX_SECURITY_SECRET_STORE: "true"
       MESSAGEBUS_AUTHMODE: usernamepassword
       MESSAGEBUS_HOST: edgex-mqtt-broker
-      MESSAGEBUS_PORT: '1883'
+      MESSAGEBUS_PORT: "1883"
       MESSAGEBUS_PROTOCOL: tcp
       MESSAGEBUS_SECRETNAME: message-bus
       MESSAGEBUS_TYPE: mqtt
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SERVICE_HOST: edgex-device-rest
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-device-rest
     image: nexus3.edgexfoundry.org:10004/device-rest:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59986:59986/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59986
+      published: "59986"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - /tmp/edgex/secrets/device-rest:/tmp/edgex/secrets/device-rest:ro,z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/device-rest
+      target: /tmp/edgex/secrets/device-rest
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   device-virtual:
-    command: /device-virtual -cp=consul.http://edgex-core-consul:8500 --registry --configDir=CONFIG_DIR_PLACE_HOLDER
+    command:
+    - /device-virtual
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
+    - --configDir=CONFIG_DIR_PLACE_HOLDER
     container_name: edgex-device-virtual
     depends_on:
-    - consul
-    - data
-    - metadata
-    - mqtt-broker
-    - security-bootstrapper
+      consul:
+        condition: service_started
+      data:
+        condition: service_started
+      metadata:
+        condition: service_started
+      mqtt-broker:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/ready_to_run_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
@@ -882,65 +1224,88 @@ services:
       EDGEX_SECURITY_SECRET_STORE: "true"
       MESSAGEBUS_AUTHMODE: usernamepassword
       MESSAGEBUS_HOST: edgex-mqtt-broker
-      MESSAGEBUS_PORT: '1883'
+      MESSAGEBUS_PORT: "1883"
       MESSAGEBUS_PROTOCOL: tcp
       MESSAGEBUS_SECRETNAME: message-bus
       MESSAGEBUS_TYPE: mqtt
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SERVICE_HOST: edgex-device-virtual
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-device-virtual
     image: nexus3.edgexfoundry.org:10004/device-virtual:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59900:59900/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59900
+      published: "59900"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - /tmp/edgex/secrets/device-virtual:/tmp/edgex/secrets/device-virtual:ro,z
-    - PROFILE_VOLUME_PLACE_HOLDER:CONFIG_DIR_PLACE_HOLDER:z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/device-virtual
+      target: /tmp/edgex/secrets/device-virtual
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
+    - type: bind
+      source: /PROFILE_VOLUME_PLACE_HOLDER
+      target: CONFIG_DIR_PLACE_HOLDER
+      bind:
+        selinux: z
+        create_host_path: true
   kong:
     container_name: edgex-kong
     depends_on:
-    - kong-db
-    - security-bootstrapper
+      kong-db:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/kong_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       KONG_ADMIN_ACCESS_LOG: /dev/stdout
       KONG_ADMIN_ERROR_LOG: /dev/stderr
       KONG_ADMIN_LISTEN: 127.0.0.1:8001, 127.0.0.1:8444 ssl
       KONG_DATABASE: postgres
       KONG_DNS_ORDER: LAST,A,CNAME
-      KONG_DNS_VALID_TTL: '1'
-      KONG_NGINX_WORKER_PROCESSES: '1'
+      KONG_DNS_VALID_TTL: "1"
+      KONG_NGINX_WORKER_PROCESSES: "1"
       KONG_PG_HOST: edgex-kong-db
       KONG_PG_PASSWORD_FILE: /tmp/postgres-config/.pgpassword
       KONG_PROXY_ACCESS_LOG: /dev/stdout
@@ -949,28 +1314,38 @@ services:
       KONG_STATUS_LISTEN: 0.0.0.0:8100
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-kong
     image: kong:2.8
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 8000:8000/tcp
-    - 127.0.0.1:8100:8100/tcp
-    - 8443:8443/tcp
+    - mode: ingress
+      target: 8000
+      published: "8000"
+      protocol: tcp
+    - mode: ingress
+      target: 8443
+      published: "8443"
+      protocol: tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 8100
+      published: "8100"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
@@ -981,50 +1356,77 @@ services:
     tty: true
     user: kong:nogroup
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - /tmp/edgex/secrets/security-proxy-setup:/tmp/edgex/secrets/security-proxy-setup:ro,z
-    - postgres-config:/tmp/postgres-config:z
-    - kong:/usr/local/kong:z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: postgres-config
+      target: /tmp/postgres-config
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: kong
+      target: /usr/local/kong
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/security-proxy-setup
+      target: /tmp/edgex/secrets/security-proxy-setup
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   kong-db:
     container_name: edgex-kong-db
     depends_on:
-    - security-bootstrapper
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/postgres_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       EDGEX_SECURITY_SECRET_STORE: "true"
       POSTGRES_DB: kong
       POSTGRES_PASSWORD_FILE: /tmp/postgres-config/.pgpassword
       POSTGRES_USER: kong
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-kong-db
     image: postgres:13.8-alpine
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:5432:5432/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 5432
+      published: "5432"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
@@ -1035,24 +1437,49 @@ services:
     - /run
     user: root:root
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - postgres-config:/tmp/postgres-config:z
-    - postgres-data:/var/lib/postgresql/data:z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: postgres-data
+      target: /var/lib/postgresql/data
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: postgres-config
+      target: /tmp/postgres-config
+      bind:
+        selinux: z
+      volume: {}
   metadata:
-    command: /core-metadata -cp=consul.http://edgex-core-consul:8500 --registry
+    command:
+    - /core-metadata
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
     container_name: edgex-core-metadata
     depends_on:
-    - consul
-    - database
-    - mqtt-broker
-    - notifications
-    - secretstore-setup
-    - security-bootstrapper
+      consul:
+        condition: service_started
+      database:
+        condition: service_started
+      mqtt-broker:
+        condition: service_started
+      notifications:
+        condition: service_started
+      secretstore-setup:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/ready_to_run_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
@@ -1063,7 +1490,7 @@ services:
       MESSAGEBUS_AUTHMODE: usernamepassword
       MESSAGEBUS_HOST: edgex-mqtt-broker
       MESSAGEBUS_OPTIONAL_CLIENTID: core-metadata
-      MESSAGEBUS_PORT: '1883'
+      MESSAGEBUS_PORT: "1883"
       MESSAGEBUS_PROTOCOL: tcp
       MESSAGEBUS_SECRETNAME: message-bus
       MESSAGEBUS_TYPE: mqtt
@@ -1071,132 +1498,193 @@ services:
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SERVICE_HOST: edgex-core-metadata
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-core-metadata
     image: nexus3.edgexfoundry.org:10004/core-metadata:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59881:59881/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59881
+      published: "59881"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - /tmp/edgex/secrets/core-metadata:/tmp/edgex/secrets/core-metadata:ro,z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/core-metadata
+      target: /tmp/edgex/secrets/core-metadata
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   modbus-simulator:
     container_name: edgex-modbus-simulator
     hostname: edgex-modbus-simulator
     image: nexus3.edgexfoundry.org:10003/edgex-devops/edgex-modbus-simulator:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:1502:1502/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 1502
+      published: "1502"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
   mqtt-broker:
-    command: /usr/sbin/mosquitto -c /mosquitto/config/mosquitto.conf
+    command:
+    - /usr/sbin/mosquitto
+    - -c
+    - /mosquitto/config/mosquitto.conf
     container_name: edgex-mqtt-broker
     depends_on:
-    - secretstore-setup
-    - security-bootstrapper
+      secretstore-setup:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/messagebus_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       BROKER_TYPE: mosquitto
       CONF_DIR: /edgex-init/bootstrap-mosquitto/res
       EDGEX_SECURITY_SECRET_STORE: "true"
       ENTRYPOINT: /docker-entrypoint.sh /usr/sbin/mosquitto -c /mosquitto/config/mosquitto.conf
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-mqtt-broker
     image: eclipse-mosquitto:2.0
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:1883:1883/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 1883
+      published: "1883"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: root:root
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - mqtt:/mosquitto:z
-    - /tmp/edgex/secrets/security-bootstrapper-messagebus:/tmp/edgex/secrets/security-bootstrapper-messagebus:ro,z
+    - type: volume
+      source: mqtt
+      target: /mosquitto
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/security-bootstrapper-messagebus
+      target: /tmp/edgex/secrets/security-bootstrapper-messagebus
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   mqtt-taf-broker:
-    command: /usr/sbin/mosquitto -c /mosquitto-no-auth.conf
+    command:
+    - /usr/sbin/mosquitto
+    - -c
+    - /mosquitto-no-auth.conf
     container_name: edgex-taf-mqtt-broker
     hostname: edgex-taf-mqtt-broker
     image: eclipse-mosquitto:2.0
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:1884:1883/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 1883
+      published: "1884"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
   notifications:
-    command: /support-notifications -cp=consul.http://edgex-core-consul:8500 --registry
+    command:
+    - /support-notifications
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
     container_name: edgex-support-notifications
     depends_on:
-    - consul
-    - database
-    - mqtt-broker
-    - secretstore-setup
-    - security-bootstrapper
+      consul:
+        condition: service_started
+      database:
+        condition: service_started
+      mqtt-broker:
+        condition: service_started
+      secretstore-setup:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/ready_to_run_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
@@ -1207,59 +1695,78 @@ services:
       MESSAGEBUS_AUTHMODE: usernamepassword
       MESSAGEBUS_HOST: edgex-mqtt-broker
       MESSAGEBUS_OPTIONAL_CLIENTID: support-notifications
-      MESSAGEBUS_PORT: '1883'
+      MESSAGEBUS_PORT: "1883"
       MESSAGEBUS_PROTOCOL: tcp
       MESSAGEBUS_SECRETNAME: message-bus
       MESSAGEBUS_TYPE: mqtt
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SERVICE_HOST: edgex-support-notifications
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-support-notifications
     image: nexus3.edgexfoundry.org:10004/support-notifications:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59860:59860/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59860
+      published: "59860"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - /tmp/edgex/secrets/support-notifications:/tmp/edgex/secrets/support-notifications:ro,z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/support-notifications
+      target: /tmp/edgex/secrets/support-notifications
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   proxy-setup:
     container_name: edgex-security-proxy-setup
     depends_on:
-    - kong
-    - secretstore-setup
-    - security-bootstrapper
+      kong:
+        condition: service_started
+      secretstore-setup:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/proxy_setup_wait_install.sh
     environment:
       ADD_PROXY_ROUTE: device-modbus.http://edgex-device-modbus:59901
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       EDGEX_SECURITY_SECRET_STORE: "true"
       KONGURL_SERVER: edgex-kong
       PROXY_SETUP_HOST: edgex-security-proxy-setup
@@ -1273,127 +1780,181 @@ services:
       ROUTES_SUPPORT_SCHEDULER_HOST: edgex-support-scheduler
       ROUTES_SYS_MGMT_AGENT_HOST: edgex-sys-mgmt-agent
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-security-proxy-setup
     image: nexus3.edgexfoundry.org:10004/security-proxy-setup:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     read_only: true
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - consul-acl-token:/tmp/edgex/secrets/consul-acl-token:ro,z
-    - /tmp/edgex/secrets/security-proxy-setup:/tmp/edgex/secrets/security-proxy-setup:ro,z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: consul-acl-token
+      target: /tmp/edgex/secrets/consul-acl-token
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/security-proxy-setup
+      target: /tmp/edgex/secrets/security-proxy-setup
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   rulesengine:
     container_name: edgex-kuiper
     depends_on:
-    - database
-    - mqtt-broker
-    - secretstore-setup
-    - security-bootstrapper
+      database:
+        condition: service_started
+      mqtt-broker:
+        condition: service_started
+      secretstore-setup:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/kuiper_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       CONNECTION__EDGEX__MQTTMSGBUS__OPTIONAL__CLIENTID: kuiper-rules-engine
-      CONNECTION__EDGEX__MQTTMSGBUS__OPTIONAL__KEEPALIVE: 500
-      CONNECTION__EDGEX__MQTTMSGBUS__PORT: 1883
+      CONNECTION__EDGEX__MQTTMSGBUS__OPTIONAL__KEEPALIVE: "500"
+      CONNECTION__EDGEX__MQTTMSGBUS__PORT: "1883"
       CONNECTION__EDGEX__MQTTMSGBUS__PROTOCOL: tcp
       CONNECTION__EDGEX__MQTTMSGBUS__SERVER: edgex-mqtt-broker
       CONNECTION__EDGEX__MQTTMSGBUS__TYPE: mqtt
-      CONNECTION__EDGEX__REDISMSGBUS__PORT: 6379
+      CONNECTION__EDGEX__REDISMSGBUS__PORT: "6379"
       CONNECTION__EDGEX__REDISMSGBUS__PROTOCOL: redis
       CONNECTION__EDGEX__REDISMSGBUS__SERVER: edgex-redis
       CONNECTION__EDGEX__REDISMSGBUS__TYPE: redis
       EDGEX__DEFAULT__OPTIONAL__CLIENTID: kuiper-rules-engine
-      EDGEX__DEFAULT__OPTIONAL__KEEPALIVE: 500
-      EDGEX__DEFAULT__PORT: 1883
+      EDGEX__DEFAULT__OPTIONAL__KEEPALIVE: "500"
+      EDGEX__DEFAULT__PORT: "1883"
       EDGEX__DEFAULT__PROTOCOL: tcp
       EDGEX__DEFAULT__SERVER: edgex-mqtt-broker
       EDGEX__DEFAULT__TOPIC: rules-events
       EDGEX__DEFAULT__TYPE: mqtt
       KUIPER__BASIC__CONSOLELOG: "true"
-      KUIPER__BASIC__RESTPORT: 59720
+      KUIPER__BASIC__RESTPORT: "59720"
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-kuiper
     image: lfedge/ekuiper:1.7-alpine
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59720:59720/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59720
+      published: "59720"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: kuiper:kuiper
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - kuiper-data:/kuiper/data:z
-    - kuiper-connections:/kuiper/etc/connections:z
-    - kuiper-sources:/kuiper/etc/sources:z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: kuiper-data
+      target: /kuiper/data
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: kuiper-connections
+      target: /kuiper/etc/connections
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: kuiper-sources
+      target: /kuiper/etc/sources
+      bind:
+        selinux: z
+      volume: {}
   scalability-test-mqtt-export:
-    command: /app-service-configurable -cp=consul.http://edgex-core-consul:8500 --registry
+    command:
+    - /app-service-configurable
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
     container_name: edgex-scalability-test-mqtt-export
     depends_on:
-    - consul
-    - data
-    - mqtt-broker
-    - security-bootstrapper
+      consul:
+        condition: service_started
+      data:
+        condition: service_started
+      mqtt-broker:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/ready_to_run_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
       CLIENTS_SUPPORT_NOTIFICATIONS_HOST: edgex-support-notifications
       CLIENTS_SUPPORT_SCHEDULER_HOST: edgex-support-scheduler
-      DATABASES_PRIMARY_HOST: edgex-redis
       DATABASE_HOST: edgex-redis
+      DATABASES_PRIMARY_HOST: edgex-redis
       EDGEX_PROFILE: mqtt-export
       EDGEX_SECURITY_SECRET_STORE: "true"
       EDGEX_SERVICE_KEY: app-scalability-test-mqtt-export
       MESSAGEBUS_AUTHMODE: usernamepassword
       MESSAGEBUS_HOST: edgex-mqtt-broker
       MESSAGEBUS_OPTIONAL_CLIENTID: app-scalability-test-mqtt-export
-      MESSAGEBUS_PORT: '1883'
+      MESSAGEBUS_PORT: "1883"
       MESSAGEBUS_PROTOCOL: tcp
       MESSAGEBUS_SECRETNAME: message-bus
       MESSAGEBUS_TYPE: mqtt
@@ -1401,26 +1962,26 @@ services:
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault
       SECRETSTORE_PATH: /app-scalability-test-mqtt-export
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SECRETSTORE_TOKENFILE: /tmp/edgex/secrets/app-scalability-test-mqtt-export/secrets-token.json
       SERVICE_HOST: edgex-scalability-test-mqtt-export
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
       WRITABLE_INSECURESECRETS_MQTT_SECRETS_PASSWORD: PASSWORD_PLACE_HOLDER
       WRITABLE_INSECURESECRETS_MQTT_SECRETS_USERNAME: USERNAME_PLACEH_OLDER
@@ -1431,30 +1992,53 @@ services:
     hostname: edgex-scalability-test-mqtt-export
     image: nexus3.edgexfoundry.org:10004/app-service-configurable:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 59710:59703/tcp
+    - mode: ingress
+      target: 59703
+      published: "59710"
+      protocol: tcp
     read_only: true
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - /tmp/edgex/secrets/app-scalability-test-mqtt-export:/tmp/edgex/secrets/app-scalability-test-mqtt-export:ro,z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/app-scalability-test-mqtt-export
+      target: /tmp/edgex/secrets/app-scalability-test-mqtt-export
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   scheduler:
-    command: /support-scheduler -cp=consul.http://edgex-core-consul:8500 --registry
+    command:
+    - /support-scheduler
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
     container_name: edgex-support-scheduler
     depends_on:
-    - consul
-    - database
-    - mqtt-broker
-    - secretstore-setup
-    - security-bootstrapper
+      consul:
+        condition: service_started
+      database:
+        condition: service_started
+      mqtt-broker:
+        condition: service_started
+      secretstore-setup:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/ready_to_run_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
@@ -1467,86 +2051,104 @@ services:
       MESSAGEBUS_AUTHMODE: usernamepassword
       MESSAGEBUS_HOST: edgex-mqtt-broker
       MESSAGEBUS_OPTIONAL_CLIENTID: support-scheduler
-      MESSAGEBUS_PORT: '1883'
+      MESSAGEBUS_PORT: "1883"
       MESSAGEBUS_PROTOCOL: tcp
       MESSAGEBUS_SECRETNAME: message-bus
       MESSAGEBUS_TYPE: mqtt
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SERVICE_HOST: edgex-support-scheduler
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-support-scheduler
     image: nexus3.edgexfoundry.org:10004/support-scheduler:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59861:59861/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59861
+      published: "59861"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - /tmp/edgex/secrets/support-scheduler:/tmp/edgex/secrets/support-scheduler:ro,z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/support-scheduler
+      target: /tmp/edgex/secrets/support-scheduler
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   secretstore-setup:
     container_name: edgex-security-secretstore-setup
     depends_on:
-    - security-bootstrapper
-    - vault
+      security-bootstrapper:
+        condition: service_started
+      vault:
+        condition: service_started
     environment:
       ADD_KNOWN_SECRETS: redisdb[app-rules-engine],redisdb[app-http-export],redisdb[app-mqtt-export],redisdb[app-scalability-test-mqtt-export],redisdb[app-sample],redisdb[device-modbus],redisdb[device-rest],redisdb[device-virtual],redisdb[device-onvif-camera],message-bus[app-rules-engine],message-bus[app-http-export],message-bus[app-mqtt-export],message-bus[app-external-mqtt-trigger],message-bus[app-scalability-test-mqtt-export],message-bus[app-sample],message-bus[device-modbus],message-bus[device-rest],message-bus[device-virtual],message-bus[device-onvif-camera]
       ADD_SECRETSTORE_TOKENS: app-http-export,app-mqtt-export,app-functional-tests,app-scalability-test-mqtt-export,app-sample,device-modbus,app-external-mqtt-trigger,device-onvif-camera
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
-      EDGEX_GROUP: '2001'
+      API_GATEWAY_STATUS_PORT: "8100"
+      EDGEX_GROUP: "2001"
       EDGEX_SECURITY_SECRET_STORE: "true"
-      EDGEX_USER: '2002'
+      EDGEX_USER: "2002"
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SECUREMESSAGEBUS_TYPE: mqtt
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-security-secretstore-setup
     image: nexus3.edgexfoundry.org:10004/security-secretstore-setup:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     read_only: true
     restart: always
     security_opt:
@@ -1556,59 +2158,100 @@ services:
     - /vault
     user: root:root
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - /tmp/edgex/secrets:/tmp/edgex/secrets:z
-    - kong:/tmp/kong:z
-    - kuiper-sources:/tmp/kuiper:z
-    - kuiper-connections:/tmp/kuiper-connections:z
-    - vault-config:/vault/config:z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets
+      target: /tmp/edgex/secrets
+      bind:
+        selinux: z
+        create_host_path: true
+    - type: volume
+      source: kong
+      target: /tmp/kong
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: kuiper-sources
+      target: /tmp/kuiper
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: kuiper-connections
+      target: /tmp/kuiper-connections
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: vault-config
+      target: /vault/config
+      bind:
+        selinux: z
+      volume: {}
   security-bootstrapper:
     container_name: edgex-security-bootstrapper
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
-      EDGEX_GROUP: '2001'
-      EDGEX_USER: '2002'
+      API_GATEWAY_STATUS_PORT: "8100"
+      EDGEX_GROUP: "2001"
+      EDGEX_USER: "2002"
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-security-bootstrapper
     image: nexus3.edgexfoundry.org:10004/security-bootstrapper:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: root:root
     volumes:
-    - edgex-init:/edgex-init:z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      bind:
+        selinux: z
+      volume: {}
   security-spiffe-token-provider:
-    command: /security-spiffe-token-provider -cp=consul.http://edgex-core-consul:8500
-      --registry
+    command:
+    - /security-spiffe-token-provider
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
     container_name: edgex-security-spiffe-token-provider
     depends_on:
-    - consul
-    - security-bootstrapper
-    - security-spire-agent
+      consul:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
+      security-spire-agent:
+        condition: service_started
     entrypoint:
     - /edgex-init/ready_to_run_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
@@ -1619,32 +2262,36 @@ services:
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SERVICE_HOST: edgex-security-spiffe-token-provider
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-security-spiffe-token-provider
     image: nexus3.edgexfoundry.org:10004/security-spiffe-token-provider:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59841:59841/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59841
+      published: "59841"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
@@ -1653,19 +2300,36 @@ services:
     - /run
     user: root:root
     volumes:
-    - edgex-init:/edgex-init:z
-    - /tmp/edgex/secrets/security-spiffe-token-provider:/tmp/edgex/secrets/security-spiffe-token-provider:z
-    - /tmp/edgex/secrets/spiffe:/tmp/edgex/secrets/spiffe:z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/spiffe
+      target: /tmp/edgex/secrets/spiffe
+      bind:
+        selinux: z
+        create_host_path: true
+    - type: bind
+      source: /tmp/edgex/secrets/security-spiffe-token-provider
+      target: /tmp/edgex/secrets/security-spiffe-token-provider
+      bind:
+        selinux: z
+        create_host_path: true
   security-spire-agent:
-    command: docker-entrypoint.sh
+    command:
+    - docker-entrypoint.sh
     container_name: edgex-security-spire-agent
     depends_on:
-    - security-spire-server
+      security-spire-server:
+        condition: service_started
     entrypoint:
     - /edgex-init/ready_to_run_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
@@ -1676,29 +2340,29 @@ services:
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-security-spire-agent
     image: nexus3.edgexfoundry.org:10004/security-spire-agent:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     pid: host
     privileged: true
     read_only: true
@@ -1709,21 +2373,47 @@ services:
     - /run
     user: root:root
     volumes:
-    - edgex-init:/edgex-init:z
-    - spire-agent:/srv/spiffe/agent:z
-    - spire-ca:/srv/spiffe/ca:z
-    - /tmp/edgex/secrets/spiffe:/tmp/edgex/secrets/spiffe:z
-    - /var/run/docker.sock:/var/run/docker.sock:rw
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: spire-ca
+      target: /srv/spiffe/ca
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: spire-agent
+      target: /srv/spiffe/agent
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/spiffe
+      target: /tmp/edgex/secrets/spiffe
+      bind:
+        selinux: z
+        create_host_path: true
+    - type: bind
+      source: /var/run/docker.sock
+      target: /var/run/docker.sock
+      bind:
+        create_host_path: true
   security-spire-config:
-    command: docker-entrypoint.sh
+    command:
+    - docker-entrypoint.sh
     container_name: edgex-security-spire-config
     depends_on:
-    - security-spire-agent
+      security-spire-agent:
+        condition: service_started
     entrypoint:
     - /edgex-init/ready_to_run_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
@@ -1734,29 +2424,29 @@ services:
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-security-spire-config
     image: nexus3.edgexfoundry.org:10004/security-spire-config:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     read_only: true
     restart: always
     security_opt:
@@ -1765,18 +2455,30 @@ services:
     - /run
     user: root:root
     volumes:
-    - edgex-init:/edgex-init:z
-    - /tmp/edgex/secrets/spiffe:/tmp/edgex/secrets/spiffe:z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/spiffe
+      target: /tmp/edgex/secrets/spiffe
+      bind:
+        selinux: z
+        create_host_path: true
   security-spire-server:
-    command: docker-entrypoint.sh
+    command:
+    - docker-entrypoint.sh
     container_name: edgex-security-spire-server
     depends_on:
-    - security-bootstrapper
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/ready_to_run_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
@@ -1787,32 +2489,36 @@ services:
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-security-spire-server
     image: nexus3.edgexfoundry.org:10004/security-spire-server:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     pid: host
     ports:
-    - 127.0.0.1:59840:59840/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59840
+      published: "59840"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
@@ -1821,10 +2527,30 @@ services:
     - /run
     user: root:root
     volumes:
-    - edgex-init:/edgex-init:z
-    - spire-ca:/srv/spiffe/ca:z
-    - spire-server:/srv/spiffe/server:z
-    - /tmp/edgex/secrets/spiffe:/tmp/edgex/secrets/spiffe:z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: spire-ca
+      target: /srv/spiffe/ca
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: spire-server
+      target: /srv/spiffe/server
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/spiffe
+      target: /tmp/edgex/secrets/spiffe
+      bind:
+        selinux: z
+        create_host_path: true
   ui:
     container_name: edgex-ui-go
     environment:
@@ -1833,9 +2559,12 @@ services:
     hostname: edgex-ui-go
     image: nexus3.edgexfoundry.org:10004/edgex-ui:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 4000:4000/tcp
+    - mode: ingress
+      target: 4000
+      published: "4000"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
@@ -1844,30 +2573,32 @@ services:
   vault:
     cap_add:
     - IPC_LOCK
-    command: server
+    command:
+    - server
     container_name: edgex-vault
     depends_on:
-    - security-bootstrapper
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/vault_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
       VAULT_ADDR: http://edgex-vault:8200
       VAULT_CONFIG_DIR: /vault/config
@@ -1875,37 +2606,77 @@ services:
     hostname: edgex-vault
     image: vault:1.11.5
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:8200:8200/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 8200
+      published: "8200"
+      protocol: tcp
     restart: always
     tmpfs:
     - /vault/config
     user: root:root
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - vault-file:/vault/file:z
-    - vault-logs:/vault/logs:z
-version: '3.7'
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: vault-file
+      target: /vault/file
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: vault-logs
+      target: /vault/logs
+      bind:
+        selinux: z
+      volume: {}
+networks:
+  edgex-network:
+    name: edgex_edgex-network
+    driver: bridge
 volumes:
-  PROFILE_VOLUME_PLACE_HOLDER: {}
-  consul-acl-token: {}
-  consul-config: {}
-  consul-data: {}
-  db-data: {}
-  edgex-init: {}
-  kong: {}
-  kuiper-connections: {}
-  kuiper-data: {}
-  kuiper-sources: {}
-  mqtt: {}
-  postgres-config: {}
-  postgres-data: {}
-  redis-config: {}
-  spire-agent: {}
-  spire-ca: {}
-  spire-server: {}
-  vault-config: {}
-  vault-file: {}
-  vault-logs: {}
-
+  consul-acl-token:
+    name: edgex_consul-acl-token
+  consul-config:
+    name: edgex_consul-config
+  consul-data:
+    name: edgex_consul-data
+  db-data:
+    name: edgex_db-data
+  edgex-init:
+    name: edgex_edgex-init
+  kong:
+    name: edgex_kong
+  kuiper-connections:
+    name: edgex_kuiper-connections
+  kuiper-data:
+    name: edgex_kuiper-data
+  kuiper-sources:
+    name: edgex_kuiper-sources
+  mqtt:
+    name: edgex_mqtt
+  postgres-config:
+    name: edgex_postgres-config
+  postgres-data:
+    name: edgex_postgres-data
+  redis-config:
+    name: edgex_redis-config
+  spire-agent:
+    name: edgex_spire-agent
+  spire-ca:
+    name: edgex_spire-ca
+  spire-server:
+    name: edgex_spire-server
+  vault-config:
+    name: edgex_vault-config
+  vault-file:
+    name: edgex_vault-file
+  vault-logs:
+    name: edgex_vault-logs

--- a/taf/docker-compose-taf-mqtt-bus.yml
+++ b/taf/docker-compose-taf-mqtt-bus.yml
@@ -1568,6 +1568,7 @@ services:
   mqtt-broker:
     command:
     - /usr/sbin/mosquitto
+    - -v
     - -c
     - /mosquitto/config/mosquitto.conf
     container_name: edgex-mqtt-broker
@@ -1584,7 +1585,7 @@ services:
       BROKER_TYPE: mosquitto
       CONF_DIR: /edgex-init/bootstrap-mosquitto/res
       EDGEX_SECURITY_SECRET_STORE: "true"
-      ENTRYPOINT: /docker-entrypoint.sh /usr/sbin/mosquitto -c /mosquitto/config/mosquitto.conf
+      ENTRYPOINT: /docker-entrypoint.sh /usr/sbin/mosquitto -v -c  /mosquitto/config/mosquitto.conf
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       SECRETSTORE_HOST: edgex-vault
       SECRETSTORE_PORT: "8200"

--- a/taf/docker-compose-taf-no-secty-arm64.yml
+++ b/taf/docker-compose-taf-no-secty-arm64.yml
@@ -24,23 +24,23 @@
 #
 # From the compose-builder folder use `make build` to regenerate all standard compose files variations
 #
-networks:
-  edgex-network:
-    driver: bridge
+name: edgex
 services:
   app-service-external-mqtt-trigger:
     container_name: edgex-app-external-mqtt-trigger
     depends_on:
-    - consul
-    - data
+      consul:
+        condition: service_started
+      data:
+        condition: service_started
     environment:
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
       CLIENTS_SUPPORT_NOTIFICATIONS_HOST: edgex-support-notifications
       CLIENTS_SUPPORT_SCHEDULER_HOST: edgex-support-scheduler
-      DATABASES_PRIMARY_HOST: edgex-redis
       DATABASE_HOST: edgex-redis
+      DATABASES_PRIMARY_HOST: edgex-redis
       EDGEX_PROFILE: external-mqtt-trigger
       EDGEX_SECURITY_SECRET_STORE: "false"
       MESSAGEBUS_HOST: edgex-redis
@@ -53,9 +53,13 @@ services:
     hostname: edgex-app-external-mqtt-trigger
     image: nexus3.edgexfoundry.org:10004/app-service-configurable-arm64:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59706:59706/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59706
+      published: "59706"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
@@ -64,16 +68,18 @@ services:
   app-service-functional-tests:
     container_name: app-functional-tests
     depends_on:
-    - consul
-    - data
+      consul:
+        condition: service_started
+      data:
+        condition: service_started
     environment:
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
       CLIENTS_SUPPORT_NOTIFICATIONS_HOST: edgex-support-notifications
       CLIENTS_SUPPORT_SCHEDULER_HOST: edgex-support-scheduler
-      DATABASES_PRIMARY_HOST: edgex-redis
       DATABASE_HOST: edgex-redis
+      DATABASES_PRIMARY_HOST: edgex-redis
       EDGEX_PROFILE: functional-tests
       EDGEX_SECURITY_SECRET_STORE: "false"
       MESSAGEBUS_HOST: edgex-redis
@@ -82,9 +88,12 @@ services:
     hostname: app-functional-tests
     image: nexus3.edgexfoundry.org:10004/app-service-configurable-arm64:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 59705:59705/tcp
+    - mode: ingress
+      target: 59705
+      published: "59705"
+      protocol: tcp
     read_only: true
     security_opt:
     - no-new-privileges:true
@@ -92,16 +101,18 @@ services:
   app-service-http-export:
     container_name: edgex-app-http-export
     depends_on:
-    - consul
-    - data
+      consul:
+        condition: service_started
+      data:
+        condition: service_started
     environment:
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
       CLIENTS_SUPPORT_NOTIFICATIONS_HOST: edgex-support-notifications
       CLIENTS_SUPPORT_SCHEDULER_HOST: edgex-support-scheduler
-      DATABASES_PRIMARY_HOST: edgex-redis
       DATABASE_HOST: edgex-redis
+      DATABASES_PRIMARY_HOST: edgex-redis
       EDGEX_PROFILE: http-export
       EDGEX_SECURITY_SECRET_STORE: "false"
       MESSAGEBUS_HOST: edgex-redis
@@ -112,9 +123,13 @@ services:
     hostname: edgex-app-http-export
     image: nexus3.edgexfoundry.org:10004/app-service-configurable-arm64:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59704:59704/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59704
+      published: "59704"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
@@ -123,16 +138,18 @@ services:
   app-service-mqtt-export:
     container_name: edgex-app-mqtt-export
     depends_on:
-    - consul
-    - data
+      consul:
+        condition: service_started
+      data:
+        condition: service_started
     environment:
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
       CLIENTS_SUPPORT_NOTIFICATIONS_HOST: edgex-support-notifications
       CLIENTS_SUPPORT_SCHEDULER_HOST: edgex-support-scheduler
-      DATABASES_PRIMARY_HOST: edgex-redis
       DATABASE_HOST: edgex-redis
+      DATABASES_PRIMARY_HOST: edgex-redis
       EDGEX_PROFILE: mqtt-export
       EDGEX_SECURITY_SECRET_STORE: "false"
       MESSAGEBUS_HOST: edgex-redis
@@ -144,9 +161,13 @@ services:
     hostname: edgex-app-mqtt-export
     image: nexus3.edgexfoundry.org:10004/app-service-configurable-arm64:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59703:59703/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59703
+      published: "59703"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
@@ -155,8 +176,10 @@ services:
   app-service-rules:
     container_name: edgex-app-rules-engine
     depends_on:
-    - consul
-    - data
+      consul:
+        condition: service_started
+      data:
+        condition: service_started
     environment:
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
@@ -172,9 +195,13 @@ services:
     hostname: edgex-app-rules-engine
     image: nexus3.edgexfoundry.org:10004/app-service-configurable-arm64:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59701:59701/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59701
+      published: "59701"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
@@ -183,16 +210,18 @@ services:
   app-service-sample:
     container_name: edgex-app-sample
     depends_on:
-    - consul
-    - data
+      consul:
+        condition: service_started
+      data:
+        condition: service_started
     environment:
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
       CLIENTS_SUPPORT_NOTIFICATIONS_HOST: edgex-support-notifications
       CLIENTS_SUPPORT_SCHEDULER_HOST: edgex-support-scheduler
-      DATABASES_PRIMARY_HOST: edgex-redis
       DATABASE_HOST: edgex-redis
+      DATABASES_PRIMARY_HOST: edgex-redis
       EDGEX_PROFILE: sample
       EDGEX_SECURITY_SECRET_STORE: "false"
       MESSAGEBUS_HOST: edgex-redis
@@ -201,9 +230,13 @@ services:
     hostname: edgex-app-sample
     image: nexus3.edgexfoundry.org:10004/app-service-configurable-arm64:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59700:59700/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59700
+      published: "59700"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
@@ -212,9 +245,12 @@ services:
   command:
     container_name: edgex-core-command
     depends_on:
-    - consul
-    - database
-    - metadata
+      consul:
+        condition: service_started
+      database:
+        condition: service_started
+      metadata:
+        condition: service_started
     environment:
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
@@ -230,37 +266,64 @@ services:
     hostname: edgex-core-command
     image: nexus3.edgexfoundry.org:10004/core-command-arm64:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59882:59882/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59882
+      published: "59882"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
   consul:
-    command: agent -ui -bootstrap -server -client 0.0.0.0
+    command:
+    - agent
+    - -ui
+    - -bootstrap
+    - -server
+    - -client
+    - 0.0.0.0
     container_name: edgex-core-consul
     hostname: edgex-core-consul
     image: consul:1.13
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:8500:8500/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 8500
+      published: "8500"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: root:root
     volumes:
-    - consul-config:/consul/config:z
-    - consul-data:/consul/data:z
+    - type: volume
+      source: consul-config
+      target: /consul/config
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: consul-data
+      target: /consul/data
+      bind:
+        selinux: z
+      volume: {}
   data:
     container_name: edgex-core-data
     depends_on:
-    - consul
-    - database
-    - metadata
+      consul:
+        condition: service_started
+      database:
+        condition: service_started
+      metadata:
+        condition: service_started
     environment:
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
@@ -275,10 +338,18 @@ services:
     hostname: edgex-core-data
     image: nexus3.edgexfoundry.org:10004/core-data-arm64:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:5563:5563/tcp
-    - 127.0.0.1:59880:59880/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59880
+      published: "59880"
+      protocol: tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 5563
+      published: "5563"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
@@ -298,24 +369,40 @@ services:
     hostname: edgex-redis
     image: redis:7.0-alpine
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:6379:6379/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 6379
+      published: "6379"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: root:root
     volumes:
-    - db-data:/data:z
+    - type: volume
+      source: db-data
+      target: /data
+      bind:
+        selinux: z
+      volume: {}
   device-modbus:
-    command: -cp=consul.http://edgex-core-consul:8500 --registry --configDir=CONFIG_DIR_PLACE_HOLDER
+    command:
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
+    - --configDir=CONFIG_DIR_PLACE_HOLDER
     container_name: edgex-device-modbus
     depends_on:
-    - consul
-    - data
-    - metadata
-    - modbus-simulator
+      consul:
+        condition: service_started
+      data:
+        condition: service_started
+      metadata:
+        condition: service_started
+      modbus-simulator:
+        condition: service_started
     environment:
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
@@ -330,22 +417,34 @@ services:
     hostname: edgex-device-modbus
     image: nexus3.edgexfoundry.org:10004/device-modbus-arm64:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59901:59901/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59901
+      published: "59901"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
     volumes:
-    - PROFILE_VOLUME_PLACE_HOLDER:CONFIG_DIR_PLACE_HOLDER:z
+    - type: bind
+      source: /PROFILE_VOLUME_PLACE_HOLDER
+      target: CONFIG_DIR_PLACE_HOLDER
+      bind:
+        selinux: z
+        create_host_path: true
   device-onvif-camera:
     container_name: edgex-device-onvif-camera
     depends_on:
-    - consul
-    - data
-    - metadata
+      consul:
+        condition: service_started
+      data:
+        condition: service_started
+      metadata:
+        condition: service_started
     environment:
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
@@ -360,9 +459,13 @@ services:
     hostname: edgex-device-onvif-camera
     image: nexus3.edgexfoundry.org:10004/device-onvif-camera-arm64:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59984:59984/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59984
+      published: "59984"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
@@ -371,9 +474,12 @@ services:
   device-rest:
     container_name: edgex-device-rest
     depends_on:
-    - consul
-    - data
-    - metadata
+      consul:
+        condition: service_started
+      data:
+        condition: service_started
+      metadata:
+        condition: service_started
     environment:
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
@@ -388,21 +494,31 @@ services:
     hostname: edgex-device-rest
     image: nexus3.edgexfoundry.org:10004/device-rest-arm64:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59986:59986/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59986
+      published: "59986"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
   device-virtual:
-    command: -cp=consul.http://edgex-core-consul:8500 --registry --configDir=CONFIG_DIR_PLACE_HOLDER
+    command:
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
+    - --configDir=CONFIG_DIR_PLACE_HOLDER
     container_name: edgex-device-virtual
     depends_on:
-    - consul
-    - data
-    - metadata
+      consul:
+        condition: service_started
+      data:
+        condition: service_started
+      metadata:
+        condition: service_started
     environment:
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
@@ -417,22 +533,34 @@ services:
     hostname: edgex-device-virtual
     image: nexus3.edgexfoundry.org:10004/device-virtual-arm64:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59900:59900/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59900
+      published: "59900"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
     volumes:
-    - PROFILE_VOLUME_PLACE_HOLDER:CONFIG_DIR_PLACE_HOLDER:z
+    - type: bind
+      source: /PROFILE_VOLUME_PLACE_HOLDER
+      target: CONFIG_DIR_PLACE_HOLDER
+      bind:
+        selinux: z
+        create_host_path: true
   metadata:
     container_name: edgex-core-metadata
     depends_on:
-    - consul
-    - database
-    - notifications
+      consul:
+        condition: service_started
+      database:
+        condition: service_started
+      notifications:
+        condition: service_started
     environment:
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
@@ -448,9 +576,13 @@ services:
     hostname: edgex-core-metadata
     image: nexus3.edgexfoundry.org:10004/core-metadata-arm64:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59881:59881/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59881
+      published: "59881"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
@@ -461,37 +593,56 @@ services:
     hostname: edgex-modbus-simulator
     image: nexus3.edgexfoundry.org:10003/edgex-devops/edgex-modbus-simulator-arm64:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:1502:1502/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 1502
+      published: "1502"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
   mqtt-broker:
-    command: /usr/sbin/mosquitto -c /mosquitto-no-auth.conf
+    command:
+    - /usr/sbin/mosquitto
+    - -c
+    - /mosquitto-no-auth.conf
+    - -v
     container_name: edgex-mqtt-broker
     hostname: edgex-mqtt-broker
     image: eclipse-mosquitto:2.0
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:1883:1883/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 1883
+      published: "1883"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
   mqtt-taf-broker:
-    command: /usr/sbin/mosquitto -c /mosquitto-no-auth.conf
+    command:
+    - /usr/sbin/mosquitto
+    - -c
+    - /mosquitto-no-auth.conf
     container_name: edgex-taf-mqtt-broker
     hostname: edgex-taf-mqtt-broker
     image: eclipse-mosquitto:2.0
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:1884:1883/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 1883
+      published: "1884"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
@@ -500,8 +651,10 @@ services:
   notifications:
     container_name: edgex-support-notifications
     depends_on:
-    - consul
-    - database
+      consul:
+        condition: service_started
+      database:
+        condition: service_started
     environment:
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
@@ -516,9 +669,13 @@ services:
     hostname: edgex-support-notifications
     image: nexus3.edgexfoundry.org:10004/support-notifications-arm64:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59860:59860/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59860
+      published: "59860"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
@@ -527,45 +684,57 @@ services:
   rulesengine:
     container_name: edgex-kuiper
     depends_on:
-    - database
+      database:
+        condition: service_started
     environment:
-      CONNECTION__EDGEX__REDISMSGBUS__PORT: 6379
+      CONNECTION__EDGEX__REDISMSGBUS__PORT: "6379"
       CONNECTION__EDGEX__REDISMSGBUS__PROTOCOL: redis
       CONNECTION__EDGEX__REDISMSGBUS__SERVER: edgex-redis
       CONNECTION__EDGEX__REDISMSGBUS__TYPE: redis
-      EDGEX__DEFAULT__PORT: 6379
+      EDGEX__DEFAULT__PORT: "6379"
       EDGEX__DEFAULT__PROTOCOL: redis
       EDGEX__DEFAULT__SERVER: edgex-redis
       EDGEX__DEFAULT__TOPIC: rules-events
       EDGEX__DEFAULT__TYPE: redis
       KUIPER__BASIC__CONSOLELOG: "true"
-      KUIPER__BASIC__RESTPORT: 59720
+      KUIPER__BASIC__RESTPORT: "59720"
     hostname: edgex-kuiper
     image: lfedge/ekuiper:1.7-alpine
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59720:59720/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59720
+      published: "59720"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: kuiper:kuiper
     volumes:
-    - kuiper-data:/kuiper/data:z
+    - type: volume
+      source: kuiper-data
+      target: /kuiper/data
+      bind:
+        selinux: z
+      volume: {}
   scalability-test-mqtt-export:
     container_name: edgex-scalability-test-mqtt-export
     depends_on:
-    - consul
-    - data
+      consul:
+        condition: service_started
+      data:
+        condition: service_started
     environment:
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
       CLIENTS_SUPPORT_NOTIFICATIONS_HOST: edgex-support-notifications
       CLIENTS_SUPPORT_SCHEDULER_HOST: edgex-support-scheduler
-      DATABASES_PRIMARY_HOST: edgex-redis
       DATABASE_HOST: edgex-redis
+      DATABASES_PRIMARY_HOST: edgex-redis
       EDGEX_PROFILE: mqtt-export
       EDGEX_SECURITY_SECRET_STORE: "false"
       EDGEX_SERVICE_KEY: app-scalability-test-mqtt-export
@@ -580,9 +749,12 @@ services:
     hostname: edgex-scalability-test-mqtt-export
     image: nexus3.edgexfoundry.org:10004/app-service-configurable-arm64:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 59710:59703/tcp
+    - mode: ingress
+      target: 59703
+      published: "59710"
+      protocol: tcp
     read_only: true
     security_opt:
     - no-new-privileges:true
@@ -590,8 +762,10 @@ services:
   scheduler:
     container_name: edgex-support-scheduler
     depends_on:
-    - consul
-    - database
+      consul:
+        condition: service_started
+      database:
+        condition: service_started
     environment:
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
@@ -608,9 +782,13 @@ services:
     hostname: edgex-support-scheduler
     image: nexus3.edgexfoundry.org:10004/support-scheduler-arm64:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59861:59861/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59861
+      published: "59861"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
@@ -624,19 +802,27 @@ services:
     hostname: edgex-ui-go
     image: nexus3.edgexfoundry.org:10004/edgex-ui-arm64:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 4000:4000/tcp
+    - mode: ingress
+      target: 4000
+      published: "4000"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
-version: '3.7'
+networks:
+  edgex-network:
+    name: edgex_edgex-network
+    driver: bridge
 volumes:
-  PROFILE_VOLUME_PLACE_HOLDER: {}
-  consul-config: {}
-  consul-data: {}
-  db-data: {}
-  kuiper-data: {}
-
+  consul-config:
+    name: edgex_consul-config
+  consul-data:
+    name: edgex_consul-data
+  db-data:
+    name: edgex_db-data
+  kuiper-data:
+    name: edgex_kuiper-data

--- a/taf/docker-compose-taf-no-secty-arm64.yml
+++ b/taf/docker-compose-taf-no-secty-arm64.yml
@@ -610,7 +610,6 @@ services:
     - /usr/sbin/mosquitto
     - -c
     - /mosquitto-no-auth.conf
-    - -v
     container_name: edgex-mqtt-broker
     hostname: edgex-mqtt-broker
     image: eclipse-mosquitto:2.0

--- a/taf/docker-compose-taf-no-secty-mqtt-bus-arm64.yml
+++ b/taf/docker-compose-taf-no-secty-mqtt-bus-arm64.yml
@@ -677,9 +677,9 @@ services:
   mqtt-broker:
     command:
     - /usr/sbin/mosquitto
+    - -v
     - -c
     - /mosquitto-no-auth.conf
-    - -v
     container_name: edgex-mqtt-broker
     hostname: edgex-mqtt-broker
     image: eclipse-mosquitto:2.0

--- a/taf/docker-compose-taf-no-secty-mqtt-bus-arm64.yml
+++ b/taf/docker-compose-taf-no-secty-mqtt-bus-arm64.yml
@@ -24,23 +24,23 @@
 #
 # From the compose-builder folder use `make build` to regenerate all standard compose files variations
 #
-networks:
-  edgex-network:
-    driver: bridge
+name: edgex
 services:
   app-service-external-mqtt-trigger:
     container_name: edgex-app-external-mqtt-trigger
     depends_on:
-    - consul
-    - data
+      consul:
+        condition: service_started
+      data:
+        condition: service_started
     environment:
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
       CLIENTS_SUPPORT_NOTIFICATIONS_HOST: edgex-support-notifications
       CLIENTS_SUPPORT_SCHEDULER_HOST: edgex-support-scheduler
-      DATABASES_PRIMARY_HOST: edgex-redis
       DATABASE_HOST: edgex-redis
+      DATABASES_PRIMARY_HOST: edgex-redis
       EDGEX_PROFILE: external-mqtt-trigger
       EDGEX_SECURITY_SECRET_STORE: "false"
       MESSAGEBUS_HOST: edgex-redis
@@ -53,9 +53,13 @@ services:
     hostname: edgex-app-external-mqtt-trigger
     image: nexus3.edgexfoundry.org:10004/app-service-configurable-arm64:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59706:59706/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59706
+      published: "59706"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
@@ -64,16 +68,18 @@ services:
   app-service-functional-tests:
     container_name: app-functional-tests
     depends_on:
-    - consul
-    - data
+      consul:
+        condition: service_started
+      data:
+        condition: service_started
     environment:
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
       CLIENTS_SUPPORT_NOTIFICATIONS_HOST: edgex-support-notifications
       CLIENTS_SUPPORT_SCHEDULER_HOST: edgex-support-scheduler
-      DATABASES_PRIMARY_HOST: edgex-redis
       DATABASE_HOST: edgex-redis
+      DATABASES_PRIMARY_HOST: edgex-redis
       EDGEX_PROFILE: functional-tests
       EDGEX_SECURITY_SECRET_STORE: "false"
       MESSAGEBUS_HOST: edgex-redis
@@ -82,9 +88,12 @@ services:
     hostname: app-functional-tests
     image: nexus3.edgexfoundry.org:10004/app-service-configurable-arm64:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 59705:59705/tcp
+    - mode: ingress
+      target: 59705
+      published: "59705"
+      protocol: tcp
     read_only: true
     security_opt:
     - no-new-privileges:true
@@ -92,22 +101,25 @@ services:
   app-service-http-export:
     container_name: edgex-app-http-export
     depends_on:
-    - consul
-    - data
-    - mqtt-broker
+      consul:
+        condition: service_started
+      data:
+        condition: service_started
+      mqtt-broker:
+        condition: service_started
     environment:
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
       CLIENTS_SUPPORT_NOTIFICATIONS_HOST: edgex-support-notifications
       CLIENTS_SUPPORT_SCHEDULER_HOST: edgex-support-scheduler
-      DATABASES_PRIMARY_HOST: edgex-redis
       DATABASE_HOST: edgex-redis
+      DATABASES_PRIMARY_HOST: edgex-redis
       EDGEX_PROFILE: http-export
       EDGEX_SECURITY_SECRET_STORE: "false"
       MESSAGEBUS_AUTHMODE: none
       MESSAGEBUS_HOST: edgex-mqtt-broker
-      MESSAGEBUS_PORT: '1883'
+      MESSAGEBUS_PORT: "1883"
       MESSAGEBUS_PROTOCOL: tcp
       MESSAGEBUS_TYPE: mqtt
       REGISTRY_HOST: edgex-core-consul
@@ -117,9 +129,13 @@ services:
     hostname: edgex-app-http-export
     image: nexus3.edgexfoundry.org:10004/app-service-configurable-arm64:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59704:59704/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59704
+      published: "59704"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
@@ -128,22 +144,25 @@ services:
   app-service-mqtt-export:
     container_name: edgex-app-mqtt-export
     depends_on:
-    - consul
-    - data
-    - mqtt-broker
+      consul:
+        condition: service_started
+      data:
+        condition: service_started
+      mqtt-broker:
+        condition: service_started
     environment:
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
       CLIENTS_SUPPORT_NOTIFICATIONS_HOST: edgex-support-notifications
       CLIENTS_SUPPORT_SCHEDULER_HOST: edgex-support-scheduler
-      DATABASES_PRIMARY_HOST: edgex-redis
       DATABASE_HOST: edgex-redis
+      DATABASES_PRIMARY_HOST: edgex-redis
       EDGEX_PROFILE: mqtt-export
       EDGEX_SECURITY_SECRET_STORE: "false"
       MESSAGEBUS_AUTHMODE: none
       MESSAGEBUS_HOST: edgex-mqtt-broker
-      MESSAGEBUS_PORT: '1883'
+      MESSAGEBUS_PORT: "1883"
       MESSAGEBUS_PROTOCOL: tcp
       MESSAGEBUS_TYPE: mqtt
       REGISTRY_HOST: edgex-core-consul
@@ -154,9 +173,13 @@ services:
     hostname: edgex-app-mqtt-export
     image: nexus3.edgexfoundry.org:10004/app-service-configurable-arm64:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59703:59703/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59703
+      published: "59703"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
@@ -165,9 +188,12 @@ services:
   app-service-rules:
     container_name: edgex-app-rules-engine
     depends_on:
-    - consul
-    - data
-    - mqtt-broker
+      consul:
+        condition: service_started
+      data:
+        condition: service_started
+      mqtt-broker:
+        condition: service_started
     environment:
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
@@ -179,7 +205,7 @@ services:
       EDGEX_SECURITY_SECRET_STORE: "false"
       MESSAGEBUS_AUTHMODE: none
       MESSAGEBUS_HOST: edgex-mqtt-broker
-      MESSAGEBUS_PORT: 1883
+      MESSAGEBUS_PORT: "1883"
       MESSAGEBUS_PROTOCOL: tcp
       MESSAGEBUS_TYPE: mqtt
       REGISTRY_HOST: edgex-core-consul
@@ -187,9 +213,13 @@ services:
     hostname: edgex-app-rules-engine
     image: nexus3.edgexfoundry.org:10004/app-service-configurable-arm64:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59701:59701/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59701
+      published: "59701"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
@@ -198,22 +228,25 @@ services:
   app-service-sample:
     container_name: edgex-app-sample
     depends_on:
-    - consul
-    - data
-    - mqtt-broker
+      consul:
+        condition: service_started
+      data:
+        condition: service_started
+      mqtt-broker:
+        condition: service_started
     environment:
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
       CLIENTS_SUPPORT_NOTIFICATIONS_HOST: edgex-support-notifications
       CLIENTS_SUPPORT_SCHEDULER_HOST: edgex-support-scheduler
-      DATABASES_PRIMARY_HOST: edgex-redis
       DATABASE_HOST: edgex-redis
+      DATABASES_PRIMARY_HOST: edgex-redis
       EDGEX_PROFILE: sample
       EDGEX_SECURITY_SECRET_STORE: "false"
       MESSAGEBUS_AUTHMODE: none
       MESSAGEBUS_HOST: edgex-mqtt-broker
-      MESSAGEBUS_PORT: '1883'
+      MESSAGEBUS_PORT: "1883"
       MESSAGEBUS_PROTOCOL: tcp
       MESSAGEBUS_TYPE: mqtt
       REGISTRY_HOST: edgex-core-consul
@@ -221,9 +254,13 @@ services:
     hostname: edgex-app-sample
     image: nexus3.edgexfoundry.org:10004/app-service-configurable-arm64:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59700:59700/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59700
+      published: "59700"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
@@ -232,10 +269,14 @@ services:
   command:
     container_name: edgex-core-command
     depends_on:
-    - consul
-    - database
-    - metadata
-    - mqtt-broker
+      consul:
+        condition: service_started
+      database:
+        condition: service_started
+      metadata:
+        condition: service_started
+      mqtt-broker:
+        condition: service_started
     environment:
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
@@ -248,7 +289,7 @@ services:
       MESSAGEBUS_EXTERNAL_URL: tcp://edgex-mqtt-broker:1883
       MESSAGEBUS_INTERNAL_AUTHMODE: none
       MESSAGEBUS_INTERNAL_HOST: edgex-mqtt-broker
-      MESSAGEBUS_INTERNAL_PORT: 1883
+      MESSAGEBUS_INTERNAL_PORT: "1883"
       MESSAGEBUS_INTERNAL_PROTOCOL: tcp
       MESSAGEBUS_INTERNAL_TYPE: mqtt
       REGISTRY_HOST: edgex-core-consul
@@ -256,38 +297,66 @@ services:
     hostname: edgex-core-command
     image: nexus3.edgexfoundry.org:10004/core-command-arm64:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59882:59882/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59882
+      published: "59882"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
   consul:
-    command: agent -ui -bootstrap -server -client 0.0.0.0
+    command:
+    - agent
+    - -ui
+    - -bootstrap
+    - -server
+    - -client
+    - 0.0.0.0
     container_name: edgex-core-consul
     hostname: edgex-core-consul
     image: consul:1.13
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:8500:8500/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 8500
+      published: "8500"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: root:root
     volumes:
-    - consul-config:/consul/config:z
-    - consul-data:/consul/data:z
+    - type: volume
+      source: consul-config
+      target: /consul/config
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: consul-data
+      target: /consul/data
+      bind:
+        selinux: z
+      volume: {}
   data:
     container_name: edgex-core-data
     depends_on:
-    - consul
-    - database
-    - metadata
-    - mqtt-broker
+      consul:
+        condition: service_started
+      database:
+        condition: service_started
+      metadata:
+        condition: service_started
+      mqtt-broker:
+        condition: service_started
     environment:
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
@@ -299,7 +368,7 @@ services:
       MESSAGEBUS_AUTHMODE: none
       MESSAGEBUS_HOST: edgex-mqtt-broker
       MESSAGEBUS_OPTIONAL_CLIENTID: core-data
-      MESSAGEBUS_PORT: '1883'
+      MESSAGEBUS_PORT: "1883"
       MESSAGEBUS_PROTOCOL: tcp
       MESSAGEBUS_TYPE: mqtt
       REGISTRY_HOST: edgex-core-consul
@@ -307,10 +376,18 @@ services:
     hostname: edgex-core-data
     image: nexus3.edgexfoundry.org:10004/core-data-arm64:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:5563:5563/tcp
-    - 127.0.0.1:59880:59880/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 5563
+      published: "5563"
+      protocol: tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59880
+      published: "59880"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
@@ -330,25 +407,42 @@ services:
     hostname: edgex-redis
     image: redis:7.0-alpine
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:6379:6379/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 6379
+      published: "6379"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: root:root
     volumes:
-    - db-data:/data:z
+    - type: volume
+      source: db-data
+      target: /data
+      bind:
+        selinux: z
+      volume: {}
   device-modbus:
-    command: -cp=consul.http://edgex-core-consul:8500 --registry --configDir=CONFIG_DIR_PLACE_HOLDER
+    command:
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
+    - --configDir=CONFIG_DIR_PLACE_HOLDER
     container_name: edgex-device-modbus
     depends_on:
-    - consul
-    - data
-    - metadata
-    - modbus-simulator
-    - mqtt-broker
+      consul:
+        condition: service_started
+      data:
+        condition: service_started
+      metadata:
+        condition: service_started
+      modbus-simulator:
+        condition: service_started
+      mqtt-broker:
+        condition: service_started
     environment:
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
@@ -359,7 +453,7 @@ services:
       EDGEX_SECURITY_SECRET_STORE: "false"
       MESSAGEBUS_AUTHMODE: none
       MESSAGEBUS_HOST: edgex-mqtt-broker
-      MESSAGEBUS_PORT: '1883'
+      MESSAGEBUS_PORT: "1883"
       MESSAGEBUS_PROTOCOL: tcp
       MESSAGEBUS_TYPE: mqtt
       REGISTRY_HOST: edgex-core-consul
@@ -367,23 +461,36 @@ services:
     hostname: edgex-device-modbus
     image: nexus3.edgexfoundry.org:10004/device-modbus-arm64:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59901:59901/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59901
+      published: "59901"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
     volumes:
-    - PROFILE_VOLUME_PLACE_HOLDER:CONFIG_DIR_PLACE_HOLDER:z
+    - type: bind
+      source: /PROFILE_VOLUME_PLACE_HOLDER
+      target: CONFIG_DIR_PLACE_HOLDER
+      bind:
+        selinux: z
+        create_host_path: true
   device-onvif-camera:
     container_name: edgex-device-onvif-camera
     depends_on:
-    - consul
-    - data
-    - metadata
-    - mqtt-broker
+      consul:
+        condition: service_started
+      data:
+        condition: service_started
+      metadata:
+        condition: service_started
+      mqtt-broker:
+        condition: service_started
     environment:
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
@@ -394,7 +501,7 @@ services:
       EDGEX_SECURITY_SECRET_STORE: "false"
       MESSAGEBUS_AUTHMODE: none
       MESSAGEBUS_HOST: edgex-mqtt-broker
-      MESSAGEBUS_PORT: '1883'
+      MESSAGEBUS_PORT: "1883"
       MESSAGEBUS_PROTOCOL: tcp
       MESSAGEBUS_TYPE: mqtt
       REGISTRY_HOST: edgex-core-consul
@@ -402,9 +509,13 @@ services:
     hostname: edgex-device-onvif-camera
     image: nexus3.edgexfoundry.org:10004/device-onvif-camera-arm64:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59984:59984/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59984
+      published: "59984"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
@@ -413,10 +524,14 @@ services:
   device-rest:
     container_name: edgex-device-rest
     depends_on:
-    - consul
-    - data
-    - metadata
-    - mqtt-broker
+      consul:
+        condition: service_started
+      data:
+        condition: service_started
+      metadata:
+        condition: service_started
+      mqtt-broker:
+        condition: service_started
     environment:
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
@@ -427,7 +542,7 @@ services:
       EDGEX_SECURITY_SECRET_STORE: "false"
       MESSAGEBUS_AUTHMODE: none
       MESSAGEBUS_HOST: edgex-mqtt-broker
-      MESSAGEBUS_PORT: '1883'
+      MESSAGEBUS_PORT: "1883"
       MESSAGEBUS_PROTOCOL: tcp
       MESSAGEBUS_TYPE: mqtt
       REGISTRY_HOST: edgex-core-consul
@@ -435,22 +550,33 @@ services:
     hostname: edgex-device-rest
     image: nexus3.edgexfoundry.org:10004/device-rest-arm64:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59986:59986/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59986
+      published: "59986"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
   device-virtual:
-    command: -cp=consul.http://edgex-core-consul:8500 --registry --configDir=CONFIG_DIR_PLACE_HOLDER
+    command:
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
+    - --configDir=CONFIG_DIR_PLACE_HOLDER
     container_name: edgex-device-virtual
     depends_on:
-    - consul
-    - data
-    - metadata
-    - mqtt-broker
+      consul:
+        condition: service_started
+      data:
+        condition: service_started
+      metadata:
+        condition: service_started
+      mqtt-broker:
+        condition: service_started
     environment:
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
@@ -461,7 +587,7 @@ services:
       EDGEX_SECURITY_SECRET_STORE: "false"
       MESSAGEBUS_AUTHMODE: none
       MESSAGEBUS_HOST: edgex-mqtt-broker
-      MESSAGEBUS_PORT: '1883'
+      MESSAGEBUS_PORT: "1883"
       MESSAGEBUS_PROTOCOL: tcp
       MESSAGEBUS_TYPE: mqtt
       REGISTRY_HOST: edgex-core-consul
@@ -469,23 +595,36 @@ services:
     hostname: edgex-device-virtual
     image: nexus3.edgexfoundry.org:10004/device-virtual-arm64:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59900:59900/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59900
+      published: "59900"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
     volumes:
-    - PROFILE_VOLUME_PLACE_HOLDER:CONFIG_DIR_PLACE_HOLDER:z
+    - type: bind
+      source: /PROFILE_VOLUME_PLACE_HOLDER
+      target: CONFIG_DIR_PLACE_HOLDER
+      bind:
+        selinux: z
+        create_host_path: true
   metadata:
     container_name: edgex-core-metadata
     depends_on:
-    - consul
-    - database
-    - mqtt-broker
-    - notifications
+      consul:
+        condition: service_started
+      database:
+        condition: service_started
+      mqtt-broker:
+        condition: service_started
+      notifications:
+        condition: service_started
     environment:
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
@@ -497,7 +636,7 @@ services:
       MESSAGEBUS_AUTHMODE: none
       MESSAGEBUS_HOST: edgex-mqtt-broker
       MESSAGEBUS_OPTIONAL_CLIENTID: core-metadata
-      MESSAGEBUS_PORT: '1883'
+      MESSAGEBUS_PORT: "1883"
       MESSAGEBUS_PROTOCOL: tcp
       MESSAGEBUS_TYPE: mqtt
       NOTIFICATIONS_SENDER: edgex-core-metadata
@@ -506,9 +645,13 @@ services:
     hostname: edgex-core-metadata
     image: nexus3.edgexfoundry.org:10004/core-metadata-arm64:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59881:59881/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59881
+      published: "59881"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
@@ -519,37 +662,56 @@ services:
     hostname: edgex-modbus-simulator
     image: nexus3.edgexfoundry.org:10003/edgex-devops/edgex-modbus-simulator-arm64:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:1502:1502/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 1502
+      published: "1502"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
   mqtt-broker:
-    command: /usr/sbin/mosquitto -c /mosquitto-no-auth.conf
+    command:
+    - /usr/sbin/mosquitto
+    - -c
+    - /mosquitto-no-auth.conf
+    - -v
     container_name: edgex-mqtt-broker
     hostname: edgex-mqtt-broker
     image: eclipse-mosquitto:2.0
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:1883:1883/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 1883
+      published: "1883"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
   mqtt-taf-broker:
-    command: /usr/sbin/mosquitto -c /mosquitto-no-auth.conf
+    command:
+    - /usr/sbin/mosquitto
+    - -c
+    - /mosquitto-no-auth.conf
     container_name: edgex-taf-mqtt-broker
     hostname: edgex-taf-mqtt-broker
     image: eclipse-mosquitto:2.0
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:1884:1883/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 1883
+      published: "1884"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
@@ -558,9 +720,12 @@ services:
   notifications:
     container_name: edgex-support-notifications
     depends_on:
-    - consul
-    - database
-    - mqtt-broker
+      consul:
+        condition: service_started
+      database:
+        condition: service_started
+      mqtt-broker:
+        condition: service_started
     environment:
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
@@ -572,7 +737,7 @@ services:
       MESSAGEBUS_AUTHMODE: none
       MESSAGEBUS_HOST: edgex-mqtt-broker
       MESSAGEBUS_OPTIONAL_CLIENTID: support-notifications
-      MESSAGEBUS_PORT: '1883'
+      MESSAGEBUS_PORT: "1883"
       MESSAGEBUS_PROTOCOL: tcp
       MESSAGEBUS_TYPE: mqtt
       REGISTRY_HOST: edgex-core-consul
@@ -580,9 +745,13 @@ services:
     hostname: edgex-support-notifications
     image: nexus3.edgexfoundry.org:10004/support-notifications-arm64:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59860:59860/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59860
+      published: "59860"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
@@ -591,62 +760,76 @@ services:
   rulesengine:
     container_name: edgex-kuiper
     depends_on:
-    - database
-    - mqtt-broker
+      database:
+        condition: service_started
+      mqtt-broker:
+        condition: service_started
     environment:
       CONNECTION__EDGEX__MQTTMSGBUS__OPTIONAL__CLIENTID: kuiper-rules-engine
-      CONNECTION__EDGEX__MQTTMSGBUS__OPTIONAL__KEEPALIVE: 500
-      CONNECTION__EDGEX__MQTTMSGBUS__PORT: 1883
+      CONNECTION__EDGEX__MQTTMSGBUS__OPTIONAL__KEEPALIVE: "500"
+      CONNECTION__EDGEX__MQTTMSGBUS__PORT: "1883"
       CONNECTION__EDGEX__MQTTMSGBUS__PROTOCOL: tcp
       CONNECTION__EDGEX__MQTTMSGBUS__SERVER: edgex-mqtt-broker
       CONNECTION__EDGEX__MQTTMSGBUS__TYPE: mqtt
-      CONNECTION__EDGEX__REDISMSGBUS__PORT: 6379
+      CONNECTION__EDGEX__REDISMSGBUS__PORT: "6379"
       CONNECTION__EDGEX__REDISMSGBUS__PROTOCOL: redis
       CONNECTION__EDGEX__REDISMSGBUS__SERVER: edgex-redis
       CONNECTION__EDGEX__REDISMSGBUS__TYPE: redis
       EDGEX__DEFAULT__OPTIONAL__CLIENTID: kuiper-rules-engine
-      EDGEX__DEFAULT__OPTIONAL__KEEPALIVE: 500
-      EDGEX__DEFAULT__PORT: 1883
+      EDGEX__DEFAULT__OPTIONAL__KEEPALIVE: "500"
+      EDGEX__DEFAULT__PORT: "1883"
       EDGEX__DEFAULT__PROTOCOL: tcp
       EDGEX__DEFAULT__SERVER: edgex-mqtt-broker
       EDGEX__DEFAULT__TOPIC: rules-events
       EDGEX__DEFAULT__TYPE: mqtt
       KUIPER__BASIC__CONSOLELOG: "true"
-      KUIPER__BASIC__RESTPORT: 59720
+      KUIPER__BASIC__RESTPORT: "59720"
     hostname: edgex-kuiper
     image: lfedge/ekuiper:1.7-alpine
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59720:59720/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59720
+      published: "59720"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: kuiper:kuiper
     volumes:
-    - kuiper-data:/kuiper/data:z
+    - type: volume
+      source: kuiper-data
+      target: /kuiper/data
+      bind:
+        selinux: z
+      volume: {}
   scalability-test-mqtt-export:
     container_name: edgex-scalability-test-mqtt-export
     depends_on:
-    - consul
-    - data
-    - mqtt-broker
+      consul:
+        condition: service_started
+      data:
+        condition: service_started
+      mqtt-broker:
+        condition: service_started
     environment:
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
       CLIENTS_SUPPORT_NOTIFICATIONS_HOST: edgex-support-notifications
       CLIENTS_SUPPORT_SCHEDULER_HOST: edgex-support-scheduler
-      DATABASES_PRIMARY_HOST: edgex-redis
       DATABASE_HOST: edgex-redis
+      DATABASES_PRIMARY_HOST: edgex-redis
       EDGEX_PROFILE: mqtt-export
       EDGEX_SECURITY_SECRET_STORE: "false"
       EDGEX_SERVICE_KEY: app-scalability-test-mqtt-export
       MESSAGEBUS_AUTHMODE: none
       MESSAGEBUS_HOST: edgex-mqtt-broker
       MESSAGEBUS_OPTIONAL_CLIENTID: app-scalability-test-mqtt-export
-      MESSAGEBUS_PORT: '1883'
+      MESSAGEBUS_PORT: "1883"
       MESSAGEBUS_PROTOCOL: tcp
       MESSAGEBUS_TYPE: mqtt
       REGISTRY_HOST: edgex-core-consul
@@ -658,9 +841,12 @@ services:
     hostname: edgex-scalability-test-mqtt-export
     image: nexus3.edgexfoundry.org:10004/app-service-configurable-arm64:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 59710:59703/tcp
+    - mode: ingress
+      target: 59703
+      published: "59710"
+      protocol: tcp
     read_only: true
     security_opt:
     - no-new-privileges:true
@@ -668,9 +854,12 @@ services:
   scheduler:
     container_name: edgex-support-scheduler
     depends_on:
-    - consul
-    - database
-    - mqtt-broker
+      consul:
+        condition: service_started
+      database:
+        condition: service_started
+      mqtt-broker:
+        condition: service_started
     environment:
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
@@ -684,7 +873,7 @@ services:
       MESSAGEBUS_AUTHMODE: none
       MESSAGEBUS_HOST: edgex-mqtt-broker
       MESSAGEBUS_OPTIONAL_CLIENTID: support-scheduler
-      MESSAGEBUS_PORT: '1883'
+      MESSAGEBUS_PORT: "1883"
       MESSAGEBUS_PROTOCOL: tcp
       MESSAGEBUS_TYPE: mqtt
       REGISTRY_HOST: edgex-core-consul
@@ -692,9 +881,13 @@ services:
     hostname: edgex-support-scheduler
     image: nexus3.edgexfoundry.org:10004/support-scheduler-arm64:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59861:59861/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59861
+      published: "59861"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
@@ -708,19 +901,27 @@ services:
     hostname: edgex-ui-go
     image: nexus3.edgexfoundry.org:10004/edgex-ui-arm64:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 4000:4000/tcp
+    - mode: ingress
+      target: 4000
+      published: "4000"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
-version: '3.7'
+networks:
+  edgex-network:
+    name: edgex_edgex-network
+    driver: bridge
 volumes:
-  PROFILE_VOLUME_PLACE_HOLDER: {}
-  consul-config: {}
-  consul-data: {}
-  db-data: {}
-  kuiper-data: {}
-
+  consul-config:
+    name: edgex_consul-config
+  consul-data:
+    name: edgex_consul-data
+  db-data:
+    name: edgex_db-data
+  kuiper-data:
+    name: edgex_kuiper-data

--- a/taf/docker-compose-taf-no-secty-mqtt-bus.yml
+++ b/taf/docker-compose-taf-no-secty-mqtt-bus.yml
@@ -677,9 +677,9 @@ services:
   mqtt-broker:
     command:
     - /usr/sbin/mosquitto
+    - -v
     - -c
     - /mosquitto-no-auth.conf
-    - -v
     container_name: edgex-mqtt-broker
     hostname: edgex-mqtt-broker
     image: eclipse-mosquitto:2.0

--- a/taf/docker-compose-taf-no-secty-mqtt-bus.yml
+++ b/taf/docker-compose-taf-no-secty-mqtt-bus.yml
@@ -24,23 +24,23 @@
 #
 # From the compose-builder folder use `make build` to regenerate all standard compose files variations
 #
-networks:
-  edgex-network:
-    driver: bridge
+name: edgex
 services:
   app-service-external-mqtt-trigger:
     container_name: edgex-app-external-mqtt-trigger
     depends_on:
-    - consul
-    - data
+      consul:
+        condition: service_started
+      data:
+        condition: service_started
     environment:
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
       CLIENTS_SUPPORT_NOTIFICATIONS_HOST: edgex-support-notifications
       CLIENTS_SUPPORT_SCHEDULER_HOST: edgex-support-scheduler
-      DATABASES_PRIMARY_HOST: edgex-redis
       DATABASE_HOST: edgex-redis
+      DATABASES_PRIMARY_HOST: edgex-redis
       EDGEX_PROFILE: external-mqtt-trigger
       EDGEX_SECURITY_SECRET_STORE: "false"
       MESSAGEBUS_HOST: edgex-redis
@@ -53,9 +53,13 @@ services:
     hostname: edgex-app-external-mqtt-trigger
     image: nexus3.edgexfoundry.org:10004/app-service-configurable:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59706:59706/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59706
+      published: "59706"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
@@ -64,16 +68,18 @@ services:
   app-service-functional-tests:
     container_name: app-functional-tests
     depends_on:
-    - consul
-    - data
+      consul:
+        condition: service_started
+      data:
+        condition: service_started
     environment:
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
       CLIENTS_SUPPORT_NOTIFICATIONS_HOST: edgex-support-notifications
       CLIENTS_SUPPORT_SCHEDULER_HOST: edgex-support-scheduler
-      DATABASES_PRIMARY_HOST: edgex-redis
       DATABASE_HOST: edgex-redis
+      DATABASES_PRIMARY_HOST: edgex-redis
       EDGEX_PROFILE: functional-tests
       EDGEX_SECURITY_SECRET_STORE: "false"
       MESSAGEBUS_HOST: edgex-redis
@@ -82,9 +88,12 @@ services:
     hostname: app-functional-tests
     image: nexus3.edgexfoundry.org:10004/app-service-configurable:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 59705:59705/tcp
+    - mode: ingress
+      target: 59705
+      published: "59705"
+      protocol: tcp
     read_only: true
     security_opt:
     - no-new-privileges:true
@@ -92,22 +101,25 @@ services:
   app-service-http-export:
     container_name: edgex-app-http-export
     depends_on:
-    - consul
-    - data
-    - mqtt-broker
+      consul:
+        condition: service_started
+      data:
+        condition: service_started
+      mqtt-broker:
+        condition: service_started
     environment:
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
       CLIENTS_SUPPORT_NOTIFICATIONS_HOST: edgex-support-notifications
       CLIENTS_SUPPORT_SCHEDULER_HOST: edgex-support-scheduler
-      DATABASES_PRIMARY_HOST: edgex-redis
       DATABASE_HOST: edgex-redis
+      DATABASES_PRIMARY_HOST: edgex-redis
       EDGEX_PROFILE: http-export
       EDGEX_SECURITY_SECRET_STORE: "false"
       MESSAGEBUS_AUTHMODE: none
       MESSAGEBUS_HOST: edgex-mqtt-broker
-      MESSAGEBUS_PORT: '1883'
+      MESSAGEBUS_PORT: "1883"
       MESSAGEBUS_PROTOCOL: tcp
       MESSAGEBUS_TYPE: mqtt
       REGISTRY_HOST: edgex-core-consul
@@ -117,9 +129,13 @@ services:
     hostname: edgex-app-http-export
     image: nexus3.edgexfoundry.org:10004/app-service-configurable:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59704:59704/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59704
+      published: "59704"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
@@ -128,22 +144,25 @@ services:
   app-service-mqtt-export:
     container_name: edgex-app-mqtt-export
     depends_on:
-    - consul
-    - data
-    - mqtt-broker
+      consul:
+        condition: service_started
+      data:
+        condition: service_started
+      mqtt-broker:
+        condition: service_started
     environment:
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
       CLIENTS_SUPPORT_NOTIFICATIONS_HOST: edgex-support-notifications
       CLIENTS_SUPPORT_SCHEDULER_HOST: edgex-support-scheduler
-      DATABASES_PRIMARY_HOST: edgex-redis
       DATABASE_HOST: edgex-redis
+      DATABASES_PRIMARY_HOST: edgex-redis
       EDGEX_PROFILE: mqtt-export
       EDGEX_SECURITY_SECRET_STORE: "false"
       MESSAGEBUS_AUTHMODE: none
       MESSAGEBUS_HOST: edgex-mqtt-broker
-      MESSAGEBUS_PORT: '1883'
+      MESSAGEBUS_PORT: "1883"
       MESSAGEBUS_PROTOCOL: tcp
       MESSAGEBUS_TYPE: mqtt
       REGISTRY_HOST: edgex-core-consul
@@ -154,9 +173,13 @@ services:
     hostname: edgex-app-mqtt-export
     image: nexus3.edgexfoundry.org:10004/app-service-configurable:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59703:59703/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59703
+      published: "59703"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
@@ -165,9 +188,12 @@ services:
   app-service-rules:
     container_name: edgex-app-rules-engine
     depends_on:
-    - consul
-    - data
-    - mqtt-broker
+      consul:
+        condition: service_started
+      data:
+        condition: service_started
+      mqtt-broker:
+        condition: service_started
     environment:
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
@@ -179,7 +205,7 @@ services:
       EDGEX_SECURITY_SECRET_STORE: "false"
       MESSAGEBUS_AUTHMODE: none
       MESSAGEBUS_HOST: edgex-mqtt-broker
-      MESSAGEBUS_PORT: 1883
+      MESSAGEBUS_PORT: "1883"
       MESSAGEBUS_PROTOCOL: tcp
       MESSAGEBUS_TYPE: mqtt
       REGISTRY_HOST: edgex-core-consul
@@ -187,9 +213,13 @@ services:
     hostname: edgex-app-rules-engine
     image: nexus3.edgexfoundry.org:10004/app-service-configurable:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59701:59701/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59701
+      published: "59701"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
@@ -198,22 +228,25 @@ services:
   app-service-sample:
     container_name: edgex-app-sample
     depends_on:
-    - consul
-    - data
-    - mqtt-broker
+      consul:
+        condition: service_started
+      data:
+        condition: service_started
+      mqtt-broker:
+        condition: service_started
     environment:
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
       CLIENTS_SUPPORT_NOTIFICATIONS_HOST: edgex-support-notifications
       CLIENTS_SUPPORT_SCHEDULER_HOST: edgex-support-scheduler
-      DATABASES_PRIMARY_HOST: edgex-redis
       DATABASE_HOST: edgex-redis
+      DATABASES_PRIMARY_HOST: edgex-redis
       EDGEX_PROFILE: sample
       EDGEX_SECURITY_SECRET_STORE: "false"
       MESSAGEBUS_AUTHMODE: none
       MESSAGEBUS_HOST: edgex-mqtt-broker
-      MESSAGEBUS_PORT: '1883'
+      MESSAGEBUS_PORT: "1883"
       MESSAGEBUS_PROTOCOL: tcp
       MESSAGEBUS_TYPE: mqtt
       REGISTRY_HOST: edgex-core-consul
@@ -221,9 +254,13 @@ services:
     hostname: edgex-app-sample
     image: nexus3.edgexfoundry.org:10004/app-service-configurable:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59700:59700/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59700
+      published: "59700"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
@@ -232,10 +269,14 @@ services:
   command:
     container_name: edgex-core-command
     depends_on:
-    - consul
-    - database
-    - metadata
-    - mqtt-broker
+      consul:
+        condition: service_started
+      database:
+        condition: service_started
+      metadata:
+        condition: service_started
+      mqtt-broker:
+        condition: service_started
     environment:
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
@@ -248,7 +289,7 @@ services:
       MESSAGEBUS_EXTERNAL_URL: tcp://edgex-mqtt-broker:1883
       MESSAGEBUS_INTERNAL_AUTHMODE: none
       MESSAGEBUS_INTERNAL_HOST: edgex-mqtt-broker
-      MESSAGEBUS_INTERNAL_PORT: 1883
+      MESSAGEBUS_INTERNAL_PORT: "1883"
       MESSAGEBUS_INTERNAL_PROTOCOL: tcp
       MESSAGEBUS_INTERNAL_TYPE: mqtt
       REGISTRY_HOST: edgex-core-consul
@@ -256,38 +297,66 @@ services:
     hostname: edgex-core-command
     image: nexus3.edgexfoundry.org:10004/core-command:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59882:59882/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59882
+      published: "59882"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
   consul:
-    command: agent -ui -bootstrap -server -client 0.0.0.0
+    command:
+    - agent
+    - -ui
+    - -bootstrap
+    - -server
+    - -client
+    - 0.0.0.0
     container_name: edgex-core-consul
     hostname: edgex-core-consul
     image: consul:1.13
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:8500:8500/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 8500
+      published: "8500"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: root:root
     volumes:
-    - consul-config:/consul/config:z
-    - consul-data:/consul/data:z
+    - type: volume
+      source: consul-config
+      target: /consul/config
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: consul-data
+      target: /consul/data
+      bind:
+        selinux: z
+      volume: {}
   data:
     container_name: edgex-core-data
     depends_on:
-    - consul
-    - database
-    - metadata
-    - mqtt-broker
+      consul:
+        condition: service_started
+      database:
+        condition: service_started
+      metadata:
+        condition: service_started
+      mqtt-broker:
+        condition: service_started
     environment:
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
@@ -299,7 +368,7 @@ services:
       MESSAGEBUS_AUTHMODE: none
       MESSAGEBUS_HOST: edgex-mqtt-broker
       MESSAGEBUS_OPTIONAL_CLIENTID: core-data
-      MESSAGEBUS_PORT: '1883'
+      MESSAGEBUS_PORT: "1883"
       MESSAGEBUS_PROTOCOL: tcp
       MESSAGEBUS_TYPE: mqtt
       REGISTRY_HOST: edgex-core-consul
@@ -307,10 +376,18 @@ services:
     hostname: edgex-core-data
     image: nexus3.edgexfoundry.org:10004/core-data:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:5563:5563/tcp
-    - 127.0.0.1:59880:59880/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 5563
+      published: "5563"
+      protocol: tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59880
+      published: "59880"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
@@ -330,25 +407,42 @@ services:
     hostname: edgex-redis
     image: redis:7.0-alpine
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:6379:6379/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 6379
+      published: "6379"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: root:root
     volumes:
-    - db-data:/data:z
+    - type: volume
+      source: db-data
+      target: /data
+      bind:
+        selinux: z
+      volume: {}
   device-modbus:
-    command: -cp=consul.http://edgex-core-consul:8500 --registry --configDir=CONFIG_DIR_PLACE_HOLDER
+    command:
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
+    - --configDir=CONFIG_DIR_PLACE_HOLDER
     container_name: edgex-device-modbus
     depends_on:
-    - consul
-    - data
-    - metadata
-    - modbus-simulator
-    - mqtt-broker
+      consul:
+        condition: service_started
+      data:
+        condition: service_started
+      metadata:
+        condition: service_started
+      modbus-simulator:
+        condition: service_started
+      mqtt-broker:
+        condition: service_started
     environment:
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
@@ -359,7 +453,7 @@ services:
       EDGEX_SECURITY_SECRET_STORE: "false"
       MESSAGEBUS_AUTHMODE: none
       MESSAGEBUS_HOST: edgex-mqtt-broker
-      MESSAGEBUS_PORT: '1883'
+      MESSAGEBUS_PORT: "1883"
       MESSAGEBUS_PROTOCOL: tcp
       MESSAGEBUS_TYPE: mqtt
       REGISTRY_HOST: edgex-core-consul
@@ -367,23 +461,36 @@ services:
     hostname: edgex-device-modbus
     image: nexus3.edgexfoundry.org:10004/device-modbus:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59901:59901/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59901
+      published: "59901"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
     volumes:
-    - PROFILE_VOLUME_PLACE_HOLDER:CONFIG_DIR_PLACE_HOLDER:z
+    - type: bind
+      source: /PROFILE_VOLUME_PLACE_HOLDER
+      target: CONFIG_DIR_PLACE_HOLDER
+      bind:
+        selinux: z
+        create_host_path: true
   device-onvif-camera:
     container_name: edgex-device-onvif-camera
     depends_on:
-    - consul
-    - data
-    - metadata
-    - mqtt-broker
+      consul:
+        condition: service_started
+      data:
+        condition: service_started
+      metadata:
+        condition: service_started
+      mqtt-broker:
+        condition: service_started
     environment:
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
@@ -394,7 +501,7 @@ services:
       EDGEX_SECURITY_SECRET_STORE: "false"
       MESSAGEBUS_AUTHMODE: none
       MESSAGEBUS_HOST: edgex-mqtt-broker
-      MESSAGEBUS_PORT: '1883'
+      MESSAGEBUS_PORT: "1883"
       MESSAGEBUS_PROTOCOL: tcp
       MESSAGEBUS_TYPE: mqtt
       REGISTRY_HOST: edgex-core-consul
@@ -402,9 +509,13 @@ services:
     hostname: edgex-device-onvif-camera
     image: nexus3.edgexfoundry.org:10004/device-onvif-camera:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59984:59984/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59984
+      published: "59984"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
@@ -413,10 +524,14 @@ services:
   device-rest:
     container_name: edgex-device-rest
     depends_on:
-    - consul
-    - data
-    - metadata
-    - mqtt-broker
+      consul:
+        condition: service_started
+      data:
+        condition: service_started
+      metadata:
+        condition: service_started
+      mqtt-broker:
+        condition: service_started
     environment:
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
@@ -427,7 +542,7 @@ services:
       EDGEX_SECURITY_SECRET_STORE: "false"
       MESSAGEBUS_AUTHMODE: none
       MESSAGEBUS_HOST: edgex-mqtt-broker
-      MESSAGEBUS_PORT: '1883'
+      MESSAGEBUS_PORT: "1883"
       MESSAGEBUS_PROTOCOL: tcp
       MESSAGEBUS_TYPE: mqtt
       REGISTRY_HOST: edgex-core-consul
@@ -435,22 +550,33 @@ services:
     hostname: edgex-device-rest
     image: nexus3.edgexfoundry.org:10004/device-rest:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59986:59986/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59986
+      published: "59986"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
   device-virtual:
-    command: -cp=consul.http://edgex-core-consul:8500 --registry --configDir=CONFIG_DIR_PLACE_HOLDER
+    command:
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
+    - --configDir=CONFIG_DIR_PLACE_HOLDER
     container_name: edgex-device-virtual
     depends_on:
-    - consul
-    - data
-    - metadata
-    - mqtt-broker
+      consul:
+        condition: service_started
+      data:
+        condition: service_started
+      metadata:
+        condition: service_started
+      mqtt-broker:
+        condition: service_started
     environment:
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
@@ -461,7 +587,7 @@ services:
       EDGEX_SECURITY_SECRET_STORE: "false"
       MESSAGEBUS_AUTHMODE: none
       MESSAGEBUS_HOST: edgex-mqtt-broker
-      MESSAGEBUS_PORT: '1883'
+      MESSAGEBUS_PORT: "1883"
       MESSAGEBUS_PROTOCOL: tcp
       MESSAGEBUS_TYPE: mqtt
       REGISTRY_HOST: edgex-core-consul
@@ -469,23 +595,36 @@ services:
     hostname: edgex-device-virtual
     image: nexus3.edgexfoundry.org:10004/device-virtual:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59900:59900/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59900
+      published: "59900"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
     volumes:
-    - PROFILE_VOLUME_PLACE_HOLDER:CONFIG_DIR_PLACE_HOLDER:z
+    - type: bind
+      source: /PROFILE_VOLUME_PLACE_HOLDER
+      target: CONFIG_DIR_PLACE_HOLDER
+      bind:
+        selinux: z
+        create_host_path: true
   metadata:
     container_name: edgex-core-metadata
     depends_on:
-    - consul
-    - database
-    - mqtt-broker
-    - notifications
+      consul:
+        condition: service_started
+      database:
+        condition: service_started
+      mqtt-broker:
+        condition: service_started
+      notifications:
+        condition: service_started
     environment:
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
@@ -497,7 +636,7 @@ services:
       MESSAGEBUS_AUTHMODE: none
       MESSAGEBUS_HOST: edgex-mqtt-broker
       MESSAGEBUS_OPTIONAL_CLIENTID: core-metadata
-      MESSAGEBUS_PORT: '1883'
+      MESSAGEBUS_PORT: "1883"
       MESSAGEBUS_PROTOCOL: tcp
       MESSAGEBUS_TYPE: mqtt
       NOTIFICATIONS_SENDER: edgex-core-metadata
@@ -506,9 +645,13 @@ services:
     hostname: edgex-core-metadata
     image: nexus3.edgexfoundry.org:10004/core-metadata:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59881:59881/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59881
+      published: "59881"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
@@ -519,37 +662,56 @@ services:
     hostname: edgex-modbus-simulator
     image: nexus3.edgexfoundry.org:10003/edgex-devops/edgex-modbus-simulator:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:1502:1502/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 1502
+      published: "1502"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
   mqtt-broker:
-    command: /usr/sbin/mosquitto -c /mosquitto-no-auth.conf
+    command:
+    - /usr/sbin/mosquitto
+    - -c
+    - /mosquitto-no-auth.conf
+    - -v
     container_name: edgex-mqtt-broker
     hostname: edgex-mqtt-broker
     image: eclipse-mosquitto:2.0
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:1883:1883/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 1883
+      published: "1883"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
   mqtt-taf-broker:
-    command: /usr/sbin/mosquitto -c /mosquitto-no-auth.conf
+    command:
+    - /usr/sbin/mosquitto
+    - -c
+    - /mosquitto-no-auth.conf
     container_name: edgex-taf-mqtt-broker
     hostname: edgex-taf-mqtt-broker
     image: eclipse-mosquitto:2.0
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:1884:1883/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 1883
+      published: "1884"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
@@ -558,9 +720,12 @@ services:
   notifications:
     container_name: edgex-support-notifications
     depends_on:
-    - consul
-    - database
-    - mqtt-broker
+      consul:
+        condition: service_started
+      database:
+        condition: service_started
+      mqtt-broker:
+        condition: service_started
     environment:
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
@@ -572,7 +737,7 @@ services:
       MESSAGEBUS_AUTHMODE: none
       MESSAGEBUS_HOST: edgex-mqtt-broker
       MESSAGEBUS_OPTIONAL_CLIENTID: support-notifications
-      MESSAGEBUS_PORT: '1883'
+      MESSAGEBUS_PORT: "1883"
       MESSAGEBUS_PROTOCOL: tcp
       MESSAGEBUS_TYPE: mqtt
       REGISTRY_HOST: edgex-core-consul
@@ -580,9 +745,13 @@ services:
     hostname: edgex-support-notifications
     image: nexus3.edgexfoundry.org:10004/support-notifications:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59860:59860/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59860
+      published: "59860"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
@@ -591,62 +760,76 @@ services:
   rulesengine:
     container_name: edgex-kuiper
     depends_on:
-    - database
-    - mqtt-broker
+      database:
+        condition: service_started
+      mqtt-broker:
+        condition: service_started
     environment:
       CONNECTION__EDGEX__MQTTMSGBUS__OPTIONAL__CLIENTID: kuiper-rules-engine
-      CONNECTION__EDGEX__MQTTMSGBUS__OPTIONAL__KEEPALIVE: 500
-      CONNECTION__EDGEX__MQTTMSGBUS__PORT: 1883
+      CONNECTION__EDGEX__MQTTMSGBUS__OPTIONAL__KEEPALIVE: "500"
+      CONNECTION__EDGEX__MQTTMSGBUS__PORT: "1883"
       CONNECTION__EDGEX__MQTTMSGBUS__PROTOCOL: tcp
       CONNECTION__EDGEX__MQTTMSGBUS__SERVER: edgex-mqtt-broker
       CONNECTION__EDGEX__MQTTMSGBUS__TYPE: mqtt
-      CONNECTION__EDGEX__REDISMSGBUS__PORT: 6379
+      CONNECTION__EDGEX__REDISMSGBUS__PORT: "6379"
       CONNECTION__EDGEX__REDISMSGBUS__PROTOCOL: redis
       CONNECTION__EDGEX__REDISMSGBUS__SERVER: edgex-redis
       CONNECTION__EDGEX__REDISMSGBUS__TYPE: redis
       EDGEX__DEFAULT__OPTIONAL__CLIENTID: kuiper-rules-engine
-      EDGEX__DEFAULT__OPTIONAL__KEEPALIVE: 500
-      EDGEX__DEFAULT__PORT: 1883
+      EDGEX__DEFAULT__OPTIONAL__KEEPALIVE: "500"
+      EDGEX__DEFAULT__PORT: "1883"
       EDGEX__DEFAULT__PROTOCOL: tcp
       EDGEX__DEFAULT__SERVER: edgex-mqtt-broker
       EDGEX__DEFAULT__TOPIC: rules-events
       EDGEX__DEFAULT__TYPE: mqtt
       KUIPER__BASIC__CONSOLELOG: "true"
-      KUIPER__BASIC__RESTPORT: 59720
+      KUIPER__BASIC__RESTPORT: "59720"
     hostname: edgex-kuiper
     image: lfedge/ekuiper:1.7-alpine
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59720:59720/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59720
+      published: "59720"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: kuiper:kuiper
     volumes:
-    - kuiper-data:/kuiper/data:z
+    - type: volume
+      source: kuiper-data
+      target: /kuiper/data
+      bind:
+        selinux: z
+      volume: {}
   scalability-test-mqtt-export:
     container_name: edgex-scalability-test-mqtt-export
     depends_on:
-    - consul
-    - data
-    - mqtt-broker
+      consul:
+        condition: service_started
+      data:
+        condition: service_started
+      mqtt-broker:
+        condition: service_started
     environment:
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
       CLIENTS_SUPPORT_NOTIFICATIONS_HOST: edgex-support-notifications
       CLIENTS_SUPPORT_SCHEDULER_HOST: edgex-support-scheduler
-      DATABASES_PRIMARY_HOST: edgex-redis
       DATABASE_HOST: edgex-redis
+      DATABASES_PRIMARY_HOST: edgex-redis
       EDGEX_PROFILE: mqtt-export
       EDGEX_SECURITY_SECRET_STORE: "false"
       EDGEX_SERVICE_KEY: app-scalability-test-mqtt-export
       MESSAGEBUS_AUTHMODE: none
       MESSAGEBUS_HOST: edgex-mqtt-broker
       MESSAGEBUS_OPTIONAL_CLIENTID: app-scalability-test-mqtt-export
-      MESSAGEBUS_PORT: '1883'
+      MESSAGEBUS_PORT: "1883"
       MESSAGEBUS_PROTOCOL: tcp
       MESSAGEBUS_TYPE: mqtt
       REGISTRY_HOST: edgex-core-consul
@@ -658,9 +841,12 @@ services:
     hostname: edgex-scalability-test-mqtt-export
     image: nexus3.edgexfoundry.org:10004/app-service-configurable:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 59710:59703/tcp
+    - mode: ingress
+      target: 59703
+      published: "59710"
+      protocol: tcp
     read_only: true
     security_opt:
     - no-new-privileges:true
@@ -668,9 +854,12 @@ services:
   scheduler:
     container_name: edgex-support-scheduler
     depends_on:
-    - consul
-    - database
-    - mqtt-broker
+      consul:
+        condition: service_started
+      database:
+        condition: service_started
+      mqtt-broker:
+        condition: service_started
     environment:
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
@@ -684,7 +873,7 @@ services:
       MESSAGEBUS_AUTHMODE: none
       MESSAGEBUS_HOST: edgex-mqtt-broker
       MESSAGEBUS_OPTIONAL_CLIENTID: support-scheduler
-      MESSAGEBUS_PORT: '1883'
+      MESSAGEBUS_PORT: "1883"
       MESSAGEBUS_PROTOCOL: tcp
       MESSAGEBUS_TYPE: mqtt
       REGISTRY_HOST: edgex-core-consul
@@ -692,9 +881,13 @@ services:
     hostname: edgex-support-scheduler
     image: nexus3.edgexfoundry.org:10004/support-scheduler:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59861:59861/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59861
+      published: "59861"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
@@ -708,19 +901,27 @@ services:
     hostname: edgex-ui-go
     image: nexus3.edgexfoundry.org:10004/edgex-ui:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 4000:4000/tcp
+    - mode: ingress
+      target: 4000
+      published: "4000"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
-version: '3.7'
+networks:
+  edgex-network:
+    name: edgex_edgex-network
+    driver: bridge
 volumes:
-  PROFILE_VOLUME_PLACE_HOLDER: {}
-  consul-config: {}
-  consul-data: {}
-  db-data: {}
-  kuiper-data: {}
-
+  consul-config:
+    name: edgex_consul-config
+  consul-data:
+    name: edgex_consul-data
+  db-data:
+    name: edgex_db-data
+  kuiper-data:
+    name: edgex_kuiper-data

--- a/taf/docker-compose-taf-no-secty.yml
+++ b/taf/docker-compose-taf-no-secty.yml
@@ -24,23 +24,23 @@
 #
 # From the compose-builder folder use `make build` to regenerate all standard compose files variations
 #
-networks:
-  edgex-network:
-    driver: bridge
+name: edgex
 services:
   app-service-external-mqtt-trigger:
     container_name: edgex-app-external-mqtt-trigger
     depends_on:
-    - consul
-    - data
+      consul:
+        condition: service_started
+      data:
+        condition: service_started
     environment:
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
       CLIENTS_SUPPORT_NOTIFICATIONS_HOST: edgex-support-notifications
       CLIENTS_SUPPORT_SCHEDULER_HOST: edgex-support-scheduler
-      DATABASES_PRIMARY_HOST: edgex-redis
       DATABASE_HOST: edgex-redis
+      DATABASES_PRIMARY_HOST: edgex-redis
       EDGEX_PROFILE: external-mqtt-trigger
       EDGEX_SECURITY_SECRET_STORE: "false"
       MESSAGEBUS_HOST: edgex-redis
@@ -53,9 +53,13 @@ services:
     hostname: edgex-app-external-mqtt-trigger
     image: nexus3.edgexfoundry.org:10004/app-service-configurable:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59706:59706/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59706
+      published: "59706"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
@@ -64,16 +68,18 @@ services:
   app-service-functional-tests:
     container_name: app-functional-tests
     depends_on:
-    - consul
-    - data
+      consul:
+        condition: service_started
+      data:
+        condition: service_started
     environment:
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
       CLIENTS_SUPPORT_NOTIFICATIONS_HOST: edgex-support-notifications
       CLIENTS_SUPPORT_SCHEDULER_HOST: edgex-support-scheduler
-      DATABASES_PRIMARY_HOST: edgex-redis
       DATABASE_HOST: edgex-redis
+      DATABASES_PRIMARY_HOST: edgex-redis
       EDGEX_PROFILE: functional-tests
       EDGEX_SECURITY_SECRET_STORE: "false"
       MESSAGEBUS_HOST: edgex-redis
@@ -82,9 +88,12 @@ services:
     hostname: app-functional-tests
     image: nexus3.edgexfoundry.org:10004/app-service-configurable:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 59705:59705/tcp
+    - mode: ingress
+      target: 59705
+      published: "59705"
+      protocol: tcp
     read_only: true
     security_opt:
     - no-new-privileges:true
@@ -92,16 +101,18 @@ services:
   app-service-http-export:
     container_name: edgex-app-http-export
     depends_on:
-    - consul
-    - data
+      consul:
+        condition: service_started
+      data:
+        condition: service_started
     environment:
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
       CLIENTS_SUPPORT_NOTIFICATIONS_HOST: edgex-support-notifications
       CLIENTS_SUPPORT_SCHEDULER_HOST: edgex-support-scheduler
-      DATABASES_PRIMARY_HOST: edgex-redis
       DATABASE_HOST: edgex-redis
+      DATABASES_PRIMARY_HOST: edgex-redis
       EDGEX_PROFILE: http-export
       EDGEX_SECURITY_SECRET_STORE: "false"
       MESSAGEBUS_HOST: edgex-redis
@@ -112,9 +123,13 @@ services:
     hostname: edgex-app-http-export
     image: nexus3.edgexfoundry.org:10004/app-service-configurable:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59704:59704/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59704
+      published: "59704"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
@@ -123,16 +138,18 @@ services:
   app-service-mqtt-export:
     container_name: edgex-app-mqtt-export
     depends_on:
-    - consul
-    - data
+      consul:
+        condition: service_started
+      data:
+        condition: service_started
     environment:
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
       CLIENTS_SUPPORT_NOTIFICATIONS_HOST: edgex-support-notifications
       CLIENTS_SUPPORT_SCHEDULER_HOST: edgex-support-scheduler
-      DATABASES_PRIMARY_HOST: edgex-redis
       DATABASE_HOST: edgex-redis
+      DATABASES_PRIMARY_HOST: edgex-redis
       EDGEX_PROFILE: mqtt-export
       EDGEX_SECURITY_SECRET_STORE: "false"
       MESSAGEBUS_HOST: edgex-redis
@@ -144,9 +161,13 @@ services:
     hostname: edgex-app-mqtt-export
     image: nexus3.edgexfoundry.org:10004/app-service-configurable:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59703:59703/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59703
+      published: "59703"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
@@ -155,8 +176,10 @@ services:
   app-service-rules:
     container_name: edgex-app-rules-engine
     depends_on:
-    - consul
-    - data
+      consul:
+        condition: service_started
+      data:
+        condition: service_started
     environment:
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
@@ -172,9 +195,13 @@ services:
     hostname: edgex-app-rules-engine
     image: nexus3.edgexfoundry.org:10004/app-service-configurable:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59701:59701/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59701
+      published: "59701"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
@@ -183,16 +210,18 @@ services:
   app-service-sample:
     container_name: edgex-app-sample
     depends_on:
-    - consul
-    - data
+      consul:
+        condition: service_started
+      data:
+        condition: service_started
     environment:
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
       CLIENTS_SUPPORT_NOTIFICATIONS_HOST: edgex-support-notifications
       CLIENTS_SUPPORT_SCHEDULER_HOST: edgex-support-scheduler
-      DATABASES_PRIMARY_HOST: edgex-redis
       DATABASE_HOST: edgex-redis
+      DATABASES_PRIMARY_HOST: edgex-redis
       EDGEX_PROFILE: sample
       EDGEX_SECURITY_SECRET_STORE: "false"
       MESSAGEBUS_HOST: edgex-redis
@@ -201,9 +230,13 @@ services:
     hostname: edgex-app-sample
     image: nexus3.edgexfoundry.org:10004/app-service-configurable:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59700:59700/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59700
+      published: "59700"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
@@ -212,9 +245,12 @@ services:
   command:
     container_name: edgex-core-command
     depends_on:
-    - consul
-    - database
-    - metadata
+      consul:
+        condition: service_started
+      database:
+        condition: service_started
+      metadata:
+        condition: service_started
     environment:
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
@@ -230,37 +266,64 @@ services:
     hostname: edgex-core-command
     image: nexus3.edgexfoundry.org:10004/core-command:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59882:59882/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59882
+      published: "59882"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
   consul:
-    command: agent -ui -bootstrap -server -client 0.0.0.0
+    command:
+    - agent
+    - -ui
+    - -bootstrap
+    - -server
+    - -client
+    - 0.0.0.0
     container_name: edgex-core-consul
     hostname: edgex-core-consul
     image: consul:1.13
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:8500:8500/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 8500
+      published: "8500"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: root:root
     volumes:
-    - consul-config:/consul/config:z
-    - consul-data:/consul/data:z
+    - type: volume
+      source: consul-config
+      target: /consul/config
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: consul-data
+      target: /consul/data
+      bind:
+        selinux: z
+      volume: {}
   data:
     container_name: edgex-core-data
     depends_on:
-    - consul
-    - database
-    - metadata
+      consul:
+        condition: service_started
+      database:
+        condition: service_started
+      metadata:
+        condition: service_started
     environment:
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
@@ -275,10 +338,18 @@ services:
     hostname: edgex-core-data
     image: nexus3.edgexfoundry.org:10004/core-data:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:5563:5563/tcp
-    - 127.0.0.1:59880:59880/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59880
+      published: "59880"
+      protocol: tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 5563
+      published: "5563"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
@@ -298,24 +369,40 @@ services:
     hostname: edgex-redis
     image: redis:7.0-alpine
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:6379:6379/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 6379
+      published: "6379"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: root:root
     volumes:
-    - db-data:/data:z
+    - type: volume
+      source: db-data
+      target: /data
+      bind:
+        selinux: z
+      volume: {}
   device-modbus:
-    command: -cp=consul.http://edgex-core-consul:8500 --registry --configDir=CONFIG_DIR_PLACE_HOLDER
+    command:
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
+    - --configDir=CONFIG_DIR_PLACE_HOLDER
     container_name: edgex-device-modbus
     depends_on:
-    - consul
-    - data
-    - metadata
-    - modbus-simulator
+      consul:
+        condition: service_started
+      data:
+        condition: service_started
+      metadata:
+        condition: service_started
+      modbus-simulator:
+        condition: service_started
     environment:
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
@@ -330,22 +417,34 @@ services:
     hostname: edgex-device-modbus
     image: nexus3.edgexfoundry.org:10004/device-modbus:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59901:59901/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59901
+      published: "59901"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
     volumes:
-    - PROFILE_VOLUME_PLACE_HOLDER:CONFIG_DIR_PLACE_HOLDER:z
+    - type: bind
+      source: /PROFILE_VOLUME_PLACE_HOLDER
+      target: CONFIG_DIR_PLACE_HOLDER
+      bind:
+        selinux: z
+        create_host_path: true
   device-onvif-camera:
     container_name: edgex-device-onvif-camera
     depends_on:
-    - consul
-    - data
-    - metadata
+      consul:
+        condition: service_started
+      data:
+        condition: service_started
+      metadata:
+        condition: service_started
     environment:
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
@@ -360,9 +459,13 @@ services:
     hostname: edgex-device-onvif-camera
     image: nexus3.edgexfoundry.org:10004/device-onvif-camera:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59984:59984/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59984
+      published: "59984"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
@@ -371,9 +474,12 @@ services:
   device-rest:
     container_name: edgex-device-rest
     depends_on:
-    - consul
-    - data
-    - metadata
+      consul:
+        condition: service_started
+      data:
+        condition: service_started
+      metadata:
+        condition: service_started
     environment:
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
@@ -388,21 +494,31 @@ services:
     hostname: edgex-device-rest
     image: nexus3.edgexfoundry.org:10004/device-rest:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59986:59986/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59986
+      published: "59986"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
   device-virtual:
-    command: -cp=consul.http://edgex-core-consul:8500 --registry --configDir=CONFIG_DIR_PLACE_HOLDER
+    command:
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
+    - --configDir=CONFIG_DIR_PLACE_HOLDER
     container_name: edgex-device-virtual
     depends_on:
-    - consul
-    - data
-    - metadata
+      consul:
+        condition: service_started
+      data:
+        condition: service_started
+      metadata:
+        condition: service_started
     environment:
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
@@ -417,22 +533,34 @@ services:
     hostname: edgex-device-virtual
     image: nexus3.edgexfoundry.org:10004/device-virtual:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59900:59900/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59900
+      published: "59900"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
     volumes:
-    - PROFILE_VOLUME_PLACE_HOLDER:CONFIG_DIR_PLACE_HOLDER:z
+    - type: bind
+      source: /PROFILE_VOLUME_PLACE_HOLDER
+      target: CONFIG_DIR_PLACE_HOLDER
+      bind:
+        selinux: z
+        create_host_path: true
   metadata:
     container_name: edgex-core-metadata
     depends_on:
-    - consul
-    - database
-    - notifications
+      consul:
+        condition: service_started
+      database:
+        condition: service_started
+      notifications:
+        condition: service_started
     environment:
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
@@ -448,9 +576,13 @@ services:
     hostname: edgex-core-metadata
     image: nexus3.edgexfoundry.org:10004/core-metadata:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59881:59881/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59881
+      published: "59881"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
@@ -461,37 +593,56 @@ services:
     hostname: edgex-modbus-simulator
     image: nexus3.edgexfoundry.org:10003/edgex-devops/edgex-modbus-simulator:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:1502:1502/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 1502
+      published: "1502"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
   mqtt-broker:
-    command: /usr/sbin/mosquitto -c /mosquitto-no-auth.conf
+    command:
+    - /usr/sbin/mosquitto
+    - -c
+    - /mosquitto-no-auth.conf
+    - -v
     container_name: edgex-mqtt-broker
     hostname: edgex-mqtt-broker
     image: eclipse-mosquitto:2.0
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:1883:1883/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 1883
+      published: "1883"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
   mqtt-taf-broker:
-    command: /usr/sbin/mosquitto -c /mosquitto-no-auth.conf
+    command:
+    - /usr/sbin/mosquitto
+    - -c
+    - /mosquitto-no-auth.conf
     container_name: edgex-taf-mqtt-broker
     hostname: edgex-taf-mqtt-broker
     image: eclipse-mosquitto:2.0
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:1884:1883/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 1883
+      published: "1884"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
@@ -500,8 +651,10 @@ services:
   notifications:
     container_name: edgex-support-notifications
     depends_on:
-    - consul
-    - database
+      consul:
+        condition: service_started
+      database:
+        condition: service_started
     environment:
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
@@ -516,9 +669,13 @@ services:
     hostname: edgex-support-notifications
     image: nexus3.edgexfoundry.org:10004/support-notifications:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59860:59860/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59860
+      published: "59860"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
@@ -527,45 +684,57 @@ services:
   rulesengine:
     container_name: edgex-kuiper
     depends_on:
-    - database
+      database:
+        condition: service_started
     environment:
-      CONNECTION__EDGEX__REDISMSGBUS__PORT: 6379
+      CONNECTION__EDGEX__REDISMSGBUS__PORT: "6379"
       CONNECTION__EDGEX__REDISMSGBUS__PROTOCOL: redis
       CONNECTION__EDGEX__REDISMSGBUS__SERVER: edgex-redis
       CONNECTION__EDGEX__REDISMSGBUS__TYPE: redis
-      EDGEX__DEFAULT__PORT: 6379
+      EDGEX__DEFAULT__PORT: "6379"
       EDGEX__DEFAULT__PROTOCOL: redis
       EDGEX__DEFAULT__SERVER: edgex-redis
       EDGEX__DEFAULT__TOPIC: rules-events
       EDGEX__DEFAULT__TYPE: redis
       KUIPER__BASIC__CONSOLELOG: "true"
-      KUIPER__BASIC__RESTPORT: 59720
+      KUIPER__BASIC__RESTPORT: "59720"
     hostname: edgex-kuiper
     image: lfedge/ekuiper:1.7-alpine
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59720:59720/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59720
+      published: "59720"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: kuiper:kuiper
     volumes:
-    - kuiper-data:/kuiper/data:z
+    - type: volume
+      source: kuiper-data
+      target: /kuiper/data
+      bind:
+        selinux: z
+      volume: {}
   scalability-test-mqtt-export:
     container_name: edgex-scalability-test-mqtt-export
     depends_on:
-    - consul
-    - data
+      consul:
+        condition: service_started
+      data:
+        condition: service_started
     environment:
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
       CLIENTS_SUPPORT_NOTIFICATIONS_HOST: edgex-support-notifications
       CLIENTS_SUPPORT_SCHEDULER_HOST: edgex-support-scheduler
-      DATABASES_PRIMARY_HOST: edgex-redis
       DATABASE_HOST: edgex-redis
+      DATABASES_PRIMARY_HOST: edgex-redis
       EDGEX_PROFILE: mqtt-export
       EDGEX_SECURITY_SECRET_STORE: "false"
       EDGEX_SERVICE_KEY: app-scalability-test-mqtt-export
@@ -580,9 +749,12 @@ services:
     hostname: edgex-scalability-test-mqtt-export
     image: nexus3.edgexfoundry.org:10004/app-service-configurable:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 59710:59703/tcp
+    - mode: ingress
+      target: 59703
+      published: "59710"
+      protocol: tcp
     read_only: true
     security_opt:
     - no-new-privileges:true
@@ -590,8 +762,10 @@ services:
   scheduler:
     container_name: edgex-support-scheduler
     depends_on:
-    - consul
-    - database
+      consul:
+        condition: service_started
+      database:
+        condition: service_started
     environment:
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
@@ -608,9 +782,13 @@ services:
     hostname: edgex-support-scheduler
     image: nexus3.edgexfoundry.org:10004/support-scheduler:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59861:59861/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59861
+      published: "59861"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
@@ -624,19 +802,27 @@ services:
     hostname: edgex-ui-go
     image: nexus3.edgexfoundry.org:10004/edgex-ui:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 4000:4000/tcp
+    - mode: ingress
+      target: 4000
+      published: "4000"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
-version: '3.7'
+networks:
+  edgex-network:
+    name: edgex_edgex-network
+    driver: bridge
 volumes:
-  PROFILE_VOLUME_PLACE_HOLDER: {}
-  consul-config: {}
-  consul-data: {}
-  db-data: {}
-  kuiper-data: {}
-
+  consul-config:
+    name: edgex_consul-config
+  consul-data:
+    name: edgex_consul-data
+  db-data:
+    name: edgex_db-data
+  kuiper-data:
+    name: edgex_kuiper-data

--- a/taf/docker-compose-taf-no-secty.yml
+++ b/taf/docker-compose-taf-no-secty.yml
@@ -610,7 +610,6 @@ services:
     - /usr/sbin/mosquitto
     - -c
     - /mosquitto-no-auth.conf
-    - -v
     container_name: edgex-mqtt-broker
     hostname: edgex-mqtt-broker
     image: eclipse-mosquitto:2.0

--- a/taf/docker-compose-taf-perf-arm64.yml
+++ b/taf/docker-compose-taf-perf-arm64.yml
@@ -965,7 +965,6 @@ services:
     - /usr/sbin/mosquitto
     - -c
     - /mosquitto-no-auth.conf
-    - -v
     container_name: edgex-mqtt-broker
     hostname: edgex-mqtt-broker
     image: eclipse-mosquitto:2.0

--- a/taf/docker-compose-taf-perf-arm64.yml
+++ b/taf/docker-compose-taf-perf-arm64.yml
@@ -24,54 +24,58 @@
 #
 # From the compose-builder folder use `make build` to regenerate all standard compose files variations
 #
-networks:
-  edgex-network:
-    driver: bridge
+name: edgex
 services:
   app-service-mqtt-export:
-    command: /app-service-configurable -cp=consul.http://edgex-core-consul:8500 --registry
+    command:
+    - /app-service-configurable
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
     container_name: edgex-app-mqtt-export
     depends_on:
-    - consul
-    - data
-    - security-bootstrapper
+      consul:
+        condition: service_started
+      data:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/ready_to_run_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
       CLIENTS_SUPPORT_NOTIFICATIONS_HOST: edgex-support-notifications
       CLIENTS_SUPPORT_SCHEDULER_HOST: edgex-support-scheduler
-      DATABASES_PRIMARY_HOST: edgex-redis
       DATABASE_HOST: edgex-redis
+      DATABASES_PRIMARY_HOST: edgex-redis
       EDGEX_PROFILE: mqtt-export
       EDGEX_SECURITY_SECRET_STORE: "true"
       MESSAGEBUS_HOST: edgex-redis
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SERVICE_HOST: edgex-app-mqtt-export
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
       WRITABLE_LOGLEVEL: INFO
       WRITABLE_PIPELINE_FUNCTIONS_MQTTEXPORT_PARAMETERS_BROKERADDRESS: MQTT_BROKER_ADDRESS_PLACE_HOLDER
@@ -79,29 +83,51 @@ services:
     hostname: edgex-app-mqtt-export
     image: nexus3.edgexfoundry.org:10004/app-service-configurable-arm64:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59703:59703/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59703
+      published: "59703"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - /tmp/edgex/secrets/app-mqtt-export:/tmp/edgex/secrets/app-mqtt-export:ro,z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/app-mqtt-export
+      target: /tmp/edgex/secrets/app-mqtt-export
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   app-service-rules:
-    command: /app-service-configurable -cp=consul.http://edgex-core-consul:8500 --registry
+    command:
+    - /app-service-configurable
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
     container_name: edgex-app-rules-engine
     depends_on:
-    - consul
-    - data
-    - security-bootstrapper
+      consul:
+        condition: service_started
+      data:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/ready_to_run_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
@@ -114,54 +140,78 @@ services:
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SERVICE_HOST: edgex-app-rules-engine
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-app-rules-engine
     image: nexus3.edgexfoundry.org:10004/app-service-configurable-arm64:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59701:59701/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59701
+      published: "59701"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - /tmp/edgex/secrets/app-rules-engine:/tmp/edgex/secrets/app-rules-engine:ro,z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/app-rules-engine
+      target: /tmp/edgex/secrets/app-rules-engine
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   command:
-    command: /core-command -cp=consul.http://edgex-core-consul:8500 --registry
+    command:
+    - /core-command
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
     container_name: edgex-core-command
     depends_on:
-    - consul
-    - database
-    - metadata
-    - secretstore-setup
-    - security-bootstrapper
+      consul:
+        condition: service_started
+      database:
+        condition: service_started
+      metadata:
+        condition: service_started
+      secretstore-setup:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/ready_to_run_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
@@ -174,110 +224,173 @@ services:
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SERVICE_HOST: edgex-core-command
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-core-command
     image: nexus3.edgexfoundry.org:10004/core-command-arm64:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59882:59882/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59882
+      published: "59882"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - /tmp/edgex/secrets/core-command:/tmp/edgex/secrets/core-command:ro,z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/core-command
+      target: /tmp/edgex/secrets/core-command
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   consul:
-    command: agent -ui -bootstrap -server -client 0.0.0.0
+    command:
+    - agent
+    - -ui
+    - -bootstrap
+    - -server
+    - -client
+    - 0.0.0.0
     container_name: edgex-core-consul
     depends_on:
-    - security-bootstrapper
-    - vault
+      security-bootstrapper:
+        condition: service_started
+      vault:
+        condition: service_started
     entrypoint:
     - /edgex-init/consul_wait_install.sh
     environment:
       ADD_REGISTRY_ACL_ROLES: app-http-export,app-mqtt-export,app-functional-tests,app-scalability-test-mqtt-export
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
-      EDGEX_GROUP: '2001'
+      API_GATEWAY_STATUS_PORT: "8100"
+      EDGEX_GROUP: "2001"
       EDGEX_SECURITY_SECRET_STORE: "true"
-      EDGEX_USER: '2002'
+      EDGEX_USER: "2002"
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_ACL_BOOTSTRAPTOKENPATH: /tmp/edgex/secrets/consul-acl-token/bootstrap_token.json
       STAGEGATE_REGISTRY_ACL_MANAGEMENTTOKENPATH: /tmp/edgex/secrets/consul-acl-token/mgmt_token.json
       STAGEGATE_REGISTRY_ACL_SENTINELFILEPATH: /consul/config/consul_acl_done
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-core-consul
     image: consul:1.13
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:8500:8500/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 8500
+      published: "8500"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: root:root
     volumes:
-    - consul-config:/consul/config:z
-    - consul-data:/consul/data:z
-    - edgex-init:/edgex-init:ro,z
-    - consul-acl-token:/tmp/edgex/secrets/consul-acl-token:z
-    - /tmp/edgex/secrets/edgex-consul:/tmp/edgex/secrets/edgex-consul:ro,z
+    - type: volume
+      source: consul-config
+      target: /consul/config
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: consul-data
+      target: /consul/data
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: consul-acl-token
+      target: /tmp/edgex/secrets/consul-acl-token
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/edgex-consul
+      target: /tmp/edgex/secrets/edgex-consul
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   data:
-    command: /core-data -cp=consul.http://edgex-core-consul:8500 --registry
+    command:
+    - /core-data
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
     container_name: edgex-core-data
     depends_on:
-    - consul
-    - database
-    - metadata
-    - secretstore-setup
-    - security-bootstrapper
+      consul:
+        condition: service_started
+      database:
+        condition: service_started
+      metadata:
+        condition: service_started
+      secretstore-setup:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/ready_to_run_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
@@ -289,52 +402,74 @@ services:
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SECRETSTORE_TOKENFILE: /tmp/edgex/secrets/core-data/secrets-token.json
       SERVICE_HOST: edgex-core-data
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-core-data
     image: nexus3.edgexfoundry.org:10004/core-data-arm64:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:5563:5563/tcp
-    - 127.0.0.1:59880:59880/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 5563
+      published: "5563"
+      protocol: tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59880
+      published: "59880"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - /tmp/edgex/secrets/core-data:/tmp/edgex/secrets/core-data:ro,z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/core-data
+      target: /tmp/edgex/secrets/core-data
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   database:
     container_name: edgex-redis
     depends_on:
-    - secretstore-setup
-    - security-bootstrapper
+      secretstore-setup:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/redis_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
@@ -347,31 +482,35 @@ services:
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-redis
     image: redis:7.0-alpine
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:6379:6379/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 6379
+      published: "6379"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
@@ -380,23 +519,52 @@ services:
     - /run
     user: root:root
     volumes:
-    - db-data:/data:z
-    - edgex-init:/edgex-init:ro,z
-    - redis-config:/run/redis/conf:z
-    - /tmp/edgex/secrets/security-bootstrapper-redis:/tmp/edgex/secrets/security-bootstrapper-redis:ro,z
+    - type: volume
+      source: db-data
+      target: /data
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: redis-config
+      target: /run/redis/conf
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/security-bootstrapper-redis
+      target: /tmp/edgex/secrets/security-bootstrapper-redis
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   device-rest:
-    command: /device-rest -cp=consul.http://edgex-core-consul:8500 --registry
+    command:
+    - /device-rest
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
     container_name: edgex-device-rest
     depends_on:
-    - consul
-    - data
-    - metadata
-    - security-bootstrapper
+      consul:
+        condition: service_started
+      data:
+        condition: service_started
+      metadata:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/ready_to_run_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
@@ -408,53 +576,76 @@ services:
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SERVICE_HOST: edgex-device-rest
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-device-rest
     image: nexus3.edgexfoundry.org:10004/device-rest-arm64:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59986:59986/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59986
+      published: "59986"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - /tmp/edgex/secrets/device-rest:/tmp/edgex/secrets/device-rest:ro,z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/device-rest
+      target: /tmp/edgex/secrets/device-rest
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   device-virtual:
-    command: /device-virtual -cp=consul.http://edgex-core-consul:8500 --registry
+    command:
+    - /device-virtual
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
     container_name: edgex-device-virtual
     depends_on:
-    - consul
-    - data
-    - metadata
-    - security-bootstrapper
+      consul:
+        condition: service_started
+      data:
+        condition: service_started
+      metadata:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/ready_to_run_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
@@ -466,57 +657,75 @@ services:
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SERVICE_HOST: edgex-device-virtual
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-device-virtual
     image: nexus3.edgexfoundry.org:10004/device-virtual-arm64:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59900:59900/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59900
+      published: "59900"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - /tmp/edgex/secrets/device-virtual:/tmp/edgex/secrets/device-virtual:ro,z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/device-virtual
+      target: /tmp/edgex/secrets/device-virtual
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   kong:
     container_name: edgex-kong
     depends_on:
-    - kong-db
-    - security-bootstrapper
+      kong-db:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/kong_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       KONG_ADMIN_ACCESS_LOG: /dev/stdout
       KONG_ADMIN_ERROR_LOG: /dev/stderr
       KONG_ADMIN_LISTEN: 127.0.0.1:8001, 127.0.0.1:8444 ssl
       KONG_DATABASE: postgres
       KONG_DNS_ORDER: LAST,A,CNAME
-      KONG_DNS_VALID_TTL: '1'
-      KONG_NGINX_WORKER_PROCESSES: '1'
+      KONG_DNS_VALID_TTL: "1"
+      KONG_NGINX_WORKER_PROCESSES: "1"
       KONG_PG_HOST: edgex-kong-db
       KONG_PG_PASSWORD_FILE: /tmp/postgres-config/.pgpassword
       KONG_PROXY_ACCESS_LOG: /dev/stdout
@@ -525,28 +734,38 @@ services:
       KONG_STATUS_LISTEN: 0.0.0.0:8100
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-kong
     image: kong:2.8
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 8000:8000/tcp
-    - 127.0.0.1:8100:8100/tcp
-    - 8443:8443/tcp
+    - mode: ingress
+      target: 8000
+      published: "8000"
+      protocol: tcp
+    - mode: ingress
+      target: 8443
+      published: "8443"
+      protocol: tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 8100
+      published: "8100"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
@@ -557,50 +776,77 @@ services:
     tty: true
     user: kong:nogroup
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - /tmp/edgex/secrets/security-proxy-setup:/tmp/edgex/secrets/security-proxy-setup:ro,z
-    - postgres-config:/tmp/postgres-config:z
-    - kong:/usr/local/kong:z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: postgres-config
+      target: /tmp/postgres-config
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: kong
+      target: /usr/local/kong
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/security-proxy-setup
+      target: /tmp/edgex/secrets/security-proxy-setup
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   kong-db:
     container_name: edgex-kong-db
     depends_on:
-    - security-bootstrapper
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/postgres_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       EDGEX_SECURITY_SECRET_STORE: "true"
       POSTGRES_DB: kong
       POSTGRES_PASSWORD_FILE: /tmp/postgres-config/.pgpassword
       POSTGRES_USER: kong
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-kong-db
     image: postgres:13.8-alpine
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:5432:5432/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 5432
+      published: "5432"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
@@ -611,23 +857,47 @@ services:
     - /run
     user: root:root
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - postgres-config:/tmp/postgres-config:z
-    - postgres-data:/var/lib/postgresql/data:z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: postgres-data
+      target: /var/lib/postgresql/data
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: postgres-config
+      target: /tmp/postgres-config
+      bind:
+        selinux: z
+      volume: {}
   metadata:
-    command: /core-metadata -cp=consul.http://edgex-core-consul:8500 --registry
+    command:
+    - /core-metadata
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
     container_name: edgex-core-metadata
     depends_on:
-    - consul
-    - database
-    - notifications
-    - secretstore-setup
-    - security-bootstrapper
+      consul:
+        condition: service_started
+      database:
+        condition: service_started
+      notifications:
+        condition: service_started
+      secretstore-setup:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/ready_to_run_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
@@ -640,81 +910,119 @@ services:
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SERVICE_HOST: edgex-core-metadata
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-core-metadata
     image: nexus3.edgexfoundry.org:10004/core-metadata-arm64:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59881:59881/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59881
+      published: "59881"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - /tmp/edgex/secrets/core-metadata:/tmp/edgex/secrets/core-metadata:ro,z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/core-metadata
+      target: /tmp/edgex/secrets/core-metadata
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   mqtt-broker:
-    command: /usr/sbin/mosquitto -c /mosquitto-no-auth.conf
+    command:
+    - /usr/sbin/mosquitto
+    - -c
+    - /mosquitto-no-auth.conf
+    - -v
     container_name: edgex-mqtt-broker
     hostname: edgex-mqtt-broker
     image: eclipse-mosquitto:2.0
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:1883:1883/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 1883
+      published: "1883"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
   mqtt-taf-broker:
-    command: /usr/sbin/mosquitto -c /mosquitto-no-auth.conf
+    command:
+    - /usr/sbin/mosquitto
+    - -c
+    - /mosquitto-no-auth.conf
     container_name: edgex-taf-mqtt-broker
     hostname: edgex-taf-mqtt-broker
     image: eclipse-mosquitto:2.0
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:1884:1883/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 1883
+      published: "1884"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
   notifications:
-    command: /support-notifications -cp=consul.http://edgex-core-consul:8500 --registry
+    command:
+    - /support-notifications
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
     container_name: edgex-support-notifications
     depends_on:
-    - consul
-    - database
-    - secretstore-setup
-    - security-bootstrapper
+      consul:
+        condition: service_started
+      database:
+        condition: service_started
+      secretstore-setup:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/ready_to_run_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
@@ -726,52 +1034,71 @@ services:
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SERVICE_HOST: edgex-support-notifications
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-support-notifications
     image: nexus3.edgexfoundry.org:10004/support-notifications-arm64:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59860:59860/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59860
+      published: "59860"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - /tmp/edgex/secrets/support-notifications:/tmp/edgex/secrets/support-notifications:ro,z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/support-notifications
+      target: /tmp/edgex/secrets/support-notifications
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   proxy-setup:
     container_name: edgex-security-proxy-setup
     depends_on:
-    - kong
-    - secretstore-setup
-    - security-bootstrapper
+      kong:
+        condition: service_started
+      secretstore-setup:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/proxy_setup_wait_install.sh
     environment:
       ADD_PROXY_ROUTE: device-modbus.http://edgex-device-modbus:59901
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       EDGEX_SECURITY_SECRET_STORE: "true"
       KONGURL_SERVER: edgex-kong
       PROXY_SETUP_HOST: edgex-security-proxy-setup
@@ -785,104 +1112,157 @@ services:
       ROUTES_SUPPORT_SCHEDULER_HOST: edgex-support-scheduler
       ROUTES_SYS_MGMT_AGENT_HOST: edgex-sys-mgmt-agent
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-security-proxy-setup
     image: nexus3.edgexfoundry.org:10004/security-proxy-setup-arm64:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     read_only: true
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - consul-acl-token:/tmp/edgex/secrets/consul-acl-token:ro,z
-    - /tmp/edgex/secrets/security-proxy-setup:/tmp/edgex/secrets/security-proxy-setup:ro,z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: consul-acl-token
+      target: /tmp/edgex/secrets/consul-acl-token
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/security-proxy-setup
+      target: /tmp/edgex/secrets/security-proxy-setup
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   rulesengine:
     container_name: edgex-kuiper
     depends_on:
-    - database
-    - secretstore-setup
-    - security-bootstrapper
+      database:
+        condition: service_started
+      secretstore-setup:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/kuiper_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
-      CONNECTION__EDGEX__REDISMSGBUS__PORT: 6379
+      API_GATEWAY_STATUS_PORT: "8100"
+      CONNECTION__EDGEX__REDISMSGBUS__PORT: "6379"
       CONNECTION__EDGEX__REDISMSGBUS__PROTOCOL: redis
       CONNECTION__EDGEX__REDISMSGBUS__SERVER: edgex-redis
       CONNECTION__EDGEX__REDISMSGBUS__TYPE: redis
-      EDGEX__DEFAULT__PORT: 6379
+      EDGEX__DEFAULT__PORT: "6379"
       EDGEX__DEFAULT__PROTOCOL: redis
       EDGEX__DEFAULT__SERVER: edgex-redis
       EDGEX__DEFAULT__TOPIC: rules-events
       EDGEX__DEFAULT__TYPE: redis
       KUIPER__BASIC__CONSOLELOG: "true"
-      KUIPER__BASIC__RESTPORT: 59720
+      KUIPER__BASIC__RESTPORT: "59720"
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-kuiper
     image: lfedge/ekuiper:1.7-alpine
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59720:59720/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59720
+      published: "59720"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: kuiper:kuiper
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - kuiper-data:/kuiper/data:z
-    - kuiper-connections:/kuiper/etc/connections:z
-    - kuiper-sources:/kuiper/etc/sources:z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: kuiper-data
+      target: /kuiper/data
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: kuiper-connections
+      target: /kuiper/etc/connections
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: kuiper-sources
+      target: /kuiper/etc/sources
+      bind:
+        selinux: z
+      volume: {}
   scheduler:
-    command: /support-scheduler -cp=consul.http://edgex-core-consul:8500 --registry
+    command:
+    - /support-scheduler
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
     container_name: edgex-support-scheduler
     depends_on:
-    - consul
-    - database
-    - secretstore-setup
-    - security-bootstrapper
+      consul:
+        condition: service_started
+      database:
+        condition: service_started
+      secretstore-setup:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/ready_to_run_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
@@ -896,79 +1276,97 @@ services:
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SERVICE_HOST: edgex-support-scheduler
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-support-scheduler
     image: nexus3.edgexfoundry.org:10004/support-scheduler-arm64:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59861:59861/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59861
+      published: "59861"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - /tmp/edgex/secrets/support-scheduler:/tmp/edgex/secrets/support-scheduler:ro,z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/support-scheduler
+      target: /tmp/edgex/secrets/support-scheduler
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   secretstore-setup:
     container_name: edgex-security-secretstore-setup
     depends_on:
-    - security-bootstrapper
-    - vault
+      security-bootstrapper:
+        condition: service_started
+      vault:
+        condition: service_started
     environment:
       ADD_KNOWN_SECRETS: redisdb[app-rules-engine],redisdb[app-http-export],redisdb[app-mqtt-export],redisdb[app-scalability-test-mqtt-export],redisdb[device-rest],redisdb[device-virtual]
       ADD_SECRETSTORE_TOKENS: app-http-export,app-mqtt-export,app-functional-tests,app-scalability-test-mqtt-export
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
-      EDGEX_GROUP: '2001'
+      API_GATEWAY_STATUS_PORT: "8100"
+      EDGEX_GROUP: "2001"
       EDGEX_SECURITY_SECRET_STORE: "true"
-      EDGEX_USER: '2002'
+      EDGEX_USER: "2002"
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SECUREMESSAGEBUS_TYPE: redis
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-security-secretstore-setup
     image: nexus3.edgexfoundry.org:10004/security-secretstore-setup-arm64:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     read_only: true
     restart: always
     security_opt:
@@ -978,59 +1376,100 @@ services:
     - /vault
     user: root:root
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - /tmp/edgex/secrets:/tmp/edgex/secrets:z
-    - kong:/tmp/kong:z
-    - kuiper-sources:/tmp/kuiper:z
-    - kuiper-connections:/tmp/kuiper-connections:z
-    - vault-config:/vault/config:z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets
+      target: /tmp/edgex/secrets
+      bind:
+        selinux: z
+        create_host_path: true
+    - type: volume
+      source: kong
+      target: /tmp/kong
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: kuiper-sources
+      target: /tmp/kuiper
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: kuiper-connections
+      target: /tmp/kuiper-connections
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: vault-config
+      target: /vault/config
+      bind:
+        selinux: z
+      volume: {}
   security-bootstrapper:
     container_name: edgex-security-bootstrapper
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
-      EDGEX_GROUP: '2001'
-      EDGEX_USER: '2002'
+      API_GATEWAY_STATUS_PORT: "8100"
+      EDGEX_GROUP: "2001"
+      EDGEX_USER: "2002"
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-security-bootstrapper
     image: nexus3.edgexfoundry.org:10004/security-bootstrapper-arm64:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: root:root
     volumes:
-    - edgex-init:/edgex-init:z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      bind:
+        selinux: z
+      volume: {}
   security-spiffe-token-provider:
-    command: /security-spiffe-token-provider -cp=consul.http://edgex-core-consul:8500
-      --registry
+    command:
+    - /security-spiffe-token-provider
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
     container_name: edgex-security-spiffe-token-provider
     depends_on:
-    - consul
-    - security-bootstrapper
-    - security-spire-agent
+      consul:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
+      security-spire-agent:
+        condition: service_started
     entrypoint:
     - /edgex-init/ready_to_run_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
@@ -1041,32 +1480,36 @@ services:
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SERVICE_HOST: edgex-security-spiffe-token-provider
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-security-spiffe-token-provider
     image: nexus3.edgexfoundry.org:10004/security-spiffe-token-provider-arm64:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59841:59841/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59841
+      published: "59841"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
@@ -1075,19 +1518,36 @@ services:
     - /run
     user: root:root
     volumes:
-    - edgex-init:/edgex-init:z
-    - /tmp/edgex/secrets/security-spiffe-token-provider:/tmp/edgex/secrets/security-spiffe-token-provider:z
-    - /tmp/edgex/secrets/spiffe:/tmp/edgex/secrets/spiffe:z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/spiffe
+      target: /tmp/edgex/secrets/spiffe
+      bind:
+        selinux: z
+        create_host_path: true
+    - type: bind
+      source: /tmp/edgex/secrets/security-spiffe-token-provider
+      target: /tmp/edgex/secrets/security-spiffe-token-provider
+      bind:
+        selinux: z
+        create_host_path: true
   security-spire-agent:
-    command: docker-entrypoint.sh
+    command:
+    - docker-entrypoint.sh
     container_name: edgex-security-spire-agent
     depends_on:
-    - security-spire-server
+      security-spire-server:
+        condition: service_started
     entrypoint:
     - /edgex-init/ready_to_run_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
@@ -1098,29 +1558,29 @@ services:
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-security-spire-agent
     image: nexus3.edgexfoundry.org:10004/security-spire-agent-arm64:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     pid: host
     privileged: true
     read_only: true
@@ -1131,21 +1591,47 @@ services:
     - /run
     user: root:root
     volumes:
-    - edgex-init:/edgex-init:z
-    - spire-agent:/srv/spiffe/agent:z
-    - spire-ca:/srv/spiffe/ca:z
-    - /tmp/edgex/secrets/spiffe:/tmp/edgex/secrets/spiffe:z
-    - /var/run/docker.sock:/var/run/docker.sock:rw
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: spire-ca
+      target: /srv/spiffe/ca
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: spire-agent
+      target: /srv/spiffe/agent
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/spiffe
+      target: /tmp/edgex/secrets/spiffe
+      bind:
+        selinux: z
+        create_host_path: true
+    - type: bind
+      source: /var/run/docker.sock
+      target: /var/run/docker.sock
+      bind:
+        create_host_path: true
   security-spire-config:
-    command: docker-entrypoint.sh
+    command:
+    - docker-entrypoint.sh
     container_name: edgex-security-spire-config
     depends_on:
-    - security-spire-agent
+      security-spire-agent:
+        condition: service_started
     entrypoint:
     - /edgex-init/ready_to_run_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
@@ -1156,29 +1642,29 @@ services:
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-security-spire-config
     image: nexus3.edgexfoundry.org:10004/security-spire-config-arm64:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     read_only: true
     restart: always
     security_opt:
@@ -1187,18 +1673,30 @@ services:
     - /run
     user: root:root
     volumes:
-    - edgex-init:/edgex-init:z
-    - /tmp/edgex/secrets/spiffe:/tmp/edgex/secrets/spiffe:z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/spiffe
+      target: /tmp/edgex/secrets/spiffe
+      bind:
+        selinux: z
+        create_host_path: true
   security-spire-server:
-    command: docker-entrypoint.sh
+    command:
+    - docker-entrypoint.sh
     container_name: edgex-security-spire-server
     depends_on:
-    - security-bootstrapper
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/ready_to_run_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
@@ -1209,32 +1707,36 @@ services:
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-security-spire-server
     image: nexus3.edgexfoundry.org:10004/security-spire-server-arm64:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     pid: host
     ports:
-    - 127.0.0.1:59840:59840/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59840
+      published: "59840"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
@@ -1243,10 +1745,30 @@ services:
     - /run
     user: root:root
     volumes:
-    - edgex-init:/edgex-init:z
-    - spire-ca:/srv/spiffe/ca:z
-    - spire-server:/srv/spiffe/server:z
-    - /tmp/edgex/secrets/spiffe:/tmp/edgex/secrets/spiffe:z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: spire-ca
+      target: /srv/spiffe/ca
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: spire-server
+      target: /srv/spiffe/server
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/spiffe
+      target: /tmp/edgex/secrets/spiffe
+      bind:
+        selinux: z
+        create_host_path: true
   ui:
     container_name: edgex-ui-go
     environment:
@@ -1255,9 +1777,12 @@ services:
     hostname: edgex-ui-go
     image: nexus3.edgexfoundry.org:10004/edgex-ui-arm64:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 4000:4000/tcp
+    - mode: ingress
+      target: 4000
+      published: "4000"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
@@ -1266,30 +1791,32 @@ services:
   vault:
     cap_add:
     - IPC_LOCK
-    command: server
+    command:
+    - server
     container_name: edgex-vault
     depends_on:
-    - security-bootstrapper
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/vault_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
       VAULT_ADDR: http://edgex-vault:8200
       VAULT_CONFIG_DIR: /vault/config
@@ -1297,35 +1824,75 @@ services:
     hostname: edgex-vault
     image: vault:1.11.5
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:8200:8200/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 8200
+      published: "8200"
+      protocol: tcp
     restart: always
     tmpfs:
     - /vault/config
     user: root:root
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - vault-file:/vault/file:z
-    - vault-logs:/vault/logs:z
-version: '3.7'
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: vault-file
+      target: /vault/file
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: vault-logs
+      target: /vault/logs
+      bind:
+        selinux: z
+      volume: {}
+networks:
+  edgex-network:
+    name: edgex_edgex-network
+    driver: bridge
 volumes:
-  consul-acl-token: {}
-  consul-config: {}
-  consul-data: {}
-  db-data: {}
-  edgex-init: {}
-  kong: {}
-  kuiper-connections: {}
-  kuiper-data: {}
-  kuiper-sources: {}
-  postgres-config: {}
-  postgres-data: {}
-  redis-config: {}
-  spire-agent: {}
-  spire-ca: {}
-  spire-server: {}
-  vault-config: {}
-  vault-file: {}
-  vault-logs: {}
-
+  consul-acl-token:
+    name: edgex_consul-acl-token
+  consul-config:
+    name: edgex_consul-config
+  consul-data:
+    name: edgex_consul-data
+  db-data:
+    name: edgex_db-data
+  edgex-init:
+    name: edgex_edgex-init
+  kong:
+    name: edgex_kong
+  kuiper-connections:
+    name: edgex_kuiper-connections
+  kuiper-data:
+    name: edgex_kuiper-data
+  kuiper-sources:
+    name: edgex_kuiper-sources
+  postgres-config:
+    name: edgex_postgres-config
+  postgres-data:
+    name: edgex_postgres-data
+  redis-config:
+    name: edgex_redis-config
+  spire-agent:
+    name: edgex_spire-agent
+  spire-ca:
+    name: edgex_spire-ca
+  spire-server:
+    name: edgex_spire-server
+  vault-config:
+    name: edgex_vault-config
+  vault-file:
+    name: edgex_vault-file
+  vault-logs:
+    name: edgex_vault-logs

--- a/taf/docker-compose-taf-perf-no-secty-arm64.yml
+++ b/taf/docker-compose-taf-perf-no-secty-arm64.yml
@@ -24,23 +24,23 @@
 #
 # From the compose-builder folder use `make build` to regenerate all standard compose files variations
 #
-networks:
-  edgex-network:
-    driver: bridge
+name: edgex
 services:
   app-service-mqtt-export:
     container_name: edgex-app-mqtt-export
     depends_on:
-    - consul
-    - data
+      consul:
+        condition: service_started
+      data:
+        condition: service_started
     environment:
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
       CLIENTS_SUPPORT_NOTIFICATIONS_HOST: edgex-support-notifications
       CLIENTS_SUPPORT_SCHEDULER_HOST: edgex-support-scheduler
-      DATABASES_PRIMARY_HOST: edgex-redis
       DATABASE_HOST: edgex-redis
+      DATABASES_PRIMARY_HOST: edgex-redis
       EDGEX_PROFILE: mqtt-export
       EDGEX_SECURITY_SECRET_STORE: "false"
       MESSAGEBUS_HOST: edgex-redis
@@ -52,9 +52,13 @@ services:
     hostname: edgex-app-mqtt-export
     image: nexus3.edgexfoundry.org:10004/app-service-configurable-arm64:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59703:59703/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59703
+      published: "59703"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
@@ -63,8 +67,10 @@ services:
   app-service-rules:
     container_name: edgex-app-rules-engine
     depends_on:
-    - consul
-    - data
+      consul:
+        condition: service_started
+      data:
+        condition: service_started
     environment:
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
@@ -80,9 +86,13 @@ services:
     hostname: edgex-app-rules-engine
     image: nexus3.edgexfoundry.org:10004/app-service-configurable-arm64:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59701:59701/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59701
+      published: "59701"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
@@ -91,9 +101,12 @@ services:
   command:
     container_name: edgex-core-command
     depends_on:
-    - consul
-    - database
-    - metadata
+      consul:
+        condition: service_started
+      database:
+        condition: service_started
+      metadata:
+        condition: service_started
     environment:
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
@@ -109,37 +122,64 @@ services:
     hostname: edgex-core-command
     image: nexus3.edgexfoundry.org:10004/core-command-arm64:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59882:59882/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59882
+      published: "59882"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
   consul:
-    command: agent -ui -bootstrap -server -client 0.0.0.0
+    command:
+    - agent
+    - -ui
+    - -bootstrap
+    - -server
+    - -client
+    - 0.0.0.0
     container_name: edgex-core-consul
     hostname: edgex-core-consul
     image: consul:1.13
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:8500:8500/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 8500
+      published: "8500"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: root:root
     volumes:
-    - consul-config:/consul/config:z
-    - consul-data:/consul/data:z
+    - type: volume
+      source: consul-config
+      target: /consul/config
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: consul-data
+      target: /consul/data
+      bind:
+        selinux: z
+      volume: {}
   data:
     container_name: edgex-core-data
     depends_on:
-    - consul
-    - database
-    - metadata
+      consul:
+        condition: service_started
+      database:
+        condition: service_started
+      metadata:
+        condition: service_started
     environment:
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
@@ -154,10 +194,18 @@ services:
     hostname: edgex-core-data
     image: nexus3.edgexfoundry.org:10004/core-data-arm64:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:5563:5563/tcp
-    - 127.0.0.1:59880:59880/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59880
+      published: "59880"
+      protocol: tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 5563
+      published: "5563"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
@@ -177,22 +225,34 @@ services:
     hostname: edgex-redis
     image: redis:7.0-alpine
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:6379:6379/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 6379
+      published: "6379"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: root:root
     volumes:
-    - db-data:/data:z
+    - type: volume
+      source: db-data
+      target: /data
+      bind:
+        selinux: z
+      volume: {}
   device-rest:
     container_name: edgex-device-rest
     depends_on:
-    - consul
-    - data
-    - metadata
+      consul:
+        condition: service_started
+      data:
+        condition: service_started
+      metadata:
+        condition: service_started
     environment:
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
@@ -207,9 +267,13 @@ services:
     hostname: edgex-device-rest
     image: nexus3.edgexfoundry.org:10004/device-rest-arm64:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59986:59986/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59986
+      published: "59986"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
@@ -218,9 +282,12 @@ services:
   device-virtual:
     container_name: edgex-device-virtual
     depends_on:
-    - consul
-    - data
-    - metadata
+      consul:
+        condition: service_started
+      data:
+        condition: service_started
+      metadata:
+        condition: service_started
     environment:
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
@@ -235,9 +302,13 @@ services:
     hostname: edgex-device-virtual
     image: nexus3.edgexfoundry.org:10004/device-virtual-arm64:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59900:59900/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59900
+      published: "59900"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
@@ -246,9 +317,12 @@ services:
   metadata:
     container_name: edgex-core-metadata
     depends_on:
-    - consul
-    - database
-    - notifications
+      consul:
+        condition: service_started
+      database:
+        condition: service_started
+      notifications:
+        condition: service_started
     environment:
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
@@ -264,37 +338,56 @@ services:
     hostname: edgex-core-metadata
     image: nexus3.edgexfoundry.org:10004/core-metadata-arm64:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59881:59881/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59881
+      published: "59881"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
   mqtt-broker:
-    command: /usr/sbin/mosquitto -c /mosquitto-no-auth.conf
+    command:
+    - /usr/sbin/mosquitto
+    - -c
+    - /mosquitto-no-auth.conf
+    - -v
     container_name: edgex-mqtt-broker
     hostname: edgex-mqtt-broker
     image: eclipse-mosquitto:2.0
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:1883:1883/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 1883
+      published: "1883"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
   mqtt-taf-broker:
-    command: /usr/sbin/mosquitto -c /mosquitto-no-auth.conf
+    command:
+    - /usr/sbin/mosquitto
+    - -c
+    - /mosquitto-no-auth.conf
     container_name: edgex-taf-mqtt-broker
     hostname: edgex-taf-mqtt-broker
     image: eclipse-mosquitto:2.0
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:1884:1883/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 1883
+      published: "1884"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
@@ -303,8 +396,10 @@ services:
   notifications:
     container_name: edgex-support-notifications
     depends_on:
-    - consul
-    - database
+      consul:
+        condition: service_started
+      database:
+        condition: service_started
     environment:
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
@@ -319,9 +414,13 @@ services:
     hostname: edgex-support-notifications
     image: nexus3.edgexfoundry.org:10004/support-notifications-arm64:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59860:59860/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59860
+      published: "59860"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
@@ -330,37 +429,49 @@ services:
   rulesengine:
     container_name: edgex-kuiper
     depends_on:
-    - database
+      database:
+        condition: service_started
     environment:
-      CONNECTION__EDGEX__REDISMSGBUS__PORT: 6379
+      CONNECTION__EDGEX__REDISMSGBUS__PORT: "6379"
       CONNECTION__EDGEX__REDISMSGBUS__PROTOCOL: redis
       CONNECTION__EDGEX__REDISMSGBUS__SERVER: edgex-redis
       CONNECTION__EDGEX__REDISMSGBUS__TYPE: redis
-      EDGEX__DEFAULT__PORT: 6379
+      EDGEX__DEFAULT__PORT: "6379"
       EDGEX__DEFAULT__PROTOCOL: redis
       EDGEX__DEFAULT__SERVER: edgex-redis
       EDGEX__DEFAULT__TOPIC: rules-events
       EDGEX__DEFAULT__TYPE: redis
       KUIPER__BASIC__CONSOLELOG: "true"
-      KUIPER__BASIC__RESTPORT: 59720
+      KUIPER__BASIC__RESTPORT: "59720"
     hostname: edgex-kuiper
     image: lfedge/ekuiper:1.7-alpine
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59720:59720/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59720
+      published: "59720"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: kuiper:kuiper
     volumes:
-    - kuiper-data:/kuiper/data:z
+    - type: volume
+      source: kuiper-data
+      target: /kuiper/data
+      bind:
+        selinux: z
+      volume: {}
   scheduler:
     container_name: edgex-support-scheduler
     depends_on:
-    - consul
-    - database
+      consul:
+        condition: service_started
+      database:
+        condition: service_started
     environment:
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
@@ -377,9 +488,13 @@ services:
     hostname: edgex-support-scheduler
     image: nexus3.edgexfoundry.org:10004/support-scheduler-arm64:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59861:59861/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59861
+      published: "59861"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
@@ -393,18 +508,27 @@ services:
     hostname: edgex-ui-go
     image: nexus3.edgexfoundry.org:10004/edgex-ui-arm64:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 4000:4000/tcp
+    - mode: ingress
+      target: 4000
+      published: "4000"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
-version: '3.7'
+networks:
+  edgex-network:
+    name: edgex_edgex-network
+    driver: bridge
 volumes:
-  consul-config: {}
-  consul-data: {}
-  db-data: {}
-  kuiper-data: {}
-
+  consul-config:
+    name: edgex_consul-config
+  consul-data:
+    name: edgex_consul-data
+  db-data:
+    name: edgex_db-data
+  kuiper-data:
+    name: edgex_kuiper-data

--- a/taf/docker-compose-taf-perf-no-secty-arm64.yml
+++ b/taf/docker-compose-taf-perf-no-secty-arm64.yml
@@ -355,7 +355,6 @@ services:
     - /usr/sbin/mosquitto
     - -c
     - /mosquitto-no-auth.conf
-    - -v
     container_name: edgex-mqtt-broker
     hostname: edgex-mqtt-broker
     image: eclipse-mosquitto:2.0

--- a/taf/docker-compose-taf-perf-no-secty.yml
+++ b/taf/docker-compose-taf-perf-no-secty.yml
@@ -355,7 +355,6 @@ services:
     - /usr/sbin/mosquitto
     - -c
     - /mosquitto-no-auth.conf
-    - -v
     container_name: edgex-mqtt-broker
     hostname: edgex-mqtt-broker
     image: eclipse-mosquitto:2.0

--- a/taf/docker-compose-taf-perf-no-secty.yml
+++ b/taf/docker-compose-taf-perf-no-secty.yml
@@ -24,23 +24,23 @@
 #
 # From the compose-builder folder use `make build` to regenerate all standard compose files variations
 #
-networks:
-  edgex-network:
-    driver: bridge
+name: edgex
 services:
   app-service-mqtt-export:
     container_name: edgex-app-mqtt-export
     depends_on:
-    - consul
-    - data
+      consul:
+        condition: service_started
+      data:
+        condition: service_started
     environment:
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
       CLIENTS_SUPPORT_NOTIFICATIONS_HOST: edgex-support-notifications
       CLIENTS_SUPPORT_SCHEDULER_HOST: edgex-support-scheduler
-      DATABASES_PRIMARY_HOST: edgex-redis
       DATABASE_HOST: edgex-redis
+      DATABASES_PRIMARY_HOST: edgex-redis
       EDGEX_PROFILE: mqtt-export
       EDGEX_SECURITY_SECRET_STORE: "false"
       MESSAGEBUS_HOST: edgex-redis
@@ -52,9 +52,13 @@ services:
     hostname: edgex-app-mqtt-export
     image: nexus3.edgexfoundry.org:10004/app-service-configurable:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59703:59703/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59703
+      published: "59703"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
@@ -63,8 +67,10 @@ services:
   app-service-rules:
     container_name: edgex-app-rules-engine
     depends_on:
-    - consul
-    - data
+      consul:
+        condition: service_started
+      data:
+        condition: service_started
     environment:
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
@@ -80,9 +86,13 @@ services:
     hostname: edgex-app-rules-engine
     image: nexus3.edgexfoundry.org:10004/app-service-configurable:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59701:59701/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59701
+      published: "59701"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
@@ -91,9 +101,12 @@ services:
   command:
     container_name: edgex-core-command
     depends_on:
-    - consul
-    - database
-    - metadata
+      consul:
+        condition: service_started
+      database:
+        condition: service_started
+      metadata:
+        condition: service_started
     environment:
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
@@ -109,37 +122,64 @@ services:
     hostname: edgex-core-command
     image: nexus3.edgexfoundry.org:10004/core-command:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59882:59882/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59882
+      published: "59882"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
   consul:
-    command: agent -ui -bootstrap -server -client 0.0.0.0
+    command:
+    - agent
+    - -ui
+    - -bootstrap
+    - -server
+    - -client
+    - 0.0.0.0
     container_name: edgex-core-consul
     hostname: edgex-core-consul
     image: consul:1.13
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:8500:8500/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 8500
+      published: "8500"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: root:root
     volumes:
-    - consul-config:/consul/config:z
-    - consul-data:/consul/data:z
+    - type: volume
+      source: consul-config
+      target: /consul/config
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: consul-data
+      target: /consul/data
+      bind:
+        selinux: z
+      volume: {}
   data:
     container_name: edgex-core-data
     depends_on:
-    - consul
-    - database
-    - metadata
+      consul:
+        condition: service_started
+      database:
+        condition: service_started
+      metadata:
+        condition: service_started
     environment:
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
@@ -154,10 +194,18 @@ services:
     hostname: edgex-core-data
     image: nexus3.edgexfoundry.org:10004/core-data:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:5563:5563/tcp
-    - 127.0.0.1:59880:59880/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59880
+      published: "59880"
+      protocol: tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 5563
+      published: "5563"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
@@ -177,22 +225,34 @@ services:
     hostname: edgex-redis
     image: redis:7.0-alpine
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:6379:6379/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 6379
+      published: "6379"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: root:root
     volumes:
-    - db-data:/data:z
+    - type: volume
+      source: db-data
+      target: /data
+      bind:
+        selinux: z
+      volume: {}
   device-rest:
     container_name: edgex-device-rest
     depends_on:
-    - consul
-    - data
-    - metadata
+      consul:
+        condition: service_started
+      data:
+        condition: service_started
+      metadata:
+        condition: service_started
     environment:
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
@@ -207,9 +267,13 @@ services:
     hostname: edgex-device-rest
     image: nexus3.edgexfoundry.org:10004/device-rest:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59986:59986/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59986
+      published: "59986"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
@@ -218,9 +282,12 @@ services:
   device-virtual:
     container_name: edgex-device-virtual
     depends_on:
-    - consul
-    - data
-    - metadata
+      consul:
+        condition: service_started
+      data:
+        condition: service_started
+      metadata:
+        condition: service_started
     environment:
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
@@ -235,9 +302,13 @@ services:
     hostname: edgex-device-virtual
     image: nexus3.edgexfoundry.org:10004/device-virtual:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59900:59900/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59900
+      published: "59900"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
@@ -246,9 +317,12 @@ services:
   metadata:
     container_name: edgex-core-metadata
     depends_on:
-    - consul
-    - database
-    - notifications
+      consul:
+        condition: service_started
+      database:
+        condition: service_started
+      notifications:
+        condition: service_started
     environment:
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
@@ -264,37 +338,56 @@ services:
     hostname: edgex-core-metadata
     image: nexus3.edgexfoundry.org:10004/core-metadata:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59881:59881/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59881
+      published: "59881"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
   mqtt-broker:
-    command: /usr/sbin/mosquitto -c /mosquitto-no-auth.conf
+    command:
+    - /usr/sbin/mosquitto
+    - -c
+    - /mosquitto-no-auth.conf
+    - -v
     container_name: edgex-mqtt-broker
     hostname: edgex-mqtt-broker
     image: eclipse-mosquitto:2.0
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:1883:1883/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 1883
+      published: "1883"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
   mqtt-taf-broker:
-    command: /usr/sbin/mosquitto -c /mosquitto-no-auth.conf
+    command:
+    - /usr/sbin/mosquitto
+    - -c
+    - /mosquitto-no-auth.conf
     container_name: edgex-taf-mqtt-broker
     hostname: edgex-taf-mqtt-broker
     image: eclipse-mosquitto:2.0
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:1884:1883/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 1883
+      published: "1884"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
@@ -303,8 +396,10 @@ services:
   notifications:
     container_name: edgex-support-notifications
     depends_on:
-    - consul
-    - database
+      consul:
+        condition: service_started
+      database:
+        condition: service_started
     environment:
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
@@ -319,9 +414,13 @@ services:
     hostname: edgex-support-notifications
     image: nexus3.edgexfoundry.org:10004/support-notifications:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59860:59860/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59860
+      published: "59860"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
@@ -330,37 +429,49 @@ services:
   rulesengine:
     container_name: edgex-kuiper
     depends_on:
-    - database
+      database:
+        condition: service_started
     environment:
-      CONNECTION__EDGEX__REDISMSGBUS__PORT: 6379
+      CONNECTION__EDGEX__REDISMSGBUS__PORT: "6379"
       CONNECTION__EDGEX__REDISMSGBUS__PROTOCOL: redis
       CONNECTION__EDGEX__REDISMSGBUS__SERVER: edgex-redis
       CONNECTION__EDGEX__REDISMSGBUS__TYPE: redis
-      EDGEX__DEFAULT__PORT: 6379
+      EDGEX__DEFAULT__PORT: "6379"
       EDGEX__DEFAULT__PROTOCOL: redis
       EDGEX__DEFAULT__SERVER: edgex-redis
       EDGEX__DEFAULT__TOPIC: rules-events
       EDGEX__DEFAULT__TYPE: redis
       KUIPER__BASIC__CONSOLELOG: "true"
-      KUIPER__BASIC__RESTPORT: 59720
+      KUIPER__BASIC__RESTPORT: "59720"
     hostname: edgex-kuiper
     image: lfedge/ekuiper:1.7-alpine
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59720:59720/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59720
+      published: "59720"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: kuiper:kuiper
     volumes:
-    - kuiper-data:/kuiper/data:z
+    - type: volume
+      source: kuiper-data
+      target: /kuiper/data
+      bind:
+        selinux: z
+      volume: {}
   scheduler:
     container_name: edgex-support-scheduler
     depends_on:
-    - consul
-    - database
+      consul:
+        condition: service_started
+      database:
+        condition: service_started
     environment:
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
@@ -377,9 +488,13 @@ services:
     hostname: edgex-support-scheduler
     image: nexus3.edgexfoundry.org:10004/support-scheduler:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59861:59861/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59861
+      published: "59861"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
@@ -393,18 +508,27 @@ services:
     hostname: edgex-ui-go
     image: nexus3.edgexfoundry.org:10004/edgex-ui:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 4000:4000/tcp
+    - mode: ingress
+      target: 4000
+      published: "4000"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
-version: '3.7'
+networks:
+  edgex-network:
+    name: edgex_edgex-network
+    driver: bridge
 volumes:
-  consul-config: {}
-  consul-data: {}
-  db-data: {}
-  kuiper-data: {}
-
+  consul-config:
+    name: edgex_consul-config
+  consul-data:
+    name: edgex_consul-data
+  db-data:
+    name: edgex_db-data
+  kuiper-data:
+    name: edgex_kuiper-data

--- a/taf/docker-compose-taf-perf.yml
+++ b/taf/docker-compose-taf-perf.yml
@@ -965,7 +965,6 @@ services:
     - /usr/sbin/mosquitto
     - -c
     - /mosquitto-no-auth.conf
-    - -v
     container_name: edgex-mqtt-broker
     hostname: edgex-mqtt-broker
     image: eclipse-mosquitto:2.0

--- a/taf/docker-compose-taf-perf.yml
+++ b/taf/docker-compose-taf-perf.yml
@@ -24,54 +24,58 @@
 #
 # From the compose-builder folder use `make build` to regenerate all standard compose files variations
 #
-networks:
-  edgex-network:
-    driver: bridge
+name: edgex
 services:
   app-service-mqtt-export:
-    command: /app-service-configurable -cp=consul.http://edgex-core-consul:8500 --registry
+    command:
+    - /app-service-configurable
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
     container_name: edgex-app-mqtt-export
     depends_on:
-    - consul
-    - data
-    - security-bootstrapper
+      consul:
+        condition: service_started
+      data:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/ready_to_run_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
       CLIENTS_SUPPORT_NOTIFICATIONS_HOST: edgex-support-notifications
       CLIENTS_SUPPORT_SCHEDULER_HOST: edgex-support-scheduler
-      DATABASES_PRIMARY_HOST: edgex-redis
       DATABASE_HOST: edgex-redis
+      DATABASES_PRIMARY_HOST: edgex-redis
       EDGEX_PROFILE: mqtt-export
       EDGEX_SECURITY_SECRET_STORE: "true"
       MESSAGEBUS_HOST: edgex-redis
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SERVICE_HOST: edgex-app-mqtt-export
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
       WRITABLE_LOGLEVEL: INFO
       WRITABLE_PIPELINE_FUNCTIONS_MQTTEXPORT_PARAMETERS_BROKERADDRESS: MQTT_BROKER_ADDRESS_PLACE_HOLDER
@@ -79,29 +83,51 @@ services:
     hostname: edgex-app-mqtt-export
     image: nexus3.edgexfoundry.org:10004/app-service-configurable:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59703:59703/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59703
+      published: "59703"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - /tmp/edgex/secrets/app-mqtt-export:/tmp/edgex/secrets/app-mqtt-export:ro,z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/app-mqtt-export
+      target: /tmp/edgex/secrets/app-mqtt-export
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   app-service-rules:
-    command: /app-service-configurable -cp=consul.http://edgex-core-consul:8500 --registry
+    command:
+    - /app-service-configurable
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
     container_name: edgex-app-rules-engine
     depends_on:
-    - consul
-    - data
-    - security-bootstrapper
+      consul:
+        condition: service_started
+      data:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/ready_to_run_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
@@ -114,54 +140,78 @@ services:
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SERVICE_HOST: edgex-app-rules-engine
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-app-rules-engine
     image: nexus3.edgexfoundry.org:10004/app-service-configurable:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59701:59701/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59701
+      published: "59701"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - /tmp/edgex/secrets/app-rules-engine:/tmp/edgex/secrets/app-rules-engine:ro,z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/app-rules-engine
+      target: /tmp/edgex/secrets/app-rules-engine
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   command:
-    command: /core-command -cp=consul.http://edgex-core-consul:8500 --registry
+    command:
+    - /core-command
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
     container_name: edgex-core-command
     depends_on:
-    - consul
-    - database
-    - metadata
-    - secretstore-setup
-    - security-bootstrapper
+      consul:
+        condition: service_started
+      database:
+        condition: service_started
+      metadata:
+        condition: service_started
+      secretstore-setup:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/ready_to_run_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
@@ -174,110 +224,173 @@ services:
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SERVICE_HOST: edgex-core-command
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-core-command
     image: nexus3.edgexfoundry.org:10004/core-command:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59882:59882/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59882
+      published: "59882"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - /tmp/edgex/secrets/core-command:/tmp/edgex/secrets/core-command:ro,z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/core-command
+      target: /tmp/edgex/secrets/core-command
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   consul:
-    command: agent -ui -bootstrap -server -client 0.0.0.0
+    command:
+    - agent
+    - -ui
+    - -bootstrap
+    - -server
+    - -client
+    - 0.0.0.0
     container_name: edgex-core-consul
     depends_on:
-    - security-bootstrapper
-    - vault
+      security-bootstrapper:
+        condition: service_started
+      vault:
+        condition: service_started
     entrypoint:
     - /edgex-init/consul_wait_install.sh
     environment:
       ADD_REGISTRY_ACL_ROLES: app-http-export,app-mqtt-export,app-functional-tests,app-scalability-test-mqtt-export
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
-      EDGEX_GROUP: '2001'
+      API_GATEWAY_STATUS_PORT: "8100"
+      EDGEX_GROUP: "2001"
       EDGEX_SECURITY_SECRET_STORE: "true"
-      EDGEX_USER: '2002'
+      EDGEX_USER: "2002"
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_ACL_BOOTSTRAPTOKENPATH: /tmp/edgex/secrets/consul-acl-token/bootstrap_token.json
       STAGEGATE_REGISTRY_ACL_MANAGEMENTTOKENPATH: /tmp/edgex/secrets/consul-acl-token/mgmt_token.json
       STAGEGATE_REGISTRY_ACL_SENTINELFILEPATH: /consul/config/consul_acl_done
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-core-consul
     image: consul:1.13
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:8500:8500/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 8500
+      published: "8500"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: root:root
     volumes:
-    - consul-config:/consul/config:z
-    - consul-data:/consul/data:z
-    - edgex-init:/edgex-init:ro,z
-    - consul-acl-token:/tmp/edgex/secrets/consul-acl-token:z
-    - /tmp/edgex/secrets/edgex-consul:/tmp/edgex/secrets/edgex-consul:ro,z
+    - type: volume
+      source: consul-config
+      target: /consul/config
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: consul-data
+      target: /consul/data
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: consul-acl-token
+      target: /tmp/edgex/secrets/consul-acl-token
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/edgex-consul
+      target: /tmp/edgex/secrets/edgex-consul
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   data:
-    command: /core-data -cp=consul.http://edgex-core-consul:8500 --registry
+    command:
+    - /core-data
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
     container_name: edgex-core-data
     depends_on:
-    - consul
-    - database
-    - metadata
-    - secretstore-setup
-    - security-bootstrapper
+      consul:
+        condition: service_started
+      database:
+        condition: service_started
+      metadata:
+        condition: service_started
+      secretstore-setup:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/ready_to_run_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
@@ -289,52 +402,74 @@ services:
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SECRETSTORE_TOKENFILE: /tmp/edgex/secrets/core-data/secrets-token.json
       SERVICE_HOST: edgex-core-data
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-core-data
     image: nexus3.edgexfoundry.org:10004/core-data:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:5563:5563/tcp
-    - 127.0.0.1:59880:59880/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 5563
+      published: "5563"
+      protocol: tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59880
+      published: "59880"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - /tmp/edgex/secrets/core-data:/tmp/edgex/secrets/core-data:ro,z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/core-data
+      target: /tmp/edgex/secrets/core-data
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   database:
     container_name: edgex-redis
     depends_on:
-    - secretstore-setup
-    - security-bootstrapper
+      secretstore-setup:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/redis_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
@@ -347,31 +482,35 @@ services:
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-redis
     image: redis:7.0-alpine
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:6379:6379/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 6379
+      published: "6379"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
@@ -380,23 +519,52 @@ services:
     - /run
     user: root:root
     volumes:
-    - db-data:/data:z
-    - edgex-init:/edgex-init:ro,z
-    - redis-config:/run/redis/conf:z
-    - /tmp/edgex/secrets/security-bootstrapper-redis:/tmp/edgex/secrets/security-bootstrapper-redis:ro,z
+    - type: volume
+      source: db-data
+      target: /data
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: redis-config
+      target: /run/redis/conf
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/security-bootstrapper-redis
+      target: /tmp/edgex/secrets/security-bootstrapper-redis
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   device-rest:
-    command: /device-rest -cp=consul.http://edgex-core-consul:8500 --registry
+    command:
+    - /device-rest
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
     container_name: edgex-device-rest
     depends_on:
-    - consul
-    - data
-    - metadata
-    - security-bootstrapper
+      consul:
+        condition: service_started
+      data:
+        condition: service_started
+      metadata:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/ready_to_run_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
@@ -408,53 +576,76 @@ services:
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SERVICE_HOST: edgex-device-rest
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-device-rest
     image: nexus3.edgexfoundry.org:10004/device-rest:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59986:59986/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59986
+      published: "59986"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - /tmp/edgex/secrets/device-rest:/tmp/edgex/secrets/device-rest:ro,z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/device-rest
+      target: /tmp/edgex/secrets/device-rest
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   device-virtual:
-    command: /device-virtual -cp=consul.http://edgex-core-consul:8500 --registry
+    command:
+    - /device-virtual
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
     container_name: edgex-device-virtual
     depends_on:
-    - consul
-    - data
-    - metadata
-    - security-bootstrapper
+      consul:
+        condition: service_started
+      data:
+        condition: service_started
+      metadata:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/ready_to_run_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
@@ -466,57 +657,75 @@ services:
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SERVICE_HOST: edgex-device-virtual
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-device-virtual
     image: nexus3.edgexfoundry.org:10004/device-virtual:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59900:59900/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59900
+      published: "59900"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - /tmp/edgex/secrets/device-virtual:/tmp/edgex/secrets/device-virtual:ro,z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/device-virtual
+      target: /tmp/edgex/secrets/device-virtual
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   kong:
     container_name: edgex-kong
     depends_on:
-    - kong-db
-    - security-bootstrapper
+      kong-db:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/kong_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       KONG_ADMIN_ACCESS_LOG: /dev/stdout
       KONG_ADMIN_ERROR_LOG: /dev/stderr
       KONG_ADMIN_LISTEN: 127.0.0.1:8001, 127.0.0.1:8444 ssl
       KONG_DATABASE: postgres
       KONG_DNS_ORDER: LAST,A,CNAME
-      KONG_DNS_VALID_TTL: '1'
-      KONG_NGINX_WORKER_PROCESSES: '1'
+      KONG_DNS_VALID_TTL: "1"
+      KONG_NGINX_WORKER_PROCESSES: "1"
       KONG_PG_HOST: edgex-kong-db
       KONG_PG_PASSWORD_FILE: /tmp/postgres-config/.pgpassword
       KONG_PROXY_ACCESS_LOG: /dev/stdout
@@ -525,28 +734,38 @@ services:
       KONG_STATUS_LISTEN: 0.0.0.0:8100
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-kong
     image: kong:2.8
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 8000:8000/tcp
-    - 127.0.0.1:8100:8100/tcp
-    - 8443:8443/tcp
+    - mode: ingress
+      target: 8000
+      published: "8000"
+      protocol: tcp
+    - mode: ingress
+      target: 8443
+      published: "8443"
+      protocol: tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 8100
+      published: "8100"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
@@ -557,50 +776,77 @@ services:
     tty: true
     user: kong:nogroup
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - /tmp/edgex/secrets/security-proxy-setup:/tmp/edgex/secrets/security-proxy-setup:ro,z
-    - postgres-config:/tmp/postgres-config:z
-    - kong:/usr/local/kong:z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: postgres-config
+      target: /tmp/postgres-config
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: kong
+      target: /usr/local/kong
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/security-proxy-setup
+      target: /tmp/edgex/secrets/security-proxy-setup
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   kong-db:
     container_name: edgex-kong-db
     depends_on:
-    - security-bootstrapper
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/postgres_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       EDGEX_SECURITY_SECRET_STORE: "true"
       POSTGRES_DB: kong
       POSTGRES_PASSWORD_FILE: /tmp/postgres-config/.pgpassword
       POSTGRES_USER: kong
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-kong-db
     image: postgres:13.8-alpine
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:5432:5432/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 5432
+      published: "5432"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
@@ -611,23 +857,47 @@ services:
     - /run
     user: root:root
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - postgres-config:/tmp/postgres-config:z
-    - postgres-data:/var/lib/postgresql/data:z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: postgres-data
+      target: /var/lib/postgresql/data
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: postgres-config
+      target: /tmp/postgres-config
+      bind:
+        selinux: z
+      volume: {}
   metadata:
-    command: /core-metadata -cp=consul.http://edgex-core-consul:8500 --registry
+    command:
+    - /core-metadata
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
     container_name: edgex-core-metadata
     depends_on:
-    - consul
-    - database
-    - notifications
-    - secretstore-setup
-    - security-bootstrapper
+      consul:
+        condition: service_started
+      database:
+        condition: service_started
+      notifications:
+        condition: service_started
+      secretstore-setup:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/ready_to_run_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
@@ -640,81 +910,119 @@ services:
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SERVICE_HOST: edgex-core-metadata
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-core-metadata
     image: nexus3.edgexfoundry.org:10004/core-metadata:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59881:59881/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59881
+      published: "59881"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - /tmp/edgex/secrets/core-metadata:/tmp/edgex/secrets/core-metadata:ro,z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/core-metadata
+      target: /tmp/edgex/secrets/core-metadata
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   mqtt-broker:
-    command: /usr/sbin/mosquitto -c /mosquitto-no-auth.conf
+    command:
+    - /usr/sbin/mosquitto
+    - -c
+    - /mosquitto-no-auth.conf
+    - -v
     container_name: edgex-mqtt-broker
     hostname: edgex-mqtt-broker
     image: eclipse-mosquitto:2.0
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:1883:1883/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 1883
+      published: "1883"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
   mqtt-taf-broker:
-    command: /usr/sbin/mosquitto -c /mosquitto-no-auth.conf
+    command:
+    - /usr/sbin/mosquitto
+    - -c
+    - /mosquitto-no-auth.conf
     container_name: edgex-taf-mqtt-broker
     hostname: edgex-taf-mqtt-broker
     image: eclipse-mosquitto:2.0
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:1884:1883/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 1883
+      published: "1884"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
   notifications:
-    command: /support-notifications -cp=consul.http://edgex-core-consul:8500 --registry
+    command:
+    - /support-notifications
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
     container_name: edgex-support-notifications
     depends_on:
-    - consul
-    - database
-    - secretstore-setup
-    - security-bootstrapper
+      consul:
+        condition: service_started
+      database:
+        condition: service_started
+      secretstore-setup:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/ready_to_run_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
@@ -726,52 +1034,71 @@ services:
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SERVICE_HOST: edgex-support-notifications
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-support-notifications
     image: nexus3.edgexfoundry.org:10004/support-notifications:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59860:59860/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59860
+      published: "59860"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - /tmp/edgex/secrets/support-notifications:/tmp/edgex/secrets/support-notifications:ro,z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/support-notifications
+      target: /tmp/edgex/secrets/support-notifications
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   proxy-setup:
     container_name: edgex-security-proxy-setup
     depends_on:
-    - kong
-    - secretstore-setup
-    - security-bootstrapper
+      kong:
+        condition: service_started
+      secretstore-setup:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/proxy_setup_wait_install.sh
     environment:
       ADD_PROXY_ROUTE: device-modbus.http://edgex-device-modbus:59901
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       EDGEX_SECURITY_SECRET_STORE: "true"
       KONGURL_SERVER: edgex-kong
       PROXY_SETUP_HOST: edgex-security-proxy-setup
@@ -785,104 +1112,157 @@ services:
       ROUTES_SUPPORT_SCHEDULER_HOST: edgex-support-scheduler
       ROUTES_SYS_MGMT_AGENT_HOST: edgex-sys-mgmt-agent
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-security-proxy-setup
     image: nexus3.edgexfoundry.org:10004/security-proxy-setup:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     read_only: true
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - consul-acl-token:/tmp/edgex/secrets/consul-acl-token:ro,z
-    - /tmp/edgex/secrets/security-proxy-setup:/tmp/edgex/secrets/security-proxy-setup:ro,z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: consul-acl-token
+      target: /tmp/edgex/secrets/consul-acl-token
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/security-proxy-setup
+      target: /tmp/edgex/secrets/security-proxy-setup
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   rulesengine:
     container_name: edgex-kuiper
     depends_on:
-    - database
-    - secretstore-setup
-    - security-bootstrapper
+      database:
+        condition: service_started
+      secretstore-setup:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/kuiper_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
-      CONNECTION__EDGEX__REDISMSGBUS__PORT: 6379
+      API_GATEWAY_STATUS_PORT: "8100"
+      CONNECTION__EDGEX__REDISMSGBUS__PORT: "6379"
       CONNECTION__EDGEX__REDISMSGBUS__PROTOCOL: redis
       CONNECTION__EDGEX__REDISMSGBUS__SERVER: edgex-redis
       CONNECTION__EDGEX__REDISMSGBUS__TYPE: redis
-      EDGEX__DEFAULT__PORT: 6379
+      EDGEX__DEFAULT__PORT: "6379"
       EDGEX__DEFAULT__PROTOCOL: redis
       EDGEX__DEFAULT__SERVER: edgex-redis
       EDGEX__DEFAULT__TOPIC: rules-events
       EDGEX__DEFAULT__TYPE: redis
       KUIPER__BASIC__CONSOLELOG: "true"
-      KUIPER__BASIC__RESTPORT: 59720
+      KUIPER__BASIC__RESTPORT: "59720"
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-kuiper
     image: lfedge/ekuiper:1.7-alpine
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59720:59720/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59720
+      published: "59720"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: kuiper:kuiper
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - kuiper-data:/kuiper/data:z
-    - kuiper-connections:/kuiper/etc/connections:z
-    - kuiper-sources:/kuiper/etc/sources:z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: kuiper-data
+      target: /kuiper/data
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: kuiper-connections
+      target: /kuiper/etc/connections
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: kuiper-sources
+      target: /kuiper/etc/sources
+      bind:
+        selinux: z
+      volume: {}
   scheduler:
-    command: /support-scheduler -cp=consul.http://edgex-core-consul:8500 --registry
+    command:
+    - /support-scheduler
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
     container_name: edgex-support-scheduler
     depends_on:
-    - consul
-    - database
-    - secretstore-setup
-    - security-bootstrapper
+      consul:
+        condition: service_started
+      database:
+        condition: service_started
+      secretstore-setup:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/ready_to_run_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
@@ -896,79 +1276,97 @@ services:
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SERVICE_HOST: edgex-support-scheduler
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-support-scheduler
     image: nexus3.edgexfoundry.org:10004/support-scheduler:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59861:59861/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59861
+      published: "59861"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - /tmp/edgex/secrets/support-scheduler:/tmp/edgex/secrets/support-scheduler:ro,z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/support-scheduler
+      target: /tmp/edgex/secrets/support-scheduler
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   secretstore-setup:
     container_name: edgex-security-secretstore-setup
     depends_on:
-    - security-bootstrapper
-    - vault
+      security-bootstrapper:
+        condition: service_started
+      vault:
+        condition: service_started
     environment:
       ADD_KNOWN_SECRETS: redisdb[app-rules-engine],redisdb[app-http-export],redisdb[app-mqtt-export],redisdb[app-scalability-test-mqtt-export],redisdb[device-rest],redisdb[device-virtual]
       ADD_SECRETSTORE_TOKENS: app-http-export,app-mqtt-export,app-functional-tests,app-scalability-test-mqtt-export
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
-      EDGEX_GROUP: '2001'
+      API_GATEWAY_STATUS_PORT: "8100"
+      EDGEX_GROUP: "2001"
       EDGEX_SECURITY_SECRET_STORE: "true"
-      EDGEX_USER: '2002'
+      EDGEX_USER: "2002"
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SECUREMESSAGEBUS_TYPE: redis
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-security-secretstore-setup
     image: nexus3.edgexfoundry.org:10004/security-secretstore-setup:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     read_only: true
     restart: always
     security_opt:
@@ -978,59 +1376,100 @@ services:
     - /vault
     user: root:root
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - /tmp/edgex/secrets:/tmp/edgex/secrets:z
-    - kong:/tmp/kong:z
-    - kuiper-sources:/tmp/kuiper:z
-    - kuiper-connections:/tmp/kuiper-connections:z
-    - vault-config:/vault/config:z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets
+      target: /tmp/edgex/secrets
+      bind:
+        selinux: z
+        create_host_path: true
+    - type: volume
+      source: kong
+      target: /tmp/kong
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: kuiper-sources
+      target: /tmp/kuiper
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: kuiper-connections
+      target: /tmp/kuiper-connections
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: vault-config
+      target: /vault/config
+      bind:
+        selinux: z
+      volume: {}
   security-bootstrapper:
     container_name: edgex-security-bootstrapper
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
-      EDGEX_GROUP: '2001'
-      EDGEX_USER: '2002'
+      API_GATEWAY_STATUS_PORT: "8100"
+      EDGEX_GROUP: "2001"
+      EDGEX_USER: "2002"
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-security-bootstrapper
     image: nexus3.edgexfoundry.org:10004/security-bootstrapper:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: root:root
     volumes:
-    - edgex-init:/edgex-init:z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      bind:
+        selinux: z
+      volume: {}
   security-spiffe-token-provider:
-    command: /security-spiffe-token-provider -cp=consul.http://edgex-core-consul:8500
-      --registry
+    command:
+    - /security-spiffe-token-provider
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
     container_name: edgex-security-spiffe-token-provider
     depends_on:
-    - consul
-    - security-bootstrapper
-    - security-spire-agent
+      consul:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
+      security-spire-agent:
+        condition: service_started
     entrypoint:
     - /edgex-init/ready_to_run_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
@@ -1041,32 +1480,36 @@ services:
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SERVICE_HOST: edgex-security-spiffe-token-provider
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-security-spiffe-token-provider
     image: nexus3.edgexfoundry.org:10004/security-spiffe-token-provider:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59841:59841/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59841
+      published: "59841"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
@@ -1075,19 +1518,36 @@ services:
     - /run
     user: root:root
     volumes:
-    - edgex-init:/edgex-init:z
-    - /tmp/edgex/secrets/security-spiffe-token-provider:/tmp/edgex/secrets/security-spiffe-token-provider:z
-    - /tmp/edgex/secrets/spiffe:/tmp/edgex/secrets/spiffe:z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/spiffe
+      target: /tmp/edgex/secrets/spiffe
+      bind:
+        selinux: z
+        create_host_path: true
+    - type: bind
+      source: /tmp/edgex/secrets/security-spiffe-token-provider
+      target: /tmp/edgex/secrets/security-spiffe-token-provider
+      bind:
+        selinux: z
+        create_host_path: true
   security-spire-agent:
-    command: docker-entrypoint.sh
+    command:
+    - docker-entrypoint.sh
     container_name: edgex-security-spire-agent
     depends_on:
-    - security-spire-server
+      security-spire-server:
+        condition: service_started
     entrypoint:
     - /edgex-init/ready_to_run_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
@@ -1098,29 +1558,29 @@ services:
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-security-spire-agent
     image: nexus3.edgexfoundry.org:10004/security-spire-agent:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     pid: host
     privileged: true
     read_only: true
@@ -1131,21 +1591,47 @@ services:
     - /run
     user: root:root
     volumes:
-    - edgex-init:/edgex-init:z
-    - spire-agent:/srv/spiffe/agent:z
-    - spire-ca:/srv/spiffe/ca:z
-    - /tmp/edgex/secrets/spiffe:/tmp/edgex/secrets/spiffe:z
-    - /var/run/docker.sock:/var/run/docker.sock:rw
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: spire-ca
+      target: /srv/spiffe/ca
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: spire-agent
+      target: /srv/spiffe/agent
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/spiffe
+      target: /tmp/edgex/secrets/spiffe
+      bind:
+        selinux: z
+        create_host_path: true
+    - type: bind
+      source: /var/run/docker.sock
+      target: /var/run/docker.sock
+      bind:
+        create_host_path: true
   security-spire-config:
-    command: docker-entrypoint.sh
+    command:
+    - docker-entrypoint.sh
     container_name: edgex-security-spire-config
     depends_on:
-    - security-spire-agent
+      security-spire-agent:
+        condition: service_started
     entrypoint:
     - /edgex-init/ready_to_run_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
@@ -1156,29 +1642,29 @@ services:
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-security-spire-config
     image: nexus3.edgexfoundry.org:10004/security-spire-config:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     read_only: true
     restart: always
     security_opt:
@@ -1187,18 +1673,30 @@ services:
     - /run
     user: root:root
     volumes:
-    - edgex-init:/edgex-init:z
-    - /tmp/edgex/secrets/spiffe:/tmp/edgex/secrets/spiffe:z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/spiffe
+      target: /tmp/edgex/secrets/spiffe
+      bind:
+        selinux: z
+        create_host_path: true
   security-spire-server:
-    command: docker-entrypoint.sh
+    command:
+    - docker-entrypoint.sh
     container_name: edgex-security-spire-server
     depends_on:
-    - security-bootstrapper
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/ready_to_run_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
@@ -1209,32 +1707,36 @@ services:
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-security-spire-server
     image: nexus3.edgexfoundry.org:10004/security-spire-server:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     pid: host
     ports:
-    - 127.0.0.1:59840:59840/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59840
+      published: "59840"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
@@ -1243,10 +1745,30 @@ services:
     - /run
     user: root:root
     volumes:
-    - edgex-init:/edgex-init:z
-    - spire-ca:/srv/spiffe/ca:z
-    - spire-server:/srv/spiffe/server:z
-    - /tmp/edgex/secrets/spiffe:/tmp/edgex/secrets/spiffe:z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: spire-ca
+      target: /srv/spiffe/ca
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: spire-server
+      target: /srv/spiffe/server
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/spiffe
+      target: /tmp/edgex/secrets/spiffe
+      bind:
+        selinux: z
+        create_host_path: true
   ui:
     container_name: edgex-ui-go
     environment:
@@ -1255,9 +1777,12 @@ services:
     hostname: edgex-ui-go
     image: nexus3.edgexfoundry.org:10004/edgex-ui:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 4000:4000/tcp
+    - mode: ingress
+      target: 4000
+      published: "4000"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
@@ -1266,30 +1791,32 @@ services:
   vault:
     cap_add:
     - IPC_LOCK
-    command: server
+    command:
+    - server
     container_name: edgex-vault
     depends_on:
-    - security-bootstrapper
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/vault_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
       VAULT_ADDR: http://edgex-vault:8200
       VAULT_CONFIG_DIR: /vault/config
@@ -1297,35 +1824,75 @@ services:
     hostname: edgex-vault
     image: vault:1.11.5
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:8200:8200/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 8200
+      published: "8200"
+      protocol: tcp
     restart: always
     tmpfs:
     - /vault/config
     user: root:root
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - vault-file:/vault/file:z
-    - vault-logs:/vault/logs:z
-version: '3.7'
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: vault-file
+      target: /vault/file
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: vault-logs
+      target: /vault/logs
+      bind:
+        selinux: z
+      volume: {}
+networks:
+  edgex-network:
+    name: edgex_edgex-network
+    driver: bridge
 volumes:
-  consul-acl-token: {}
-  consul-config: {}
-  consul-data: {}
-  db-data: {}
-  edgex-init: {}
-  kong: {}
-  kuiper-connections: {}
-  kuiper-data: {}
-  kuiper-sources: {}
-  postgres-config: {}
-  postgres-data: {}
-  redis-config: {}
-  spire-agent: {}
-  spire-ca: {}
-  spire-server: {}
-  vault-config: {}
-  vault-file: {}
-  vault-logs: {}
-
+  consul-acl-token:
+    name: edgex_consul-acl-token
+  consul-config:
+    name: edgex_consul-config
+  consul-data:
+    name: edgex_consul-data
+  db-data:
+    name: edgex_db-data
+  edgex-init:
+    name: edgex_edgex-init
+  kong:
+    name: edgex_kong
+  kuiper-connections:
+    name: edgex_kuiper-connections
+  kuiper-data:
+    name: edgex_kuiper-data
+  kuiper-sources:
+    name: edgex_kuiper-sources
+  postgres-config:
+    name: edgex_postgres-config
+  postgres-data:
+    name: edgex_postgres-data
+  redis-config:
+    name: edgex_redis-config
+  spire-agent:
+    name: edgex_spire-agent
+  spire-ca:
+    name: edgex_spire-ca
+  spire-server:
+    name: edgex_spire-server
+  vault-config:
+    name: edgex_vault-config
+  vault-file:
+    name: edgex_vault-file
+  vault-logs:
+    name: edgex_vault-logs

--- a/taf/docker-compose-taf.yml
+++ b/taf/docker-compose-taf.yml
@@ -24,54 +24,58 @@
 #
 # From the compose-builder folder use `make build` to regenerate all standard compose files variations
 #
-networks:
-  edgex-network:
-    driver: bridge
+name: edgex
 services:
   app-service-external-mqtt-trigger:
-    command: /app-service-configurable -cp=consul.http://edgex-core-consul:8500 --registry
+    command:
+    - /app-service-configurable
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
     container_name: edgex-app-external-mqtt-trigger
     depends_on:
-    - consul
-    - data
-    - security-bootstrapper
+      consul:
+        condition: service_started
+      data:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/ready_to_run_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
       CLIENTS_SUPPORT_NOTIFICATIONS_HOST: edgex-support-notifications
       CLIENTS_SUPPORT_SCHEDULER_HOST: edgex-support-scheduler
-      DATABASES_PRIMARY_HOST: edgex-redis
       DATABASE_HOST: edgex-redis
+      DATABASES_PRIMARY_HOST: edgex-redis
       EDGEX_PROFILE: external-mqtt-trigger
       EDGEX_SECURITY_SECRET_STORE: "true"
       MESSAGEBUS_HOST: edgex-redis
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SERVICE_HOST: edgex-app-external-mqtt-trigger
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
       TRIGGER_EXTERNALMQTT_URL: MQTT_BROKER_ADDRESS_PLACE_HOLDER
       WRITABLE_LOGLEVEL: INFO
@@ -80,180 +84,245 @@ services:
     hostname: edgex-app-external-mqtt-trigger
     image: nexus3.edgexfoundry.org:10004/app-service-configurable:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59706:59706/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59706
+      published: "59706"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - /tmp/edgex/secrets/app-external-mqtt-trigger:/tmp/edgex/secrets/app-external-mqtt-trigger:ro,z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/app-external-mqtt-trigger
+      target: /tmp/edgex/secrets/app-external-mqtt-trigger
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   app-service-functional-tests:
-    command: /app-service-configurable -cp=consul.http://edgex-core-consul:8500 --registry
+    command:
+    - /app-service-configurable
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
     container_name: app-functional-tests
     depends_on:
-    - consul
-    - data
-    - security-bootstrapper
+      consul:
+        condition: service_started
+      data:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/ready_to_run_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
       CLIENTS_SUPPORT_NOTIFICATIONS_HOST: edgex-support-notifications
       CLIENTS_SUPPORT_SCHEDULER_HOST: edgex-support-scheduler
-      DATABASES_PRIMARY_HOST: edgex-redis
       DATABASE_HOST: edgex-redis
+      DATABASES_PRIMARY_HOST: edgex-redis
       EDGEX_PROFILE: functional-tests
       EDGEX_SECURITY_SECRET_STORE: "true"
       MESSAGEBUS_HOST: edgex-redis
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SERVICE_HOST: app-functional-tests
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: app-functional-tests
     image: nexus3.edgexfoundry.org:10004/app-service-configurable:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 59705:59705/tcp
+    - mode: ingress
+      target: 59705
+      published: "59705"
+      protocol: tcp
     read_only: true
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - /tmp/edgex/secrets/app-functional-tests:/tmp/edgex/secrets/app-functional-tests:ro,z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/app-functional-tests
+      target: /tmp/edgex/secrets/app-functional-tests
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   app-service-http-export:
-    command: /app-service-configurable -cp=consul.http://edgex-core-consul:8500 --registry
+    command:
+    - /app-service-configurable
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
     container_name: edgex-app-http-export
     depends_on:
-    - consul
-    - data
-    - security-bootstrapper
+      consul:
+        condition: service_started
+      data:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/ready_to_run_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
       CLIENTS_SUPPORT_NOTIFICATIONS_HOST: edgex-support-notifications
       CLIENTS_SUPPORT_SCHEDULER_HOST: edgex-support-scheduler
-      DATABASES_PRIMARY_HOST: edgex-redis
       DATABASE_HOST: edgex-redis
+      DATABASES_PRIMARY_HOST: edgex-redis
       EDGEX_PROFILE: http-export
       EDGEX_SECURITY_SECRET_STORE: "true"
       MESSAGEBUS_HOST: edgex-redis
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SERVICE_HOST: edgex-app-http-export
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
       WRITABLE_LOGLEVEL: INFO
       WRITABLE_PIPELINE_FUNCTIONS_HTTPEXPORT_PARAMETERS_URL: http://EXPORT_HOST_PLACE_HOLDER:7770
     hostname: edgex-app-http-export
     image: nexus3.edgexfoundry.org:10004/app-service-configurable:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59704:59704/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59704
+      published: "59704"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - /tmp/edgex/secrets/app-http-export:/tmp/edgex/secrets/app-http-export:ro,z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/app-http-export
+      target: /tmp/edgex/secrets/app-http-export
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   app-service-mqtt-export:
-    command: /app-service-configurable -cp=consul.http://edgex-core-consul:8500 --registry
+    command:
+    - /app-service-configurable
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
     container_name: edgex-app-mqtt-export
     depends_on:
-    - consul
-    - data
-    - security-bootstrapper
+      consul:
+        condition: service_started
+      data:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/ready_to_run_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
       CLIENTS_SUPPORT_NOTIFICATIONS_HOST: edgex-support-notifications
       CLIENTS_SUPPORT_SCHEDULER_HOST: edgex-support-scheduler
-      DATABASES_PRIMARY_HOST: edgex-redis
       DATABASE_HOST: edgex-redis
+      DATABASES_PRIMARY_HOST: edgex-redis
       EDGEX_PROFILE: mqtt-export
       EDGEX_SECURITY_SECRET_STORE: "true"
       MESSAGEBUS_HOST: edgex-redis
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SERVICE_HOST: edgex-app-mqtt-export
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
       WRITABLE_LOGLEVEL: INFO
       WRITABLE_PIPELINE_FUNCTIONS_MQTTEXPORT_PARAMETERS_BROKERADDRESS: MQTT_BROKER_ADDRESS_PLACE_HOLDER
@@ -261,29 +330,51 @@ services:
     hostname: edgex-app-mqtt-export
     image: nexus3.edgexfoundry.org:10004/app-service-configurable:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59703:59703/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59703
+      published: "59703"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - /tmp/edgex/secrets/app-mqtt-export:/tmp/edgex/secrets/app-mqtt-export:ro,z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/app-mqtt-export
+      target: /tmp/edgex/secrets/app-mqtt-export
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   app-service-rules:
-    command: /app-service-configurable -cp=consul.http://edgex-core-consul:8500 --registry
+    command:
+    - /app-service-configurable
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
     container_name: edgex-app-rules-engine
     depends_on:
-    - consul
-    - data
-    - security-bootstrapper
+      consul:
+        condition: service_started
+      data:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/ready_to_run_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
@@ -296,113 +387,159 @@ services:
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SERVICE_HOST: edgex-app-rules-engine
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-app-rules-engine
     image: nexus3.edgexfoundry.org:10004/app-service-configurable:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59701:59701/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59701
+      published: "59701"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - /tmp/edgex/secrets/app-rules-engine:/tmp/edgex/secrets/app-rules-engine:ro,z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/app-rules-engine
+      target: /tmp/edgex/secrets/app-rules-engine
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   app-service-sample:
-    command: /app-service-configurable -cp=consul.http://edgex-core-consul:8500 --registry
+    command:
+    - /app-service-configurable
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
     container_name: edgex-app-sample
     depends_on:
-    - consul
-    - data
-    - security-bootstrapper
+      consul:
+        condition: service_started
+      data:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/ready_to_run_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
       CLIENTS_SUPPORT_NOTIFICATIONS_HOST: edgex-support-notifications
       CLIENTS_SUPPORT_SCHEDULER_HOST: edgex-support-scheduler
-      DATABASES_PRIMARY_HOST: edgex-redis
       DATABASE_HOST: edgex-redis
+      DATABASES_PRIMARY_HOST: edgex-redis
       EDGEX_PROFILE: sample
       EDGEX_SECURITY_SECRET_STORE: "true"
       MESSAGEBUS_HOST: edgex-redis
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SERVICE_HOST: edgex-app-sample
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-app-sample
     image: nexus3.edgexfoundry.org:10004/app-service-configurable:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59700:59700/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59700
+      published: "59700"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - /tmp/edgex/secrets/app-sample:/tmp/edgex/secrets/app-sample:ro,z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/app-sample
+      target: /tmp/edgex/secrets/app-sample
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   command:
-    command: /core-command -cp=consul.http://edgex-core-consul:8500 --registry
+    command:
+    - /core-command
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
     container_name: edgex-core-command
     depends_on:
-    - consul
-    - database
-    - metadata
-    - secretstore-setup
-    - security-bootstrapper
+      consul:
+        condition: service_started
+      database:
+        condition: service_started
+      metadata:
+        condition: service_started
+      secretstore-setup:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/ready_to_run_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
@@ -415,110 +552,173 @@ services:
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SERVICE_HOST: edgex-core-command
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-core-command
     image: nexus3.edgexfoundry.org:10004/core-command:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59882:59882/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59882
+      published: "59882"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - /tmp/edgex/secrets/core-command:/tmp/edgex/secrets/core-command:ro,z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/core-command
+      target: /tmp/edgex/secrets/core-command
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   consul:
-    command: agent -ui -bootstrap -server -client 0.0.0.0
+    command:
+    - agent
+    - -ui
+    - -bootstrap
+    - -server
+    - -client
+    - 0.0.0.0
     container_name: edgex-core-consul
     depends_on:
-    - security-bootstrapper
-    - vault
+      security-bootstrapper:
+        condition: service_started
+      vault:
+        condition: service_started
     entrypoint:
     - /edgex-init/consul_wait_install.sh
     environment:
       ADD_REGISTRY_ACL_ROLES: app-http-export,app-mqtt-export,app-functional-tests,app-scalability-test-mqtt-export,app-sample,device-modbus,app-external-mqtt-trigger,device-onvif-camera
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
-      EDGEX_GROUP: '2001'
+      API_GATEWAY_STATUS_PORT: "8100"
+      EDGEX_GROUP: "2001"
       EDGEX_SECURITY_SECRET_STORE: "true"
-      EDGEX_USER: '2002'
+      EDGEX_USER: "2002"
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_ACL_BOOTSTRAPTOKENPATH: /tmp/edgex/secrets/consul-acl-token/bootstrap_token.json
       STAGEGATE_REGISTRY_ACL_MANAGEMENTTOKENPATH: /tmp/edgex/secrets/consul-acl-token/mgmt_token.json
       STAGEGATE_REGISTRY_ACL_SENTINELFILEPATH: /consul/config/consul_acl_done
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-core-consul
     image: consul:1.13
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:8500:8500/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 8500
+      published: "8500"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: root:root
     volumes:
-    - consul-config:/consul/config:z
-    - consul-data:/consul/data:z
-    - edgex-init:/edgex-init:ro,z
-    - consul-acl-token:/tmp/edgex/secrets/consul-acl-token:z
-    - /tmp/edgex/secrets/edgex-consul:/tmp/edgex/secrets/edgex-consul:ro,z
+    - type: volume
+      source: consul-config
+      target: /consul/config
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: consul-data
+      target: /consul/data
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: consul-acl-token
+      target: /tmp/edgex/secrets/consul-acl-token
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/edgex-consul
+      target: /tmp/edgex/secrets/edgex-consul
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   data:
-    command: /core-data -cp=consul.http://edgex-core-consul:8500 --registry
+    command:
+    - /core-data
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
     container_name: edgex-core-data
     depends_on:
-    - consul
-    - database
-    - metadata
-    - secretstore-setup
-    - security-bootstrapper
+      consul:
+        condition: service_started
+      database:
+        condition: service_started
+      metadata:
+        condition: service_started
+      secretstore-setup:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/ready_to_run_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
@@ -530,52 +730,74 @@ services:
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SECRETSTORE_TOKENFILE: /tmp/edgex/secrets/core-data/secrets-token.json
       SERVICE_HOST: edgex-core-data
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-core-data
     image: nexus3.edgexfoundry.org:10004/core-data:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:5563:5563/tcp
-    - 127.0.0.1:59880:59880/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 5563
+      published: "5563"
+      protocol: tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59880
+      published: "59880"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - /tmp/edgex/secrets/core-data:/tmp/edgex/secrets/core-data:ro,z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/core-data
+      target: /tmp/edgex/secrets/core-data
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   database:
     container_name: edgex-redis
     depends_on:
-    - secretstore-setup
-    - security-bootstrapper
+      secretstore-setup:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/redis_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
@@ -588,31 +810,35 @@ services:
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-redis
     image: redis:7.0-alpine
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:6379:6379/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 6379
+      published: "6379"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
@@ -621,24 +847,55 @@ services:
     - /run
     user: root:root
     volumes:
-    - db-data:/data:z
-    - edgex-init:/edgex-init:ro,z
-    - redis-config:/run/redis/conf:z
-    - /tmp/edgex/secrets/security-bootstrapper-redis:/tmp/edgex/secrets/security-bootstrapper-redis:ro,z
+    - type: volume
+      source: db-data
+      target: /data
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: redis-config
+      target: /run/redis/conf
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/security-bootstrapper-redis
+      target: /tmp/edgex/secrets/security-bootstrapper-redis
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   device-modbus:
-    command: /device-modbus -cp=consul.http://edgex-core-consul:8500 --registry --configDir=CONFIG_DIR_PLACE_HOLDER
+    command:
+    - /device-modbus
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
+    - --configDir=CONFIG_DIR_PLACE_HOLDER
     container_name: edgex-device-modbus
     depends_on:
-    - consul
-    - data
-    - metadata
-    - modbus-simulator
-    - security-bootstrapper
+      consul:
+        condition: service_started
+      data:
+        condition: service_started
+      metadata:
+        condition: service_started
+      modbus-simulator:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/ready_to_run_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
@@ -650,54 +907,82 @@ services:
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SERVICE_HOST: edgex-device-modbus
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-device-modbus
     image: nexus3.edgexfoundry.org:10004/device-modbus:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59901:59901/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59901
+      published: "59901"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - /tmp/edgex/secrets/device-modbus:/tmp/edgex/secrets/device-modbus:ro,z
-    - PROFILE_VOLUME_PLACE_HOLDER:CONFIG_DIR_PLACE_HOLDER:z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/device-modbus
+      target: /tmp/edgex/secrets/device-modbus
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
+    - type: bind
+      source: /PROFILE_VOLUME_PLACE_HOLDER
+      target: CONFIG_DIR_PLACE_HOLDER
+      bind:
+        selinux: z
+        create_host_path: true
   device-onvif-camera:
-    command: /device-onvif-camera -cp=consul.http://edgex-core-consul:8500 --registry
+    command:
+    - /device-onvif-camera
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
     container_name: edgex-device-onvif-camera
     depends_on:
-    - consul
-    - data
-    - metadata
-    - security-bootstrapper
+      consul:
+        condition: service_started
+      data:
+        condition: service_started
+      metadata:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/ready_to_run_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
@@ -709,53 +994,76 @@ services:
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SERVICE_HOST: edgex-device-onvif-camera
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-device-onvif-camera
     image: nexus3.edgexfoundry.org:10004/device-onvif-camera:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59984:59984/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59984
+      published: "59984"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - /tmp/edgex/secrets/device-onvif-camera:/tmp/edgex/secrets/device-onvif-camera:ro,z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/device-onvif-camera
+      target: /tmp/edgex/secrets/device-onvif-camera
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   device-rest:
-    command: /device-rest -cp=consul.http://edgex-core-consul:8500 --registry
+    command:
+    - /device-rest
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
     container_name: edgex-device-rest
     depends_on:
-    - consul
-    - data
-    - metadata
-    - security-bootstrapper
+      consul:
+        condition: service_started
+      data:
+        condition: service_started
+      metadata:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/ready_to_run_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
@@ -767,53 +1075,77 @@ services:
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SERVICE_HOST: edgex-device-rest
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-device-rest
     image: nexus3.edgexfoundry.org:10004/device-rest:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59986:59986/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59986
+      published: "59986"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - /tmp/edgex/secrets/device-rest:/tmp/edgex/secrets/device-rest:ro,z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/device-rest
+      target: /tmp/edgex/secrets/device-rest
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   device-virtual:
-    command: /device-virtual -cp=consul.http://edgex-core-consul:8500 --registry --configDir=CONFIG_DIR_PLACE_HOLDER
+    command:
+    - /device-virtual
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
+    - --configDir=CONFIG_DIR_PLACE_HOLDER
     container_name: edgex-device-virtual
     depends_on:
-    - consul
-    - data
-    - metadata
-    - security-bootstrapper
+      consul:
+        condition: service_started
+      data:
+        condition: service_started
+      metadata:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/ready_to_run_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
@@ -825,58 +1157,81 @@ services:
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SERVICE_HOST: edgex-device-virtual
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-device-virtual
     image: nexus3.edgexfoundry.org:10004/device-virtual:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59900:59900/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59900
+      published: "59900"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - /tmp/edgex/secrets/device-virtual:/tmp/edgex/secrets/device-virtual:ro,z
-    - PROFILE_VOLUME_PLACE_HOLDER:CONFIG_DIR_PLACE_HOLDER:z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/device-virtual
+      target: /tmp/edgex/secrets/device-virtual
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
+    - type: bind
+      source: /PROFILE_VOLUME_PLACE_HOLDER
+      target: CONFIG_DIR_PLACE_HOLDER
+      bind:
+        selinux: z
+        create_host_path: true
   kong:
     container_name: edgex-kong
     depends_on:
-    - kong-db
-    - security-bootstrapper
+      kong-db:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/kong_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       KONG_ADMIN_ACCESS_LOG: /dev/stdout
       KONG_ADMIN_ERROR_LOG: /dev/stderr
       KONG_ADMIN_LISTEN: 127.0.0.1:8001, 127.0.0.1:8444 ssl
       KONG_DATABASE: postgres
       KONG_DNS_ORDER: LAST,A,CNAME
-      KONG_DNS_VALID_TTL: '1'
-      KONG_NGINX_WORKER_PROCESSES: '1'
+      KONG_DNS_VALID_TTL: "1"
+      KONG_NGINX_WORKER_PROCESSES: "1"
       KONG_PG_HOST: edgex-kong-db
       KONG_PG_PASSWORD_FILE: /tmp/postgres-config/.pgpassword
       KONG_PROXY_ACCESS_LOG: /dev/stdout
@@ -885,28 +1240,38 @@ services:
       KONG_STATUS_LISTEN: 0.0.0.0:8100
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-kong
     image: kong:2.8
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 8000:8000/tcp
-    - 127.0.0.1:8100:8100/tcp
-    - 8443:8443/tcp
+    - mode: ingress
+      target: 8000
+      published: "8000"
+      protocol: tcp
+    - mode: ingress
+      target: 8443
+      published: "8443"
+      protocol: tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 8100
+      published: "8100"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
@@ -917,50 +1282,77 @@ services:
     tty: true
     user: kong:nogroup
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - /tmp/edgex/secrets/security-proxy-setup:/tmp/edgex/secrets/security-proxy-setup:ro,z
-    - postgres-config:/tmp/postgres-config:z
-    - kong:/usr/local/kong:z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: postgres-config
+      target: /tmp/postgres-config
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: kong
+      target: /usr/local/kong
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/security-proxy-setup
+      target: /tmp/edgex/secrets/security-proxy-setup
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   kong-db:
     container_name: edgex-kong-db
     depends_on:
-    - security-bootstrapper
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/postgres_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       EDGEX_SECURITY_SECRET_STORE: "true"
       POSTGRES_DB: kong
       POSTGRES_PASSWORD_FILE: /tmp/postgres-config/.pgpassword
       POSTGRES_USER: kong
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-kong-db
     image: postgres:13.8-alpine
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:5432:5432/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 5432
+      published: "5432"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
@@ -971,23 +1363,47 @@ services:
     - /run
     user: root:root
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - postgres-config:/tmp/postgres-config:z
-    - postgres-data:/var/lib/postgresql/data:z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: postgres-data
+      target: /var/lib/postgresql/data
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: postgres-config
+      target: /tmp/postgres-config
+      bind:
+        selinux: z
+      volume: {}
   metadata:
-    command: /core-metadata -cp=consul.http://edgex-core-consul:8500 --registry
+    command:
+    - /core-metadata
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
     container_name: edgex-core-metadata
     depends_on:
-    - consul
-    - database
-    - notifications
-    - secretstore-setup
-    - security-bootstrapper
+      consul:
+        condition: service_started
+      database:
+        condition: service_started
+      notifications:
+        condition: service_started
+      secretstore-setup:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/ready_to_run_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
@@ -1000,94 +1416,136 @@ services:
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SERVICE_HOST: edgex-core-metadata
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-core-metadata
     image: nexus3.edgexfoundry.org:10004/core-metadata:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59881:59881/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59881
+      published: "59881"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - /tmp/edgex/secrets/core-metadata:/tmp/edgex/secrets/core-metadata:ro,z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/core-metadata
+      target: /tmp/edgex/secrets/core-metadata
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   modbus-simulator:
     container_name: edgex-modbus-simulator
     hostname: edgex-modbus-simulator
     image: nexus3.edgexfoundry.org:10003/edgex-devops/edgex-modbus-simulator:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:1502:1502/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 1502
+      published: "1502"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
   mqtt-broker:
-    command: /usr/sbin/mosquitto -c /mosquitto-no-auth.conf
+    command:
+    - /usr/sbin/mosquitto
+    - -c
+    - /mosquitto-no-auth.conf
+    - -v
     container_name: edgex-mqtt-broker
     hostname: edgex-mqtt-broker
     image: eclipse-mosquitto:2.0
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:1883:1883/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 1883
+      published: "1883"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
   mqtt-taf-broker:
-    command: /usr/sbin/mosquitto -c /mosquitto-no-auth.conf
+    command:
+    - /usr/sbin/mosquitto
+    - -c
+    - /mosquitto-no-auth.conf
     container_name: edgex-taf-mqtt-broker
     hostname: edgex-taf-mqtt-broker
     image: eclipse-mosquitto:2.0
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:1884:1883/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 1883
+      published: "1884"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
   notifications:
-    command: /support-notifications -cp=consul.http://edgex-core-consul:8500 --registry
+    command:
+    - /support-notifications
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
     container_name: edgex-support-notifications
     depends_on:
-    - consul
-    - database
-    - secretstore-setup
-    - security-bootstrapper
+      consul:
+        condition: service_started
+      database:
+        condition: service_started
+      secretstore-setup:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/ready_to_run_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
@@ -1099,52 +1557,71 @@ services:
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SERVICE_HOST: edgex-support-notifications
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-support-notifications
     image: nexus3.edgexfoundry.org:10004/support-notifications:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59860:59860/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59860
+      published: "59860"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - /tmp/edgex/secrets/support-notifications:/tmp/edgex/secrets/support-notifications:ro,z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/support-notifications
+      target: /tmp/edgex/secrets/support-notifications
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   proxy-setup:
     container_name: edgex-security-proxy-setup
     depends_on:
-    - kong
-    - secretstore-setup
-    - security-bootstrapper
+      kong:
+        condition: service_started
+      secretstore-setup:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/proxy_setup_wait_install.sh
     environment:
       ADD_PROXY_ROUTE: device-modbus.http://edgex-device-modbus:59901
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       EDGEX_SECURITY_SECRET_STORE: "true"
       KONGURL_SERVER: edgex-kong
       PROXY_SETUP_HOST: edgex-security-proxy-setup
@@ -1158,110 +1635,162 @@ services:
       ROUTES_SUPPORT_SCHEDULER_HOST: edgex-support-scheduler
       ROUTES_SYS_MGMT_AGENT_HOST: edgex-sys-mgmt-agent
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-security-proxy-setup
     image: nexus3.edgexfoundry.org:10004/security-proxy-setup:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     read_only: true
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - consul-acl-token:/tmp/edgex/secrets/consul-acl-token:ro,z
-    - /tmp/edgex/secrets/security-proxy-setup:/tmp/edgex/secrets/security-proxy-setup:ro,z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: consul-acl-token
+      target: /tmp/edgex/secrets/consul-acl-token
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/security-proxy-setup
+      target: /tmp/edgex/secrets/security-proxy-setup
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   rulesengine:
     container_name: edgex-kuiper
     depends_on:
-    - database
-    - secretstore-setup
-    - security-bootstrapper
+      database:
+        condition: service_started
+      secretstore-setup:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/kuiper_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
-      CONNECTION__EDGEX__REDISMSGBUS__PORT: 6379
+      API_GATEWAY_STATUS_PORT: "8100"
+      CONNECTION__EDGEX__REDISMSGBUS__PORT: "6379"
       CONNECTION__EDGEX__REDISMSGBUS__PROTOCOL: redis
       CONNECTION__EDGEX__REDISMSGBUS__SERVER: edgex-redis
       CONNECTION__EDGEX__REDISMSGBUS__TYPE: redis
-      EDGEX__DEFAULT__PORT: 6379
+      EDGEX__DEFAULT__PORT: "6379"
       EDGEX__DEFAULT__PROTOCOL: redis
       EDGEX__DEFAULT__SERVER: edgex-redis
       EDGEX__DEFAULT__TOPIC: rules-events
       EDGEX__DEFAULT__TYPE: redis
       KUIPER__BASIC__CONSOLELOG: "true"
-      KUIPER__BASIC__RESTPORT: 59720
+      KUIPER__BASIC__RESTPORT: "59720"
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-kuiper
     image: lfedge/ekuiper:1.7-alpine
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59720:59720/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59720
+      published: "59720"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: kuiper:kuiper
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - kuiper-data:/kuiper/data:z
-    - kuiper-connections:/kuiper/etc/connections:z
-    - kuiper-sources:/kuiper/etc/sources:z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: kuiper-data
+      target: /kuiper/data
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: kuiper-connections
+      target: /kuiper/etc/connections
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: kuiper-sources
+      target: /kuiper/etc/sources
+      bind:
+        selinux: z
+      volume: {}
   scalability-test-mqtt-export:
-    command: /app-service-configurable -cp=consul.http://edgex-core-consul:8500 --registry
+    command:
+    - /app-service-configurable
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
     container_name: edgex-scalability-test-mqtt-export
     depends_on:
-    - consul
-    - data
-    - security-bootstrapper
+      consul:
+        condition: service_started
+      data:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/ready_to_run_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
       CLIENTS_SUPPORT_NOTIFICATIONS_HOST: edgex-support-notifications
       CLIENTS_SUPPORT_SCHEDULER_HOST: edgex-support-scheduler
-      DATABASES_PRIMARY_HOST: edgex-redis
       DATABASE_HOST: edgex-redis
+      DATABASES_PRIMARY_HOST: edgex-redis
       EDGEX_PROFILE: mqtt-export
       EDGEX_SECURITY_SECRET_STORE: "true"
       EDGEX_SERVICE_KEY: app-scalability-test-mqtt-export
@@ -1271,26 +1800,26 @@ services:
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault
       SECRETSTORE_PATH: /app-scalability-test-mqtt-export
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SECRETSTORE_TOKENFILE: /tmp/edgex/secrets/app-scalability-test-mqtt-export/secrets-token.json
       SERVICE_HOST: edgex-scalability-test-mqtt-export
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
       WRITABLE_LOGLEVEL: DEBUG
       WRITABLE_PIPELINE_FUNCTIONS_MQTTEXPORT_PARAMETERS_BROKERADDRESS: MQTT_BROKER_ADDRESS_PLACE_HOLDER
@@ -1299,29 +1828,51 @@ services:
     hostname: edgex-scalability-test-mqtt-export
     image: nexus3.edgexfoundry.org:10004/app-service-configurable:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 59710:59703/tcp
+    - mode: ingress
+      target: 59703
+      published: "59710"
+      protocol: tcp
     read_only: true
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - /tmp/edgex/secrets/app-scalability-test-mqtt-export:/tmp/edgex/secrets/app-scalability-test-mqtt-export:ro,z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/app-scalability-test-mqtt-export
+      target: /tmp/edgex/secrets/app-scalability-test-mqtt-export
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   scheduler:
-    command: /support-scheduler -cp=consul.http://edgex-core-consul:8500 --registry
+    command:
+    - /support-scheduler
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
     container_name: edgex-support-scheduler
     depends_on:
-    - consul
-    - database
-    - secretstore-setup
-    - security-bootstrapper
+      consul:
+        condition: service_started
+      database:
+        condition: service_started
+      secretstore-setup:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/ready_to_run_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
@@ -1335,79 +1886,97 @@ services:
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SERVICE_HOST: edgex-support-scheduler
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-support-scheduler
     image: nexus3.edgexfoundry.org:10004/support-scheduler:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59861:59861/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59861
+      published: "59861"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - /tmp/edgex/secrets/support-scheduler:/tmp/edgex/secrets/support-scheduler:ro,z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/support-scheduler
+      target: /tmp/edgex/secrets/support-scheduler
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   secretstore-setup:
     container_name: edgex-security-secretstore-setup
     depends_on:
-    - security-bootstrapper
-    - vault
+      security-bootstrapper:
+        condition: service_started
+      vault:
+        condition: service_started
     environment:
       ADD_KNOWN_SECRETS: redisdb[app-rules-engine],redisdb[app-http-export],redisdb[app-mqtt-export],redisdb[app-scalability-test-mqtt-export],redisdb[app-sample],redisdb[device-modbus],redisdb[device-rest],redisdb[device-virtual],redisdb[device-onvif-camera],message-bus[app-rules-engine],message-bus[app-http-export],message-bus[app-mqtt-export],message-bus[app-external-mqtt-trigger],message-bus[app-scalability-test-mqtt-export],message-bus[app-sample],message-bus[device-modbus],message-bus[device-rest],message-bus[device-virtual],message-bus[device-onvif-camera]
       ADD_SECRETSTORE_TOKENS: app-http-export,app-mqtt-export,app-functional-tests,app-scalability-test-mqtt-export,app-sample,device-modbus,app-external-mqtt-trigger,device-onvif-camera
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
-      EDGEX_GROUP: '2001'
+      API_GATEWAY_STATUS_PORT: "8100"
+      EDGEX_GROUP: "2001"
       EDGEX_SECURITY_SECRET_STORE: "true"
-      EDGEX_USER: '2002'
+      EDGEX_USER: "2002"
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SECUREMESSAGEBUS_TYPE: redis
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-security-secretstore-setup
     image: nexus3.edgexfoundry.org:10004/security-secretstore-setup:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     read_only: true
     restart: always
     security_opt:
@@ -1417,59 +1986,100 @@ services:
     - /vault
     user: root:root
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - /tmp/edgex/secrets:/tmp/edgex/secrets:z
-    - kong:/tmp/kong:z
-    - kuiper-sources:/tmp/kuiper:z
-    - kuiper-connections:/tmp/kuiper-connections:z
-    - vault-config:/vault/config:z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets
+      target: /tmp/edgex/secrets
+      bind:
+        selinux: z
+        create_host_path: true
+    - type: volume
+      source: kong
+      target: /tmp/kong
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: kuiper-sources
+      target: /tmp/kuiper
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: kuiper-connections
+      target: /tmp/kuiper-connections
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: vault-config
+      target: /vault/config
+      bind:
+        selinux: z
+      volume: {}
   security-bootstrapper:
     container_name: edgex-security-bootstrapper
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
-      EDGEX_GROUP: '2001'
-      EDGEX_USER: '2002'
+      API_GATEWAY_STATUS_PORT: "8100"
+      EDGEX_GROUP: "2001"
+      EDGEX_USER: "2002"
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-security-bootstrapper
     image: nexus3.edgexfoundry.org:10004/security-bootstrapper:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
     user: root:root
     volumes:
-    - edgex-init:/edgex-init:z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      bind:
+        selinux: z
+      volume: {}
   security-spiffe-token-provider:
-    command: /security-spiffe-token-provider -cp=consul.http://edgex-core-consul:8500
-      --registry
+    command:
+    - /security-spiffe-token-provider
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
     container_name: edgex-security-spiffe-token-provider
     depends_on:
-    - consul
-    - security-bootstrapper
-    - security-spire-agent
+      consul:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
+      security-spire-agent:
+        condition: service_started
     entrypoint:
     - /edgex-init/ready_to_run_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
@@ -1480,32 +2090,36 @@ services:
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SERVICE_HOST: edgex-security-spiffe-token-provider
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-security-spiffe-token-provider
     image: nexus3.edgexfoundry.org:10004/security-spiffe-token-provider:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:59841:59841/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59841
+      published: "59841"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
@@ -1514,19 +2128,36 @@ services:
     - /run
     user: root:root
     volumes:
-    - edgex-init:/edgex-init:z
-    - /tmp/edgex/secrets/security-spiffe-token-provider:/tmp/edgex/secrets/security-spiffe-token-provider:z
-    - /tmp/edgex/secrets/spiffe:/tmp/edgex/secrets/spiffe:z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/spiffe
+      target: /tmp/edgex/secrets/spiffe
+      bind:
+        selinux: z
+        create_host_path: true
+    - type: bind
+      source: /tmp/edgex/secrets/security-spiffe-token-provider
+      target: /tmp/edgex/secrets/security-spiffe-token-provider
+      bind:
+        selinux: z
+        create_host_path: true
   security-spire-agent:
-    command: docker-entrypoint.sh
+    command:
+    - docker-entrypoint.sh
     container_name: edgex-security-spire-agent
     depends_on:
-    - security-spire-server
+      security-spire-server:
+        condition: service_started
     entrypoint:
     - /edgex-init/ready_to_run_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
@@ -1537,29 +2168,29 @@ services:
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-security-spire-agent
     image: nexus3.edgexfoundry.org:10004/security-spire-agent:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     pid: host
     privileged: true
     read_only: true
@@ -1570,21 +2201,47 @@ services:
     - /run
     user: root:root
     volumes:
-    - edgex-init:/edgex-init:z
-    - spire-agent:/srv/spiffe/agent:z
-    - spire-ca:/srv/spiffe/ca:z
-    - /tmp/edgex/secrets/spiffe:/tmp/edgex/secrets/spiffe:z
-    - /var/run/docker.sock:/var/run/docker.sock:rw
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: spire-ca
+      target: /srv/spiffe/ca
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: spire-agent
+      target: /srv/spiffe/agent
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/spiffe
+      target: /tmp/edgex/secrets/spiffe
+      bind:
+        selinux: z
+        create_host_path: true
+    - type: bind
+      source: /var/run/docker.sock
+      target: /var/run/docker.sock
+      bind:
+        create_host_path: true
   security-spire-config:
-    command: docker-entrypoint.sh
+    command:
+    - docker-entrypoint.sh
     container_name: edgex-security-spire-config
     depends_on:
-    - security-spire-agent
+      security-spire-agent:
+        condition: service_started
     entrypoint:
     - /edgex-init/ready_to_run_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
@@ -1595,29 +2252,29 @@ services:
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-security-spire-config
     image: nexus3.edgexfoundry.org:10004/security-spire-config:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     read_only: true
     restart: always
     security_opt:
@@ -1626,18 +2283,30 @@ services:
     - /run
     user: root:root
     volumes:
-    - edgex-init:/edgex-init:z
-    - /tmp/edgex/secrets/spiffe:/tmp/edgex/secrets/spiffe:z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/spiffe
+      target: /tmp/edgex/secrets/spiffe
+      bind:
+        selinux: z
+        create_host_path: true
   security-spire-server:
-    command: docker-entrypoint.sh
+    command:
+    - docker-entrypoint.sh
     container_name: edgex-security-spire-server
     depends_on:
-    - security-bootstrapper
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/ready_to_run_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
       CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
@@ -1648,32 +2317,36 @@ services:
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault
-      SECRETSTORE_PORT: '8200'
+      SECRETSTORE_PORT: "8200"
       SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
       SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
       SPIFFE_TRUSTDOMAIN: edgexfoundry.org
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-security-spire-server
     image: nexus3.edgexfoundry.org:10004/security-spire-server:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     pid: host
     ports:
-    - 127.0.0.1:59840:59840/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59840
+      published: "59840"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
@@ -1682,10 +2355,30 @@ services:
     - /run
     user: root:root
     volumes:
-    - edgex-init:/edgex-init:z
-    - spire-ca:/srv/spiffe/ca:z
-    - spire-server:/srv/spiffe/server:z
-    - /tmp/edgex/secrets/spiffe:/tmp/edgex/secrets/spiffe:z
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: spire-ca
+      target: /srv/spiffe/ca
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: spire-server
+      target: /srv/spiffe/server
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/spiffe
+      target: /tmp/edgex/secrets/spiffe
+      bind:
+        selinux: z
+        create_host_path: true
   ui:
     container_name: edgex-ui-go
     environment:
@@ -1694,9 +2387,12 @@ services:
     hostname: edgex-ui-go
     image: nexus3.edgexfoundry.org:10004/edgex-ui:latest
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 4000:4000/tcp
+    - mode: ingress
+      target: 4000
+      published: "4000"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
@@ -1705,30 +2401,32 @@ services:
   vault:
     cap_add:
     - IPC_LOCK
-    command: server
+    command:
+    - server
     container_name: edgex-vault
     depends_on:
-    - security-bootstrapper
+      security-bootstrapper:
+        condition: service_started
     entrypoint:
     - /edgex-init/vault_wait_install.sh
     environment:
       API_GATEWAY_HOST: edgex-kong
-      API_GATEWAY_STATUS_PORT: '8100'
+      API_GATEWAY_STATUS_PORT: "8100"
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: '54321'
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: '6379'
-      STAGEGATE_DATABASE_READYPORT: '6379'
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
       STAGEGATE_KONGDB_HOST: edgex-kong-db
-      STAGEGATE_KONGDB_PORT: '5432'
-      STAGEGATE_KONGDB_READYPORT: '54325'
-      STAGEGATE_READY_TORUNPORT: '54329'
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
       STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: '8500'
-      STAGEGATE_REGISTRY_READYPORT: '54324'
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: '54322'
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
       VAULT_ADDR: http://edgex-vault:8200
       VAULT_CONFIG_DIR: /vault/config
@@ -1736,36 +2434,75 @@ services:
     hostname: edgex-vault
     image: vault:1.11.5
     networks:
-      edgex-network: {}
+      edgex-network: null
     ports:
-    - 127.0.0.1:8200:8200/tcp
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 8200
+      published: "8200"
+      protocol: tcp
     restart: always
     tmpfs:
     - /vault/config
     user: root:root
     volumes:
-    - edgex-init:/edgex-init:ro,z
-    - vault-file:/vault/file:z
-    - vault-logs:/vault/logs:z
-version: '3.7'
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: vault-file
+      target: /vault/file
+      bind:
+        selinux: z
+      volume: {}
+    - type: volume
+      source: vault-logs
+      target: /vault/logs
+      bind:
+        selinux: z
+      volume: {}
+networks:
+  edgex-network:
+    name: edgex_edgex-network
+    driver: bridge
 volumes:
-  PROFILE_VOLUME_PLACE_HOLDER: {}
-  consul-acl-token: {}
-  consul-config: {}
-  consul-data: {}
-  db-data: {}
-  edgex-init: {}
-  kong: {}
-  kuiper-connections: {}
-  kuiper-data: {}
-  kuiper-sources: {}
-  postgres-config: {}
-  postgres-data: {}
-  redis-config: {}
-  spire-agent: {}
-  spire-ca: {}
-  spire-server: {}
-  vault-config: {}
-  vault-file: {}
-  vault-logs: {}
-
+  consul-acl-token:
+    name: edgex_consul-acl-token
+  consul-config:
+    name: edgex_consul-config
+  consul-data:
+    name: edgex_consul-data
+  db-data:
+    name: edgex_db-data
+  edgex-init:
+    name: edgex_edgex-init
+  kong:
+    name: edgex_kong
+  kuiper-connections:
+    name: edgex_kuiper-connections
+  kuiper-data:
+    name: edgex_kuiper-data
+  kuiper-sources:
+    name: edgex_kuiper-sources
+  postgres-config:
+    name: edgex_postgres-config
+  postgres-data:
+    name: edgex_postgres-data
+  redis-config:
+    name: edgex_redis-config
+  spire-agent:
+    name: edgex_spire-agent
+  spire-ca:
+    name: edgex_spire-ca
+  spire-server:
+    name: edgex_spire-server
+  vault-config:
+    name: edgex_vault-config
+  vault-file:
+    name: edgex_vault-file
+  vault-logs:
+    name: edgex_vault-logs

--- a/taf/docker-compose-taf.yml
+++ b/taf/docker-compose-taf.yml
@@ -1488,7 +1488,6 @@ services:
     - /usr/sbin/mosquitto
     - -c
     - /mosquitto-no-auth.conf
-    - -v
     container_name: edgex-mqtt-broker
     hostname: edgex-mqtt-broker
     image: eclipse-mosquitto:2.0


### PR DESCRIPTION
 BREAKING CHANGE: Old docker-compose tool no longer supported. Must use docker compose CLI command. See README for details.

closes #315

Signed-off-by: Leonard Goodell <leonard.goodell@intel.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-compose/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-compose/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  **TBD**


## Testing Instructions
<!-- How can the reviewers test your change? -->
