### PR TITLE
fix!: Use new --configDir option (replaces --confdir)

### DIFF
--- a/compose-builder/.env
+++ b/compose-builder/.env
@@ -52,4 +52,4 @@ NATS_VERSION=2.9-alpine
 EDGEX_USER=2002
 EDGEX_GROUP=2001
 
-DEFAULT_EDGEX_RUN_CMD_PARMS="-cp=consul.http://edgex-core-consul:8500 --registry --confdir=/res"
+DEFAULT_EDGEX_RUN_CMD_PARMS="-cp=consul.http://edgex-core-consul:8500 --registry --configDir=/res"

--- a/compose-builder/Makefile
+++ b/compose-builder/Makefile
@@ -822,9 +822,9 @@ ifeq (taf-secty, $(filter taf-secty,$(ARGS)))
 	# taf has its special place holder from taf-device-services-mods and thus we need to keep it
 	# and extend security related things on top of it
 	ds_virtual_ext:= $(shell GEN_EXT_DIR="$(GEN_EXT_DIR)" ./gen_secure_compose_ext.sh device-virtual \
-		device-virtual device-virtual ' -cp=consul.http:\/\/edgex-core-consul:8500 --registry --confdir=CONF_DIR_PLACE_HOLDER')
+		device-virtual device-virtual ' -cp=consul.http:\/\/edgex-core-consul:8500 --registry --configDir=CONF_DIR_PLACE_HOLDER')
 	ds_modbus_ext:= $(shell GEN_EXT_DIR="$(GEN_EXT_DIR)" ./gen_secure_compose_ext.sh device-modbus \
-		device-modbus device-modbus ' -cp=consul.http:\/\/edgex-core-consul:8500 --registry --confdir=CONF_DIR_PLACE_HOLDER')
+		device-modbus device-modbus ' -cp=consul.http:\/\/edgex-core-consul:8500 --registry --configDir=CONF_DIR_PLACE_HOLDER')
 	ds_camera_ext:= $(shell GEN_EXT_DIR="$(GEN_EXT_DIR)" ./gen_secure_compose_ext.sh device-onvif-camera)
 	COMPOSE_FILES:=$(COMPOSE_FILES) -f $(asc_http_export_ext) -f $(asc_mqtt_export_ext) -f $(asc_external_mqtt_trigger_ext) -f $(scalability_mqtt_export_ext) -f $(asc_sample_ext)
 	COMPOSE_FILES:=$(COMPOSE_FILES) -f $(ds_virtual_ext) -f $(ds_rest_ext) -f $(ds_modbus_ext) -f $(ds_camera_ext)

--- a/compose-builder/add-delayed-start-services.yml
+++ b/compose-builder/add-delayed-start-services.yml
@@ -113,7 +113,7 @@ services:
     image: ${CORE_EDGEX_REPOSITORY}/security-spiffe-token-provider${ARCH}:${CORE_EDGEX_VERSION}
     entrypoint:
       - /edgex-init/ready_to_run_wait_install.sh
-    command: /security-spiffe-token-provider -cp=consul.http://edgex-core-consul:8500 --registry --confdir=/res
+    command: /security-spiffe-token-provider -cp=consul.http://edgex-core-consul:8500 --registry --configDir=/res
     user: "root:root"
     container_name: edgex-security-spiffe-token-provider
     hostname: edgex-security-spiffe-token-provider

--- a/compose-builder/add-taf-device-services-mods.yml
+++ b/compose-builder/add-taf-device-services-mods.yml
@@ -19,12 +19,12 @@ volumes:
 
 services:
   device-virtual:
-    command: "-cp=consul.http://edgex-core-consul:8500 --registry --confdir=CONF_DIR_PLACE_HOLDER"
+    command: "-cp=consul.http://edgex-core-consul:8500 --registry --configDir=CONF_DIR_PLACE_HOLDER"
     volumes:
       - PROFILE_VOLUME_PLACE_HOLDER:CONF_DIR_PLACE_HOLDER:z
 
   device-modbus:
-    command: "-cp=consul.http://edgex-core-consul:8500 --registry --confdir=CONF_DIR_PLACE_HOLDER"
+    command: "-cp=consul.http://edgex-core-consul:8500 --registry --configDir=CONF_DIR_PLACE_HOLDER"
     volumes:
       - PROFILE_VOLUME_PLACE_HOLDER:CONF_DIR_PLACE_HOLDER:z
     depends_on:

--- a/docker-compose-arm64.yml
+++ b/docker-compose-arm64.yml
@@ -30,7 +30,7 @@ networks:
 services:
   app-service-rules:
     command: /app-service-configurable -cp=consul.http://edgex-core-consul:8500 --registry
-      --confdir=/res
+      --configDir=/res
     container_name: edgex-app-rules-engine
     depends_on:
     - consul
@@ -89,7 +89,7 @@ services:
     - edgex-init:/edgex-init:ro,z
     - /tmp/edgex/secrets/app-rules-engine:/tmp/edgex/secrets/app-rules-engine:ro,z
   command:
-    command: /core-command -cp=consul.http://edgex-core-consul:8500 --registry --confdir=/res
+    command: /core-command -cp=consul.http://edgex-core-consul:8500 --registry --configDir=/res
     container_name: edgex-core-command
     depends_on:
     - consul
@@ -205,7 +205,7 @@ services:
     - consul-acl-token:/tmp/edgex/secrets/consul-acl-token:z
     - /tmp/edgex/secrets/edgex-consul:/tmp/edgex/secrets/edgex-consul:ro,z
   data:
-    command: /core-data -cp=consul.http://edgex-core-consul:8500 --registry --confdir=/res
+    command: /core-data -cp=consul.http://edgex-core-consul:8500 --registry --configDir=/res
     container_name: edgex-core-data
     depends_on:
     - consul
@@ -325,7 +325,7 @@ services:
     - redis-config:/run/redis/conf:z
     - /tmp/edgex/secrets/security-bootstrapper-redis:/tmp/edgex/secrets/security-bootstrapper-redis:ro,z
   device-rest:
-    command: /device-rest -cp=consul.http://edgex-core-consul:8500 --registry --confdir=/res
+    command: /device-rest -cp=consul.http://edgex-core-consul:8500 --registry --configDir=/res
     container_name: edgex-device-rest
     depends_on:
     - consul
@@ -383,7 +383,7 @@ services:
     - edgex-init:/edgex-init:ro,z
     - /tmp/edgex/secrets/device-rest:/tmp/edgex/secrets/device-rest:ro,z
   device-virtual:
-    command: /device-virtual -cp=consul.http://edgex-core-consul:8500 --registry --confdir=/res
+    command: /device-virtual -cp=consul.http://edgex-core-consul:8500 --registry --configDir=/res
     container_name: edgex-device-virtual
     depends_on:
     - consul
@@ -555,7 +555,7 @@ services:
     - postgres-config:/tmp/postgres-config:z
     - postgres-data:/var/lib/postgresql/data:z
   metadata:
-    command: /core-metadata -cp=consul.http://edgex-core-consul:8500 --registry --confdir=/res
+    command: /core-metadata -cp=consul.http://edgex-core-consul:8500 --registry --configDir=/res
     container_name: edgex-core-metadata
     depends_on:
     - consul
@@ -616,7 +616,7 @@ services:
     - /tmp/edgex/secrets/core-metadata:/tmp/edgex/secrets/core-metadata:ro,z
   notifications:
     command: /support-notifications -cp=consul.http://edgex-core-consul:8500 --registry
-      --confdir=/res
+      --configDir=/res
     container_name: edgex-support-notifications
     depends_on:
     - consul
@@ -785,7 +785,7 @@ services:
     - kuiper-sources:/kuiper/etc/sources:z
   scheduler:
     command: /support-scheduler -cp=consul.http://edgex-core-consul:8500 --registry
-      --confdir=/res
+      --configDir=/res
     container_name: edgex-support-scheduler
     depends_on:
     - consul

--- a/docker-compose-with-app-sample-arm64.yml
+++ b/docker-compose-with-app-sample-arm64.yml
@@ -30,7 +30,7 @@ networks:
 services:
   app-service-rules:
     command: /app-service-configurable -cp=consul.http://edgex-core-consul:8500 --registry
-      --confdir=/res
+      --configDir=/res
     container_name: edgex-app-rules-engine
     depends_on:
     - consul
@@ -90,7 +90,7 @@ services:
     - /tmp/edgex/secrets/app-rules-engine:/tmp/edgex/secrets/app-rules-engine:ro,z
   app-service-sample:
     command: /app-service-configurable -cp=consul.http://edgex-core-consul:8500 --registry
-      --confdir=/res
+      --configDir=/res
     container_name: edgex-app-sample
     depends_on:
     - consul
@@ -150,7 +150,7 @@ services:
     - edgex-init:/edgex-init:ro,z
     - /tmp/edgex/secrets/app-sample:/tmp/edgex/secrets/app-sample:ro,z
   command:
-    command: /core-command -cp=consul.http://edgex-core-consul:8500 --registry --confdir=/res
+    command: /core-command -cp=consul.http://edgex-core-consul:8500 --registry --configDir=/res
     container_name: edgex-core-command
     depends_on:
     - consul
@@ -266,7 +266,7 @@ services:
     - consul-acl-token:/tmp/edgex/secrets/consul-acl-token:z
     - /tmp/edgex/secrets/edgex-consul:/tmp/edgex/secrets/edgex-consul:ro,z
   data:
-    command: /core-data -cp=consul.http://edgex-core-consul:8500 --registry --confdir=/res
+    command: /core-data -cp=consul.http://edgex-core-consul:8500 --registry --configDir=/res
     container_name: edgex-core-data
     depends_on:
     - consul
@@ -386,7 +386,7 @@ services:
     - redis-config:/run/redis/conf:z
     - /tmp/edgex/secrets/security-bootstrapper-redis:/tmp/edgex/secrets/security-bootstrapper-redis:ro,z
   device-rest:
-    command: /device-rest -cp=consul.http://edgex-core-consul:8500 --registry --confdir=/res
+    command: /device-rest -cp=consul.http://edgex-core-consul:8500 --registry --configDir=/res
     container_name: edgex-device-rest
     depends_on:
     - consul
@@ -444,7 +444,7 @@ services:
     - edgex-init:/edgex-init:ro,z
     - /tmp/edgex/secrets/device-rest:/tmp/edgex/secrets/device-rest:ro,z
   device-virtual:
-    command: /device-virtual -cp=consul.http://edgex-core-consul:8500 --registry --confdir=/res
+    command: /device-virtual -cp=consul.http://edgex-core-consul:8500 --registry --configDir=/res
     container_name: edgex-device-virtual
     depends_on:
     - consul
@@ -616,7 +616,7 @@ services:
     - postgres-config:/tmp/postgres-config:z
     - postgres-data:/var/lib/postgresql/data:z
   metadata:
-    command: /core-metadata -cp=consul.http://edgex-core-consul:8500 --registry --confdir=/res
+    command: /core-metadata -cp=consul.http://edgex-core-consul:8500 --registry --configDir=/res
     container_name: edgex-core-metadata
     depends_on:
     - consul
@@ -677,7 +677,7 @@ services:
     - /tmp/edgex/secrets/core-metadata:/tmp/edgex/secrets/core-metadata:ro,z
   notifications:
     command: /support-notifications -cp=consul.http://edgex-core-consul:8500 --registry
-      --confdir=/res
+      --configDir=/res
     container_name: edgex-support-notifications
     depends_on:
     - consul
@@ -846,7 +846,7 @@ services:
     - kuiper-sources:/kuiper/etc/sources:z
   scheduler:
     command: /support-scheduler -cp=consul.http://edgex-core-consul:8500 --registry
-      --confdir=/res
+      --configDir=/res
     container_name: edgex-support-scheduler
     depends_on:
     - consul

--- a/docker-compose-with-app-sample.yml
+++ b/docker-compose-with-app-sample.yml
@@ -30,7 +30,7 @@ networks:
 services:
   app-service-rules:
     command: /app-service-configurable -cp=consul.http://edgex-core-consul:8500 --registry
-      --confdir=/res
+      --configDir=/res
     container_name: edgex-app-rules-engine
     depends_on:
     - consul
@@ -90,7 +90,7 @@ services:
     - /tmp/edgex/secrets/app-rules-engine:/tmp/edgex/secrets/app-rules-engine:ro,z
   app-service-sample:
     command: /app-service-configurable -cp=consul.http://edgex-core-consul:8500 --registry
-      --confdir=/res
+      --configDir=/res
     container_name: edgex-app-sample
     depends_on:
     - consul
@@ -150,7 +150,7 @@ services:
     - edgex-init:/edgex-init:ro,z
     - /tmp/edgex/secrets/app-sample:/tmp/edgex/secrets/app-sample:ro,z
   command:
-    command: /core-command -cp=consul.http://edgex-core-consul:8500 --registry --confdir=/res
+    command: /core-command -cp=consul.http://edgex-core-consul:8500 --registry --configDir=/res
     container_name: edgex-core-command
     depends_on:
     - consul
@@ -266,7 +266,7 @@ services:
     - consul-acl-token:/tmp/edgex/secrets/consul-acl-token:z
     - /tmp/edgex/secrets/edgex-consul:/tmp/edgex/secrets/edgex-consul:ro,z
   data:
-    command: /core-data -cp=consul.http://edgex-core-consul:8500 --registry --confdir=/res
+    command: /core-data -cp=consul.http://edgex-core-consul:8500 --registry --configDir=/res
     container_name: edgex-core-data
     depends_on:
     - consul
@@ -386,7 +386,7 @@ services:
     - redis-config:/run/redis/conf:z
     - /tmp/edgex/secrets/security-bootstrapper-redis:/tmp/edgex/secrets/security-bootstrapper-redis:ro,z
   device-rest:
-    command: /device-rest -cp=consul.http://edgex-core-consul:8500 --registry --confdir=/res
+    command: /device-rest -cp=consul.http://edgex-core-consul:8500 --registry --configDir=/res
     container_name: edgex-device-rest
     depends_on:
     - consul
@@ -444,7 +444,7 @@ services:
     - edgex-init:/edgex-init:ro,z
     - /tmp/edgex/secrets/device-rest:/tmp/edgex/secrets/device-rest:ro,z
   device-virtual:
-    command: /device-virtual -cp=consul.http://edgex-core-consul:8500 --registry --confdir=/res
+    command: /device-virtual -cp=consul.http://edgex-core-consul:8500 --registry --configDir=/res
     container_name: edgex-device-virtual
     depends_on:
     - consul
@@ -616,7 +616,7 @@ services:
     - postgres-config:/tmp/postgres-config:z
     - postgres-data:/var/lib/postgresql/data:z
   metadata:
-    command: /core-metadata -cp=consul.http://edgex-core-consul:8500 --registry --confdir=/res
+    command: /core-metadata -cp=consul.http://edgex-core-consul:8500 --registry --configDir=/res
     container_name: edgex-core-metadata
     depends_on:
     - consul
@@ -677,7 +677,7 @@ services:
     - /tmp/edgex/secrets/core-metadata:/tmp/edgex/secrets/core-metadata:ro,z
   notifications:
     command: /support-notifications -cp=consul.http://edgex-core-consul:8500 --registry
-      --confdir=/res
+      --configDir=/res
     container_name: edgex-support-notifications
     depends_on:
     - consul
@@ -846,7 +846,7 @@ services:
     - kuiper-sources:/kuiper/etc/sources:z
   scheduler:
     command: /support-scheduler -cp=consul.http://edgex-core-consul:8500 --registry
-      --confdir=/res
+      --configDir=/res
     container_name: edgex-support-scheduler
     depends_on:
     - consul

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,7 +30,7 @@ networks:
 services:
   app-service-rules:
     command: /app-service-configurable -cp=consul.http://edgex-core-consul:8500 --registry
-      --confdir=/res
+      --configDir=/res
     container_name: edgex-app-rules-engine
     depends_on:
     - consul
@@ -89,7 +89,7 @@ services:
     - edgex-init:/edgex-init:ro,z
     - /tmp/edgex/secrets/app-rules-engine:/tmp/edgex/secrets/app-rules-engine:ro,z
   command:
-    command: /core-command -cp=consul.http://edgex-core-consul:8500 --registry --confdir=/res
+    command: /core-command -cp=consul.http://edgex-core-consul:8500 --registry --configDir=/res
     container_name: edgex-core-command
     depends_on:
     - consul
@@ -205,7 +205,7 @@ services:
     - consul-acl-token:/tmp/edgex/secrets/consul-acl-token:z
     - /tmp/edgex/secrets/edgex-consul:/tmp/edgex/secrets/edgex-consul:ro,z
   data:
-    command: /core-data -cp=consul.http://edgex-core-consul:8500 --registry --confdir=/res
+    command: /core-data -cp=consul.http://edgex-core-consul:8500 --registry --configDir=/res
     container_name: edgex-core-data
     depends_on:
     - consul
@@ -325,7 +325,7 @@ services:
     - redis-config:/run/redis/conf:z
     - /tmp/edgex/secrets/security-bootstrapper-redis:/tmp/edgex/secrets/security-bootstrapper-redis:ro,z
   device-rest:
-    command: /device-rest -cp=consul.http://edgex-core-consul:8500 --registry --confdir=/res
+    command: /device-rest -cp=consul.http://edgex-core-consul:8500 --registry --configDir=/res
     container_name: edgex-device-rest
     depends_on:
     - consul
@@ -383,7 +383,7 @@ services:
     - edgex-init:/edgex-init:ro,z
     - /tmp/edgex/secrets/device-rest:/tmp/edgex/secrets/device-rest:ro,z
   device-virtual:
-    command: /device-virtual -cp=consul.http://edgex-core-consul:8500 --registry --confdir=/res
+    command: /device-virtual -cp=consul.http://edgex-core-consul:8500 --registry --configDir=/res
     container_name: edgex-device-virtual
     depends_on:
     - consul
@@ -555,7 +555,7 @@ services:
     - postgres-config:/tmp/postgres-config:z
     - postgres-data:/var/lib/postgresql/data:z
   metadata:
-    command: /core-metadata -cp=consul.http://edgex-core-consul:8500 --registry --confdir=/res
+    command: /core-metadata -cp=consul.http://edgex-core-consul:8500 --registry --configDir=/res
     container_name: edgex-core-metadata
     depends_on:
     - consul
@@ -616,7 +616,7 @@ services:
     - /tmp/edgex/secrets/core-metadata:/tmp/edgex/secrets/core-metadata:ro,z
   notifications:
     command: /support-notifications -cp=consul.http://edgex-core-consul:8500 --registry
-      --confdir=/res
+      --configDir=/res
     container_name: edgex-support-notifications
     depends_on:
     - consul
@@ -785,7 +785,7 @@ services:
     - kuiper-sources:/kuiper/etc/sources:z
   scheduler:
     command: /support-scheduler -cp=consul.http://edgex-core-consul:8500 --registry
-      --confdir=/res
+      --configDir=/res
     container_name: edgex-support-scheduler
     depends_on:
     - consul

--- a/taf/docker-compose-taf-arm64.yml
+++ b/taf/docker-compose-taf-arm64.yml
@@ -30,7 +30,7 @@ networks:
 services:
   app-service-external-mqtt-trigger:
     command: /app-service-configurable -cp=consul.http://edgex-core-consul:8500 --registry
-      --confdir=/res
+      --configDir=/res
     container_name: edgex-app-external-mqtt-trigger
     depends_on:
     - consul
@@ -95,7 +95,7 @@ services:
     - /tmp/edgex/secrets/app-external-mqtt-trigger:/tmp/edgex/secrets/app-external-mqtt-trigger:ro,z
   app-service-functional-tests:
     command: /app-service-configurable -cp=consul.http://edgex-core-consul:8500 --registry
-      --confdir=/res
+      --configDir=/res
     container_name: app-functional-tests
     depends_on:
     - consul
@@ -155,7 +155,7 @@ services:
     - /tmp/edgex/secrets/app-functional-tests:/tmp/edgex/secrets/app-functional-tests:ro,z
   app-service-http-export:
     command: /app-service-configurable -cp=consul.http://edgex-core-consul:8500 --registry
-      --confdir=/res
+      --configDir=/res
     container_name: edgex-app-http-export
     depends_on:
     - consul
@@ -218,7 +218,7 @@ services:
     - /tmp/edgex/secrets/app-http-export:/tmp/edgex/secrets/app-http-export:ro,z
   app-service-mqtt-export:
     command: /app-service-configurable -cp=consul.http://edgex-core-consul:8500 --registry
-      --confdir=/res
+      --configDir=/res
     container_name: edgex-app-mqtt-export
     depends_on:
     - consul
@@ -282,7 +282,7 @@ services:
     - /tmp/edgex/secrets/app-mqtt-export:/tmp/edgex/secrets/app-mqtt-export:ro,z
   app-service-rules:
     command: /app-service-configurable -cp=consul.http://edgex-core-consul:8500 --registry
-      --confdir=/res
+      --configDir=/res
     container_name: edgex-app-rules-engine
     depends_on:
     - consul
@@ -342,7 +342,7 @@ services:
     - /tmp/edgex/secrets/app-rules-engine:/tmp/edgex/secrets/app-rules-engine:ro,z
   app-service-sample:
     command: /app-service-configurable -cp=consul.http://edgex-core-consul:8500 --registry
-      --confdir=/res
+      --configDir=/res
     container_name: edgex-app-sample
     depends_on:
     - consul
@@ -402,7 +402,7 @@ services:
     - edgex-init:/edgex-init:ro,z
     - /tmp/edgex/secrets/app-sample:/tmp/edgex/secrets/app-sample:ro,z
   command:
-    command: /core-command -cp=consul.http://edgex-core-consul:8500 --registry --confdir=/res
+    command: /core-command -cp=consul.http://edgex-core-consul:8500 --registry --configDir=/res
     container_name: edgex-core-command
     depends_on:
     - consul
@@ -518,7 +518,7 @@ services:
     - consul-acl-token:/tmp/edgex/secrets/consul-acl-token:z
     - /tmp/edgex/secrets/edgex-consul:/tmp/edgex/secrets/edgex-consul:ro,z
   data:
-    command: /core-data -cp=consul.http://edgex-core-consul:8500 --registry --confdir=/res
+    command: /core-data -cp=consul.http://edgex-core-consul:8500 --registry --configDir=/res
     container_name: edgex-core-data
     depends_on:
     - consul
@@ -638,7 +638,7 @@ services:
     - redis-config:/run/redis/conf:z
     - /tmp/edgex/secrets/security-bootstrapper-redis:/tmp/edgex/secrets/security-bootstrapper-redis:ro,z
   device-modbus:
-    command: /device-modbus -cp=consul.http://edgex-core-consul:8500 --registry --confdir=CONF_DIR_PLACE_HOLDER
+    command: /device-modbus -cp=consul.http://edgex-core-consul:8500 --registry --configDir=CONF_DIR_PLACE_HOLDER
     container_name: edgex-device-modbus
     depends_on:
     - consul
@@ -699,7 +699,7 @@ services:
     - PROFILE_VOLUME_PLACE_HOLDER:CONF_DIR_PLACE_HOLDER:z
   device-onvif-camera:
     command: /device-onvif-camera -cp=consul.http://edgex-core-consul:8500 --registry
-      --confdir=/res
+      --configDir=/res
     container_name: edgex-device-onvif-camera
     depends_on:
     - consul
@@ -757,7 +757,7 @@ services:
     - edgex-init:/edgex-init:ro,z
     - /tmp/edgex/secrets/device-onvif-camera:/tmp/edgex/secrets/device-onvif-camera:ro,z
   device-rest:
-    command: /device-rest -cp=consul.http://edgex-core-consul:8500 --registry --confdir=/res
+    command: /device-rest -cp=consul.http://edgex-core-consul:8500 --registry --configDir=/res
     container_name: edgex-device-rest
     depends_on:
     - consul
@@ -815,7 +815,7 @@ services:
     - edgex-init:/edgex-init:ro,z
     - /tmp/edgex/secrets/device-rest:/tmp/edgex/secrets/device-rest:ro,z
   device-virtual:
-    command: /device-virtual -cp=consul.http://edgex-core-consul:8500 --registry --confdir=CONF_DIR_PLACE_HOLDER
+    command: /device-virtual -cp=consul.http://edgex-core-consul:8500 --registry --configDir=CONF_DIR_PLACE_HOLDER
     container_name: edgex-device-virtual
     depends_on:
     - consul
@@ -988,7 +988,7 @@ services:
     - postgres-config:/tmp/postgres-config:z
     - postgres-data:/var/lib/postgresql/data:z
   metadata:
-    command: /core-metadata -cp=consul.http://edgex-core-consul:8500 --registry --confdir=/res
+    command: /core-metadata -cp=consul.http://edgex-core-consul:8500 --registry --configDir=/res
     container_name: edgex-core-metadata
     depends_on:
     - consul
@@ -1090,7 +1090,7 @@ services:
     user: 2002:2001
   notifications:
     command: /support-notifications -cp=consul.http://edgex-core-consul:8500 --registry
-      --confdir=/res
+      --configDir=/res
     container_name: edgex-support-notifications
     depends_on:
     - consul
@@ -1259,7 +1259,7 @@ services:
     - kuiper-sources:/kuiper/etc/sources:z
   scalability-test-mqtt-export:
     command: /app-service-configurable -cp=consul.http://edgex-core-consul:8500 --registry
-      --confdir=/res
+      --configDir=/res
     container_name: edgex-scalability-test-mqtt-export
     depends_on:
     - consul
@@ -1327,7 +1327,7 @@ services:
     - /tmp/edgex/secrets/app-scalability-test-mqtt-export:/tmp/edgex/secrets/app-scalability-test-mqtt-export:ro,z
   scheduler:
     command: /support-scheduler -cp=consul.http://edgex-core-consul:8500 --registry
-      --confdir=/res
+      --configDir=/res
     container_name: edgex-support-scheduler
     depends_on:
     - consul
@@ -1476,7 +1476,7 @@ services:
     - edgex-init:/edgex-init:z
   security-spiffe-token-provider:
     command: /security-spiffe-token-provider -cp=consul.http://edgex-core-consul:8500
-      --registry --confdir=/res
+      --registry --configDir=/res
     container_name: edgex-security-spiffe-token-provider
     depends_on:
     - consul

--- a/taf/docker-compose-taf-mqtt-bus-arm64.yml
+++ b/taf/docker-compose-taf-mqtt-bus-arm64.yml
@@ -30,7 +30,7 @@ networks:
 services:
   app-service-external-mqtt-trigger:
     command: /app-service-configurable -cp=consul.http://edgex-core-consul:8500 --registry
-      --confdir=/res
+      --configDir=/res
     container_name: edgex-app-external-mqtt-trigger
     depends_on:
     - consul
@@ -95,7 +95,7 @@ services:
     - /tmp/edgex/secrets/app-external-mqtt-trigger:/tmp/edgex/secrets/app-external-mqtt-trigger:ro,z
   app-service-functional-tests:
     command: /app-service-configurable -cp=consul.http://edgex-core-consul:8500 --registry
-      --confdir=/res
+      --configDir=/res
     container_name: app-functional-tests
     depends_on:
     - consul
@@ -155,7 +155,7 @@ services:
     - /tmp/edgex/secrets/app-functional-tests:/tmp/edgex/secrets/app-functional-tests:ro,z
   app-service-http-export:
     command: /app-service-configurable -cp=consul.http://edgex-core-consul:8500 --registry
-      --confdir=/res
+      --configDir=/res
     container_name: edgex-app-http-export
     depends_on:
     - consul
@@ -226,7 +226,7 @@ services:
     - /tmp/edgex/secrets/app-http-export:/tmp/edgex/secrets/app-http-export:ro,z
   app-service-mqtt-export:
     command: /app-service-configurable -cp=consul.http://edgex-core-consul:8500 --registry
-      --confdir=/res
+      --configDir=/res
     container_name: edgex-app-mqtt-export
     depends_on:
     - consul
@@ -300,7 +300,7 @@ services:
     - /tmp/edgex/secrets/app-mqtt-export:/tmp/edgex/secrets/app-mqtt-export:ro,z
   app-service-rules:
     command: /app-service-configurable -cp=consul.http://edgex-core-consul:8500 --registry
-      --confdir=/res
+      --configDir=/res
     container_name: edgex-app-rules-engine
     depends_on:
     - consul
@@ -368,7 +368,7 @@ services:
     - /tmp/edgex/secrets/app-rules-engine:/tmp/edgex/secrets/app-rules-engine:ro,z
   app-service-sample:
     command: /app-service-configurable -cp=consul.http://edgex-core-consul:8500 --registry
-      --confdir=/res
+      --configDir=/res
     container_name: edgex-app-sample
     depends_on:
     - consul
@@ -436,7 +436,7 @@ services:
     - edgex-init:/edgex-init:ro,z
     - /tmp/edgex/secrets/app-sample:/tmp/edgex/secrets/app-sample:ro,z
   command:
-    command: /core-command -cp=consul.http://edgex-core-consul:8500 --registry --confdir=/res
+    command: /core-command -cp=consul.http://edgex-core-consul:8500 --registry --configDir=/res
     container_name: edgex-core-command
     depends_on:
     - consul
@@ -559,7 +559,7 @@ services:
     - consul-acl-token:/tmp/edgex/secrets/consul-acl-token:z
     - /tmp/edgex/secrets/edgex-consul:/tmp/edgex/secrets/edgex-consul:ro,z
   data:
-    command: /core-data -cp=consul.http://edgex-core-consul:8500 --registry --confdir=/res
+    command: /core-data -cp=consul.http://edgex-core-consul:8500 --registry --configDir=/res
     container_name: edgex-core-data
     depends_on:
     - consul
@@ -686,7 +686,7 @@ services:
     - redis-config:/run/redis/conf:z
     - /tmp/edgex/secrets/security-bootstrapper-redis:/tmp/edgex/secrets/security-bootstrapper-redis:ro,z
   device-modbus:
-    command: /device-modbus -cp=consul.http://edgex-core-consul:8500 --registry --confdir=CONF_DIR_PLACE_HOLDER
+    command: /device-modbus -cp=consul.http://edgex-core-consul:8500 --registry --configDir=CONF_DIR_PLACE_HOLDER
     container_name: edgex-device-modbus
     depends_on:
     - consul
@@ -753,7 +753,7 @@ services:
     - PROFILE_VOLUME_PLACE_HOLDER:CONF_DIR_PLACE_HOLDER:z
   device-onvif-camera:
     command: /device-onvif-camera -cp=consul.http://edgex-core-consul:8500 --registry
-      --confdir=/res
+      --configDir=/res
     container_name: edgex-device-onvif-camera
     depends_on:
     - consul
@@ -817,7 +817,7 @@ services:
     - edgex-init:/edgex-init:ro,z
     - /tmp/edgex/secrets/device-onvif-camera:/tmp/edgex/secrets/device-onvif-camera:ro,z
   device-rest:
-    command: /device-rest -cp=consul.http://edgex-core-consul:8500 --registry --confdir=/res
+    command: /device-rest -cp=consul.http://edgex-core-consul:8500 --registry --configDir=/res
     container_name: edgex-device-rest
     depends_on:
     - consul
@@ -881,7 +881,7 @@ services:
     - edgex-init:/edgex-init:ro,z
     - /tmp/edgex/secrets/device-rest:/tmp/edgex/secrets/device-rest:ro,z
   device-virtual:
-    command: /device-virtual -cp=consul.http://edgex-core-consul:8500 --registry --confdir=CONF_DIR_PLACE_HOLDER
+    command: /device-virtual -cp=consul.http://edgex-core-consul:8500 --registry --configDir=CONF_DIR_PLACE_HOLDER
     container_name: edgex-device-virtual
     depends_on:
     - consul
@@ -1060,7 +1060,7 @@ services:
     - postgres-config:/tmp/postgres-config:z
     - postgres-data:/var/lib/postgresql/data:z
   metadata:
-    command: /core-metadata -cp=consul.http://edgex-core-consul:8500 --registry --confdir=/res
+    command: /core-metadata -cp=consul.http://edgex-core-consul:8500 --registry --configDir=/res
     container_name: edgex-core-metadata
     depends_on:
     - consul
@@ -1206,7 +1206,7 @@ services:
     user: 2002:2001
   notifications:
     command: /support-notifications -cp=consul.http://edgex-core-consul:8500 --registry
-      --confdir=/res
+      --configDir=/res
     container_name: edgex-support-notifications
     depends_on:
     - consul
@@ -1391,7 +1391,7 @@ services:
     - kuiper-sources:/kuiper/etc/sources:z
   scalability-test-mqtt-export:
     command: /app-service-configurable -cp=consul.http://edgex-core-consul:8500 --registry
-      --confdir=/res
+      --configDir=/res
     container_name: edgex-scalability-test-mqtt-export
     depends_on:
     - consul
@@ -1469,7 +1469,7 @@ services:
     - /tmp/edgex/secrets/app-scalability-test-mqtt-export:/tmp/edgex/secrets/app-scalability-test-mqtt-export:ro,z
   scheduler:
     command: /support-scheduler -cp=consul.http://edgex-core-consul:8500 --registry
-      --confdir=/res
+      --configDir=/res
     container_name: edgex-support-scheduler
     depends_on:
     - consul
@@ -1625,7 +1625,7 @@ services:
     - edgex-init:/edgex-init:z
   security-spiffe-token-provider:
     command: /security-spiffe-token-provider -cp=consul.http://edgex-core-consul:8500
-      --registry --confdir=/res
+      --registry --configDir=/res
     container_name: edgex-security-spiffe-token-provider
     depends_on:
     - consul

--- a/taf/docker-compose-taf-mqtt-bus.yml
+++ b/taf/docker-compose-taf-mqtt-bus.yml
@@ -30,7 +30,7 @@ networks:
 services:
   app-service-external-mqtt-trigger:
     command: /app-service-configurable -cp=consul.http://edgex-core-consul:8500 --registry
-      --confdir=/res
+      --configDir=/res
     container_name: edgex-app-external-mqtt-trigger
     depends_on:
     - consul
@@ -95,7 +95,7 @@ services:
     - /tmp/edgex/secrets/app-external-mqtt-trigger:/tmp/edgex/secrets/app-external-mqtt-trigger:ro,z
   app-service-functional-tests:
     command: /app-service-configurable -cp=consul.http://edgex-core-consul:8500 --registry
-      --confdir=/res
+      --configDir=/res
     container_name: app-functional-tests
     depends_on:
     - consul
@@ -155,7 +155,7 @@ services:
     - /tmp/edgex/secrets/app-functional-tests:/tmp/edgex/secrets/app-functional-tests:ro,z
   app-service-http-export:
     command: /app-service-configurable -cp=consul.http://edgex-core-consul:8500 --registry
-      --confdir=/res
+      --configDir=/res
     container_name: edgex-app-http-export
     depends_on:
     - consul
@@ -226,7 +226,7 @@ services:
     - /tmp/edgex/secrets/app-http-export:/tmp/edgex/secrets/app-http-export:ro,z
   app-service-mqtt-export:
     command: /app-service-configurable -cp=consul.http://edgex-core-consul:8500 --registry
-      --confdir=/res
+      --configDir=/res
     container_name: edgex-app-mqtt-export
     depends_on:
     - consul
@@ -300,7 +300,7 @@ services:
     - /tmp/edgex/secrets/app-mqtt-export:/tmp/edgex/secrets/app-mqtt-export:ro,z
   app-service-rules:
     command: /app-service-configurable -cp=consul.http://edgex-core-consul:8500 --registry
-      --confdir=/res
+      --configDir=/res
     container_name: edgex-app-rules-engine
     depends_on:
     - consul
@@ -368,7 +368,7 @@ services:
     - /tmp/edgex/secrets/app-rules-engine:/tmp/edgex/secrets/app-rules-engine:ro,z
   app-service-sample:
     command: /app-service-configurable -cp=consul.http://edgex-core-consul:8500 --registry
-      --confdir=/res
+      --configDir=/res
     container_name: edgex-app-sample
     depends_on:
     - consul
@@ -436,7 +436,7 @@ services:
     - edgex-init:/edgex-init:ro,z
     - /tmp/edgex/secrets/app-sample:/tmp/edgex/secrets/app-sample:ro,z
   command:
-    command: /core-command -cp=consul.http://edgex-core-consul:8500 --registry --confdir=/res
+    command: /core-command -cp=consul.http://edgex-core-consul:8500 --registry --configDir=/res
     container_name: edgex-core-command
     depends_on:
     - consul
@@ -559,7 +559,7 @@ services:
     - consul-acl-token:/tmp/edgex/secrets/consul-acl-token:z
     - /tmp/edgex/secrets/edgex-consul:/tmp/edgex/secrets/edgex-consul:ro,z
   data:
-    command: /core-data -cp=consul.http://edgex-core-consul:8500 --registry --confdir=/res
+    command: /core-data -cp=consul.http://edgex-core-consul:8500 --registry --configDir=/res
     container_name: edgex-core-data
     depends_on:
     - consul
@@ -686,7 +686,7 @@ services:
     - redis-config:/run/redis/conf:z
     - /tmp/edgex/secrets/security-bootstrapper-redis:/tmp/edgex/secrets/security-bootstrapper-redis:ro,z
   device-modbus:
-    command: /device-modbus -cp=consul.http://edgex-core-consul:8500 --registry --confdir=CONF_DIR_PLACE_HOLDER
+    command: /device-modbus -cp=consul.http://edgex-core-consul:8500 --registry --configDir=CONF_DIR_PLACE_HOLDER
     container_name: edgex-device-modbus
     depends_on:
     - consul
@@ -753,7 +753,7 @@ services:
     - PROFILE_VOLUME_PLACE_HOLDER:CONF_DIR_PLACE_HOLDER:z
   device-onvif-camera:
     command: /device-onvif-camera -cp=consul.http://edgex-core-consul:8500 --registry
-      --confdir=/res
+      --configDir=/res
     container_name: edgex-device-onvif-camera
     depends_on:
     - consul
@@ -817,7 +817,7 @@ services:
     - edgex-init:/edgex-init:ro,z
     - /tmp/edgex/secrets/device-onvif-camera:/tmp/edgex/secrets/device-onvif-camera:ro,z
   device-rest:
-    command: /device-rest -cp=consul.http://edgex-core-consul:8500 --registry --confdir=/res
+    command: /device-rest -cp=consul.http://edgex-core-consul:8500 --registry --configDir=/res
     container_name: edgex-device-rest
     depends_on:
     - consul
@@ -881,7 +881,7 @@ services:
     - edgex-init:/edgex-init:ro,z
     - /tmp/edgex/secrets/device-rest:/tmp/edgex/secrets/device-rest:ro,z
   device-virtual:
-    command: /device-virtual -cp=consul.http://edgex-core-consul:8500 --registry --confdir=CONF_DIR_PLACE_HOLDER
+    command: /device-virtual -cp=consul.http://edgex-core-consul:8500 --registry --configDir=CONF_DIR_PLACE_HOLDER
     container_name: edgex-device-virtual
     depends_on:
     - consul
@@ -1060,7 +1060,7 @@ services:
     - postgres-config:/tmp/postgres-config:z
     - postgres-data:/var/lib/postgresql/data:z
   metadata:
-    command: /core-metadata -cp=consul.http://edgex-core-consul:8500 --registry --confdir=/res
+    command: /core-metadata -cp=consul.http://edgex-core-consul:8500 --registry --configDir=/res
     container_name: edgex-core-metadata
     depends_on:
     - consul
@@ -1206,7 +1206,7 @@ services:
     user: 2002:2001
   notifications:
     command: /support-notifications -cp=consul.http://edgex-core-consul:8500 --registry
-      --confdir=/res
+      --configDir=/res
     container_name: edgex-support-notifications
     depends_on:
     - consul
@@ -1391,7 +1391,7 @@ services:
     - kuiper-sources:/kuiper/etc/sources:z
   scalability-test-mqtt-export:
     command: /app-service-configurable -cp=consul.http://edgex-core-consul:8500 --registry
-      --confdir=/res
+      --configDir=/res
     container_name: edgex-scalability-test-mqtt-export
     depends_on:
     - consul
@@ -1469,7 +1469,7 @@ services:
     - /tmp/edgex/secrets/app-scalability-test-mqtt-export:/tmp/edgex/secrets/app-scalability-test-mqtt-export:ro,z
   scheduler:
     command: /support-scheduler -cp=consul.http://edgex-core-consul:8500 --registry
-      --confdir=/res
+      --configDir=/res
     container_name: edgex-support-scheduler
     depends_on:
     - consul
@@ -1625,7 +1625,7 @@ services:
     - edgex-init:/edgex-init:z
   security-spiffe-token-provider:
     command: /security-spiffe-token-provider -cp=consul.http://edgex-core-consul:8500
-      --registry --confdir=/res
+      --registry --configDir=/res
     container_name: edgex-security-spiffe-token-provider
     depends_on:
     - consul

--- a/taf/docker-compose-taf-no-secty-arm64.yml
+++ b/taf/docker-compose-taf-no-secty-arm64.yml
@@ -315,7 +315,7 @@ services:
     volumes:
     - db-data:/data:z
   device-modbus:
-    command: -cp=consul.http://edgex-core-consul:8500 --registry --confdir=CONF_DIR_PLACE_HOLDER
+    command: -cp=consul.http://edgex-core-consul:8500 --registry --configDir=CONF_DIR_PLACE_HOLDER
     container_name: edgex-device-modbus
     depends_on:
     - consul
@@ -403,7 +403,7 @@ services:
     - no-new-privileges:true
     user: 2002:2001
   device-virtual:
-    command: -cp=consul.http://edgex-core-consul:8500 --registry --confdir=CONF_DIR_PLACE_HOLDER
+    command: -cp=consul.http://edgex-core-consul:8500 --registry --configDir=CONF_DIR_PLACE_HOLDER
     container_name: edgex-device-virtual
     depends_on:
     - consul

--- a/taf/docker-compose-taf-no-secty-mqtt-bus-arm64.yml
+++ b/taf/docker-compose-taf-no-secty-mqtt-bus-arm64.yml
@@ -355,7 +355,7 @@ services:
     volumes:
     - db-data:/data:z
   device-modbus:
-    command: -cp=consul.http://edgex-core-consul:8500 --registry --confdir=CONF_DIR_PLACE_HOLDER
+    command: -cp=consul.http://edgex-core-consul:8500 --registry --configDir=CONF_DIR_PLACE_HOLDER
     container_name: edgex-device-modbus
     depends_on:
     - consul
@@ -458,7 +458,7 @@ services:
     - no-new-privileges:true
     user: 2002:2001
   device-virtual:
-    command: -cp=consul.http://edgex-core-consul:8500 --registry --confdir=CONF_DIR_PLACE_HOLDER
+    command: -cp=consul.http://edgex-core-consul:8500 --registry --configDir=CONF_DIR_PLACE_HOLDER
     container_name: edgex-device-virtual
     depends_on:
     - consul

--- a/taf/docker-compose-taf-no-secty-mqtt-bus.yml
+++ b/taf/docker-compose-taf-no-secty-mqtt-bus.yml
@@ -355,7 +355,7 @@ services:
     volumes:
     - db-data:/data:z
   device-modbus:
-    command: -cp=consul.http://edgex-core-consul:8500 --registry --confdir=CONF_DIR_PLACE_HOLDER
+    command: -cp=consul.http://edgex-core-consul:8500 --registry --configDir=CONF_DIR_PLACE_HOLDER
     container_name: edgex-device-modbus
     depends_on:
     - consul
@@ -458,7 +458,7 @@ services:
     - no-new-privileges:true
     user: 2002:2001
   device-virtual:
-    command: -cp=consul.http://edgex-core-consul:8500 --registry --confdir=CONF_DIR_PLACE_HOLDER
+    command: -cp=consul.http://edgex-core-consul:8500 --registry --configDir=CONF_DIR_PLACE_HOLDER
     container_name: edgex-device-virtual
     depends_on:
     - consul

--- a/taf/docker-compose-taf-no-secty.yml
+++ b/taf/docker-compose-taf-no-secty.yml
@@ -315,7 +315,7 @@ services:
     volumes:
     - db-data:/data:z
   device-modbus:
-    command: -cp=consul.http://edgex-core-consul:8500 --registry --confdir=CONF_DIR_PLACE_HOLDER
+    command: -cp=consul.http://edgex-core-consul:8500 --registry --configDir=CONF_DIR_PLACE_HOLDER
     container_name: edgex-device-modbus
     depends_on:
     - consul
@@ -403,7 +403,7 @@ services:
     - no-new-privileges:true
     user: 2002:2001
   device-virtual:
-    command: -cp=consul.http://edgex-core-consul:8500 --registry --confdir=CONF_DIR_PLACE_HOLDER
+    command: -cp=consul.http://edgex-core-consul:8500 --registry --configDir=CONF_DIR_PLACE_HOLDER
     container_name: edgex-device-virtual
     depends_on:
     - consul

--- a/taf/docker-compose-taf-perf-arm64.yml
+++ b/taf/docker-compose-taf-perf-arm64.yml
@@ -30,7 +30,7 @@ networks:
 services:
   app-service-mqtt-export:
     command: /app-service-configurable -cp=consul.http://edgex-core-consul:8500 --registry
-      --confdir=/res
+      --configDir=/res
     container_name: edgex-app-mqtt-export
     depends_on:
     - consul
@@ -94,7 +94,7 @@ services:
     - /tmp/edgex/secrets/app-mqtt-export:/tmp/edgex/secrets/app-mqtt-export:ro,z
   app-service-rules:
     command: /app-service-configurable -cp=consul.http://edgex-core-consul:8500 --registry
-      --confdir=/res
+      --configDir=/res
     container_name: edgex-app-rules-engine
     depends_on:
     - consul
@@ -153,7 +153,7 @@ services:
     - edgex-init:/edgex-init:ro,z
     - /tmp/edgex/secrets/app-rules-engine:/tmp/edgex/secrets/app-rules-engine:ro,z
   command:
-    command: /core-command -cp=consul.http://edgex-core-consul:8500 --registry --confdir=/res
+    command: /core-command -cp=consul.http://edgex-core-consul:8500 --registry --configDir=/res
     container_name: edgex-core-command
     depends_on:
     - consul
@@ -269,7 +269,7 @@ services:
     - consul-acl-token:/tmp/edgex/secrets/consul-acl-token:z
     - /tmp/edgex/secrets/edgex-consul:/tmp/edgex/secrets/edgex-consul:ro,z
   data:
-    command: /core-data -cp=consul.http://edgex-core-consul:8500 --registry --confdir=/res
+    command: /core-data -cp=consul.http://edgex-core-consul:8500 --registry --configDir=/res
     container_name: edgex-core-data
     depends_on:
     - consul
@@ -389,7 +389,7 @@ services:
     - redis-config:/run/redis/conf:z
     - /tmp/edgex/secrets/security-bootstrapper-redis:/tmp/edgex/secrets/security-bootstrapper-redis:ro,z
   device-rest:
-    command: /device-rest -cp=consul.http://edgex-core-consul:8500 --registry --confdir=/res
+    command: /device-rest -cp=consul.http://edgex-core-consul:8500 --registry --configDir=/res
     container_name: edgex-device-rest
     depends_on:
     - consul
@@ -447,7 +447,7 @@ services:
     - edgex-init:/edgex-init:ro,z
     - /tmp/edgex/secrets/device-rest:/tmp/edgex/secrets/device-rest:ro,z
   device-virtual:
-    command: /device-virtual -cp=consul.http://edgex-core-consul:8500 --registry --confdir=/res
+    command: /device-virtual -cp=consul.http://edgex-core-consul:8500 --registry --configDir=/res
     container_name: edgex-device-virtual
     depends_on:
     - consul
@@ -619,7 +619,7 @@ services:
     - postgres-config:/tmp/postgres-config:z
     - postgres-data:/var/lib/postgresql/data:z
   metadata:
-    command: /core-metadata -cp=consul.http://edgex-core-consul:8500 --registry --confdir=/res
+    command: /core-metadata -cp=consul.http://edgex-core-consul:8500 --registry --configDir=/res
     container_name: edgex-core-metadata
     depends_on:
     - consul
@@ -708,7 +708,7 @@ services:
     user: 2002:2001
   notifications:
     command: /support-notifications -cp=consul.http://edgex-core-consul:8500 --registry
-      --confdir=/res
+      --configDir=/res
     container_name: edgex-support-notifications
     depends_on:
     - consul
@@ -877,7 +877,7 @@ services:
     - kuiper-sources:/kuiper/etc/sources:z
   scheduler:
     command: /support-scheduler -cp=consul.http://edgex-core-consul:8500 --registry
-      --confdir=/res
+      --configDir=/res
     container_name: edgex-support-scheduler
     depends_on:
     - consul
@@ -1026,7 +1026,7 @@ services:
     - edgex-init:/edgex-init:z
   security-spiffe-token-provider:
     command: /security-spiffe-token-provider -cp=consul.http://edgex-core-consul:8500
-      --registry --confdir=/res
+      --registry --configDir=/res
     container_name: edgex-security-spiffe-token-provider
     depends_on:
     - consul

--- a/taf/docker-compose-taf-perf.yml
+++ b/taf/docker-compose-taf-perf.yml
@@ -30,7 +30,7 @@ networks:
 services:
   app-service-mqtt-export:
     command: /app-service-configurable -cp=consul.http://edgex-core-consul:8500 --registry
-      --confdir=/res
+      --configDir=/res
     container_name: edgex-app-mqtt-export
     depends_on:
     - consul
@@ -94,7 +94,7 @@ services:
     - /tmp/edgex/secrets/app-mqtt-export:/tmp/edgex/secrets/app-mqtt-export:ro,z
   app-service-rules:
     command: /app-service-configurable -cp=consul.http://edgex-core-consul:8500 --registry
-      --confdir=/res
+      --configDir=/res
     container_name: edgex-app-rules-engine
     depends_on:
     - consul
@@ -153,7 +153,7 @@ services:
     - edgex-init:/edgex-init:ro,z
     - /tmp/edgex/secrets/app-rules-engine:/tmp/edgex/secrets/app-rules-engine:ro,z
   command:
-    command: /core-command -cp=consul.http://edgex-core-consul:8500 --registry --confdir=/res
+    command: /core-command -cp=consul.http://edgex-core-consul:8500 --registry --configDir=/res
     container_name: edgex-core-command
     depends_on:
     - consul
@@ -269,7 +269,7 @@ services:
     - consul-acl-token:/tmp/edgex/secrets/consul-acl-token:z
     - /tmp/edgex/secrets/edgex-consul:/tmp/edgex/secrets/edgex-consul:ro,z
   data:
-    command: /core-data -cp=consul.http://edgex-core-consul:8500 --registry --confdir=/res
+    command: /core-data -cp=consul.http://edgex-core-consul:8500 --registry --configDir=/res
     container_name: edgex-core-data
     depends_on:
     - consul
@@ -389,7 +389,7 @@ services:
     - redis-config:/run/redis/conf:z
     - /tmp/edgex/secrets/security-bootstrapper-redis:/tmp/edgex/secrets/security-bootstrapper-redis:ro,z
   device-rest:
-    command: /device-rest -cp=consul.http://edgex-core-consul:8500 --registry --confdir=/res
+    command: /device-rest -cp=consul.http://edgex-core-consul:8500 --registry --configDir=/res
     container_name: edgex-device-rest
     depends_on:
     - consul
@@ -447,7 +447,7 @@ services:
     - edgex-init:/edgex-init:ro,z
     - /tmp/edgex/secrets/device-rest:/tmp/edgex/secrets/device-rest:ro,z
   device-virtual:
-    command: /device-virtual -cp=consul.http://edgex-core-consul:8500 --registry --confdir=/res
+    command: /device-virtual -cp=consul.http://edgex-core-consul:8500 --registry --configDir=/res
     container_name: edgex-device-virtual
     depends_on:
     - consul
@@ -619,7 +619,7 @@ services:
     - postgres-config:/tmp/postgres-config:z
     - postgres-data:/var/lib/postgresql/data:z
   metadata:
-    command: /core-metadata -cp=consul.http://edgex-core-consul:8500 --registry --confdir=/res
+    command: /core-metadata -cp=consul.http://edgex-core-consul:8500 --registry --configDir=/res
     container_name: edgex-core-metadata
     depends_on:
     - consul
@@ -708,7 +708,7 @@ services:
     user: 2002:2001
   notifications:
     command: /support-notifications -cp=consul.http://edgex-core-consul:8500 --registry
-      --confdir=/res
+      --configDir=/res
     container_name: edgex-support-notifications
     depends_on:
     - consul
@@ -877,7 +877,7 @@ services:
     - kuiper-sources:/kuiper/etc/sources:z
   scheduler:
     command: /support-scheduler -cp=consul.http://edgex-core-consul:8500 --registry
-      --confdir=/res
+      --configDir=/res
     container_name: edgex-support-scheduler
     depends_on:
     - consul
@@ -1026,7 +1026,7 @@ services:
     - edgex-init:/edgex-init:z
   security-spiffe-token-provider:
     command: /security-spiffe-token-provider -cp=consul.http://edgex-core-consul:8500
-      --registry --confdir=/res
+      --registry --configDir=/res
     container_name: edgex-security-spiffe-token-provider
     depends_on:
     - consul

--- a/taf/docker-compose-taf.yml
+++ b/taf/docker-compose-taf.yml
@@ -30,7 +30,7 @@ networks:
 services:
   app-service-external-mqtt-trigger:
     command: /app-service-configurable -cp=consul.http://edgex-core-consul:8500 --registry
-      --confdir=/res
+      --configDir=/res
     container_name: edgex-app-external-mqtt-trigger
     depends_on:
     - consul
@@ -95,7 +95,7 @@ services:
     - /tmp/edgex/secrets/app-external-mqtt-trigger:/tmp/edgex/secrets/app-external-mqtt-trigger:ro,z
   app-service-functional-tests:
     command: /app-service-configurable -cp=consul.http://edgex-core-consul:8500 --registry
-      --confdir=/res
+      --configDir=/res
     container_name: app-functional-tests
     depends_on:
     - consul
@@ -155,7 +155,7 @@ services:
     - /tmp/edgex/secrets/app-functional-tests:/tmp/edgex/secrets/app-functional-tests:ro,z
   app-service-http-export:
     command: /app-service-configurable -cp=consul.http://edgex-core-consul:8500 --registry
-      --confdir=/res
+      --configDir=/res
     container_name: edgex-app-http-export
     depends_on:
     - consul
@@ -218,7 +218,7 @@ services:
     - /tmp/edgex/secrets/app-http-export:/tmp/edgex/secrets/app-http-export:ro,z
   app-service-mqtt-export:
     command: /app-service-configurable -cp=consul.http://edgex-core-consul:8500 --registry
-      --confdir=/res
+      --configDir=/res
     container_name: edgex-app-mqtt-export
     depends_on:
     - consul
@@ -282,7 +282,7 @@ services:
     - /tmp/edgex/secrets/app-mqtt-export:/tmp/edgex/secrets/app-mqtt-export:ro,z
   app-service-rules:
     command: /app-service-configurable -cp=consul.http://edgex-core-consul:8500 --registry
-      --confdir=/res
+      --configDir=/res
     container_name: edgex-app-rules-engine
     depends_on:
     - consul
@@ -342,7 +342,7 @@ services:
     - /tmp/edgex/secrets/app-rules-engine:/tmp/edgex/secrets/app-rules-engine:ro,z
   app-service-sample:
     command: /app-service-configurable -cp=consul.http://edgex-core-consul:8500 --registry
-      --confdir=/res
+      --configDir=/res
     container_name: edgex-app-sample
     depends_on:
     - consul
@@ -402,7 +402,7 @@ services:
     - edgex-init:/edgex-init:ro,z
     - /tmp/edgex/secrets/app-sample:/tmp/edgex/secrets/app-sample:ro,z
   command:
-    command: /core-command -cp=consul.http://edgex-core-consul:8500 --registry --confdir=/res
+    command: /core-command -cp=consul.http://edgex-core-consul:8500 --registry --configDir=/res
     container_name: edgex-core-command
     depends_on:
     - consul
@@ -518,7 +518,7 @@ services:
     - consul-acl-token:/tmp/edgex/secrets/consul-acl-token:z
     - /tmp/edgex/secrets/edgex-consul:/tmp/edgex/secrets/edgex-consul:ro,z
   data:
-    command: /core-data -cp=consul.http://edgex-core-consul:8500 --registry --confdir=/res
+    command: /core-data -cp=consul.http://edgex-core-consul:8500 --registry --configDir=/res
     container_name: edgex-core-data
     depends_on:
     - consul
@@ -638,7 +638,7 @@ services:
     - redis-config:/run/redis/conf:z
     - /tmp/edgex/secrets/security-bootstrapper-redis:/tmp/edgex/secrets/security-bootstrapper-redis:ro,z
   device-modbus:
-    command: /device-modbus -cp=consul.http://edgex-core-consul:8500 --registry --confdir=CONF_DIR_PLACE_HOLDER
+    command: /device-modbus -cp=consul.http://edgex-core-consul:8500 --registry --configDir=CONF_DIR_PLACE_HOLDER
     container_name: edgex-device-modbus
     depends_on:
     - consul
@@ -699,7 +699,7 @@ services:
     - PROFILE_VOLUME_PLACE_HOLDER:CONF_DIR_PLACE_HOLDER:z
   device-onvif-camera:
     command: /device-onvif-camera -cp=consul.http://edgex-core-consul:8500 --registry
-      --confdir=/res
+      --configDir=/res
     container_name: edgex-device-onvif-camera
     depends_on:
     - consul
@@ -757,7 +757,7 @@ services:
     - edgex-init:/edgex-init:ro,z
     - /tmp/edgex/secrets/device-onvif-camera:/tmp/edgex/secrets/device-onvif-camera:ro,z
   device-rest:
-    command: /device-rest -cp=consul.http://edgex-core-consul:8500 --registry --confdir=/res
+    command: /device-rest -cp=consul.http://edgex-core-consul:8500 --registry --configDir=/res
     container_name: edgex-device-rest
     depends_on:
     - consul
@@ -815,7 +815,7 @@ services:
     - edgex-init:/edgex-init:ro,z
     - /tmp/edgex/secrets/device-rest:/tmp/edgex/secrets/device-rest:ro,z
   device-virtual:
-    command: /device-virtual -cp=consul.http://edgex-core-consul:8500 --registry --confdir=CONF_DIR_PLACE_HOLDER
+    command: /device-virtual -cp=consul.http://edgex-core-consul:8500 --registry --configDir=CONF_DIR_PLACE_HOLDER
     container_name: edgex-device-virtual
     depends_on:
     - consul
@@ -988,7 +988,7 @@ services:
     - postgres-config:/tmp/postgres-config:z
     - postgres-data:/var/lib/postgresql/data:z
   metadata:
-    command: /core-metadata -cp=consul.http://edgex-core-consul:8500 --registry --confdir=/res
+    command: /core-metadata -cp=consul.http://edgex-core-consul:8500 --registry --configDir=/res
     container_name: edgex-core-metadata
     depends_on:
     - consul
@@ -1090,7 +1090,7 @@ services:
     user: 2002:2001
   notifications:
     command: /support-notifications -cp=consul.http://edgex-core-consul:8500 --registry
-      --confdir=/res
+      --configDir=/res
     container_name: edgex-support-notifications
     depends_on:
     - consul
@@ -1259,7 +1259,7 @@ services:
     - kuiper-sources:/kuiper/etc/sources:z
   scalability-test-mqtt-export:
     command: /app-service-configurable -cp=consul.http://edgex-core-consul:8500 --registry
-      --confdir=/res
+      --configDir=/res
     container_name: edgex-scalability-test-mqtt-export
     depends_on:
     - consul
@@ -1327,7 +1327,7 @@ services:
     - /tmp/edgex/secrets/app-scalability-test-mqtt-export:/tmp/edgex/secrets/app-scalability-test-mqtt-export:ro,z
   scheduler:
     command: /support-scheduler -cp=consul.http://edgex-core-consul:8500 --registry
-      --confdir=/res
+      --configDir=/res
     container_name: edgex-support-scheduler
     depends_on:
     - consul
@@ -1476,7 +1476,7 @@ services:
     - edgex-init:/edgex-init:z
   security-spiffe-token-provider:
     command: /security-spiffe-token-provider -cp=consul.http://edgex-core-consul:8500
-      --registry --confdir=/res
+      --registry --configDir=/res
     container_name: edgex-security-spiffe-token-provider
     depends_on:
     - consul


### PR DESCRIPTION
BREAKING CHANGE: Use --confDir option instead of --confdir

Signed-off-by: Bryon Nevis <bryon.nevis@intel.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [ ] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>


## Testing Instructions
This is not fully tested, but needed for the change for `--confdir` to `--configDir` with EdgeX 3.0
