### PR TITLE
fix: Move GPIO service to approved documented port

### DIFF
--- a/compose-builder/add-device-gpio.yml
+++ b/compose-builder/add-device-gpio.yml
@@ -31,6 +31,7 @@ services:
       - device-common.env
     environment:
       SERVICE_HOST: edgex-device-gpio
+      SERVICE_PORT: "59994"
     depends_on:
       - consul
       - data


### PR DESCRIPTION
Signed-off-by: Bryon Nevis <bryon.nevis@intel.com>

This PR brings device-gpio in line with the documented, approved port number, 59994 instead of 59910.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [X] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>


## Testing Instructions
```
make run ds-gpio (in compose-builder)
curl -ki http://localhost:59994/api/v2/ping
```
