### PR TITLE
feat: Add core-common-config-bootstrapper service to compose files

### DIFF
--- a/compose-builder/add-security.yml
+++ b/compose-builder/add-security.yml
@@ -326,6 +326,19 @@ services:
       - secretstore-setup
       - database
 
+  common-config:
+    env_file:
+      - common-security.env
+      - common-sec-stage-gate.env
+    entrypoint: ["/edgex-init/ready_to_run_wait_install.sh"]
+    command: ["/entrypoint.sh", "/core-common-config-bootstrapper", "-cp=consul.http://edgex-core-consul:8500"]
+    volumes:
+      - edgex-init:/edgex-init:ro,z
+      - /tmp/edgex/secrets/core-common-config-bootstrapper:/tmp/edgex/secrets/core-common-config-bootstrapper:ro,z
+    depends_on:
+      - security-bootstrapper
+      - secretstore-setup
+
   scheduler:
     env_file:
       - common-security.env

--- a/compose-builder/docker-compose-base.yml
+++ b/compose-builder/docker-compose-base.yml
@@ -157,6 +157,21 @@ services:
     security_opt: 
       - no-new-privileges:true
 
+  common-config:
+    image: ${CORE_EDGEX_REPOSITORY}/core-common-config-bootstrapper${ARCH}:${CORE_EDGEX_VERSION}
+    user: "${EDGEX_USER}:${EDGEX_GROUP}"
+    container_name: edgex-core-common-config-bootstrapper
+    hostname: edgex-core-common-config-bootstrapper
+    read_only: true
+    networks:
+      - edgex-network
+    env_file:
+      - common.env
+    depends_on:
+      - consul
+    security_opt:
+      - no-new-privileges:true
+
   scheduler:
     image: ${CORE_EDGEX_REPOSITORY}/support-scheduler${ARCH}:${CORE_EDGEX_VERSION}
     user: "${EDGEX_USER}:${EDGEX_GROUP}"

--- a/docker-compose-arm64.yml
+++ b/docker-compose-arm64.yml
@@ -190,6 +190,76 @@ services:
       bind:
         selinux: z
         create_host_path: true
+  common-config:
+    command:
+    - /entrypoint.sh
+    - /core-common-config-bootstrapper
+    - -cp=consul.http://edgex-core-consul:8500
+    container_name: edgex-core-common-config-bootstrapper
+    depends_on:
+      consul:
+        condition: service_started
+      secretstore-setup:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
+    entrypoint:
+    - /edgex-init/ready_to_run_wait_install.sh
+    environment:
+      API_GATEWAY_HOST: edgex-kong
+      API_GATEWAY_STATUS_PORT: "8100"
+      CLIENTS_CORE_COMMAND_HOST: edgex-core-command
+      CLIENTS_CORE_DATA_HOST: edgex-core-data
+      CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
+      CLIENTS_SUPPORT_NOTIFICATIONS_HOST: edgex-support-notifications
+      CLIENTS_SUPPORT_SCHEDULER_HOST: edgex-support-scheduler
+      DATABASE_HOST: edgex-redis
+      EDGEX_SECURITY_SECRET_STORE: "true"
+      PROXY_SETUP_HOST: edgex-security-proxy-setup
+      REGISTRY_HOST: edgex-core-consul
+      SECRETSTORE_HOST: edgex-vault
+      SECRETSTORE_PORT: "8200"
+      SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
+      SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
+      SPIFFE_TRUSTDOMAIN: edgexfoundry.org
+      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
+      STAGEGATE_DATABASE_HOST: edgex-redis
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
+      STAGEGATE_KONGDB_HOST: edgex-kong-db
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
+      STAGEGATE_REGISTRY_HOST: edgex-core-consul
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
+      STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
+      STAGEGATE_WAITFOR_TIMEOUT: 60s
+    hostname: edgex-core-common-config-bootstrapper
+    image: nexus3.edgexfoundry.org:10004/core-common-config-bootstrapper-arm64:latest
+    networks:
+      edgex-network: null
+    read_only: true
+    security_opt:
+    - no-new-privileges:true
+    user: 2002:2001
+    volumes:
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/core-common-config-bootstrapper
+      target: /tmp/edgex/secrets/core-common-config-bootstrapper
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   consul:
     command:
     - agent

--- a/docker-compose-no-secty-arm64.yml
+++ b/docker-compose-no-secty-arm64.yml
@@ -96,6 +96,28 @@ services:
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
+  common-config:
+    container_name: edgex-core-common-config-bootstrapper
+    depends_on:
+      consul:
+        condition: service_started
+    environment:
+      CLIENTS_CORE_COMMAND_HOST: edgex-core-command
+      CLIENTS_CORE_DATA_HOST: edgex-core-data
+      CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
+      CLIENTS_SUPPORT_NOTIFICATIONS_HOST: edgex-support-notifications
+      CLIENTS_SUPPORT_SCHEDULER_HOST: edgex-support-scheduler
+      DATABASE_HOST: edgex-redis
+      EDGEX_SECURITY_SECRET_STORE: "false"
+      REGISTRY_HOST: edgex-core-consul
+    hostname: edgex-core-common-config-bootstrapper
+    image: nexus3.edgexfoundry.org:10004/core-common-config-bootstrapper-arm64:latest
+    networks:
+      edgex-network: null
+    read_only: true
+    security_opt:
+    - no-new-privileges:true
+    user: 2002:2001
   consul:
     command:
     - agent

--- a/docker-compose-no-secty-with-app-sample-arm64.yml
+++ b/docker-compose-no-secty-with-app-sample-arm64.yml
@@ -130,6 +130,28 @@ services:
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
+  common-config:
+    container_name: edgex-core-common-config-bootstrapper
+    depends_on:
+      consul:
+        condition: service_started
+    environment:
+      CLIENTS_CORE_COMMAND_HOST: edgex-core-command
+      CLIENTS_CORE_DATA_HOST: edgex-core-data
+      CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
+      CLIENTS_SUPPORT_NOTIFICATIONS_HOST: edgex-support-notifications
+      CLIENTS_SUPPORT_SCHEDULER_HOST: edgex-support-scheduler
+      DATABASE_HOST: edgex-redis
+      EDGEX_SECURITY_SECRET_STORE: "false"
+      REGISTRY_HOST: edgex-core-consul
+    hostname: edgex-core-common-config-bootstrapper
+    image: nexus3.edgexfoundry.org:10004/core-common-config-bootstrapper-arm64:latest
+    networks:
+      edgex-network: null
+    read_only: true
+    security_opt:
+    - no-new-privileges:true
+    user: 2002:2001
   consul:
     command:
     - agent

--- a/docker-compose-no-secty-with-app-sample.yml
+++ b/docker-compose-no-secty-with-app-sample.yml
@@ -130,6 +130,28 @@ services:
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
+  common-config:
+    container_name: edgex-core-common-config-bootstrapper
+    depends_on:
+      consul:
+        condition: service_started
+    environment:
+      CLIENTS_CORE_COMMAND_HOST: edgex-core-command
+      CLIENTS_CORE_DATA_HOST: edgex-core-data
+      CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
+      CLIENTS_SUPPORT_NOTIFICATIONS_HOST: edgex-support-notifications
+      CLIENTS_SUPPORT_SCHEDULER_HOST: edgex-support-scheduler
+      DATABASE_HOST: edgex-redis
+      EDGEX_SECURITY_SECRET_STORE: "false"
+      REGISTRY_HOST: edgex-core-consul
+    hostname: edgex-core-common-config-bootstrapper
+    image: nexus3.edgexfoundry.org:10004/core-common-config-bootstrapper:latest
+    networks:
+      edgex-network: null
+    read_only: true
+    security_opt:
+    - no-new-privileges:true
+    user: 2002:2001
   consul:
     command:
     - agent

--- a/docker-compose-no-secty.yml
+++ b/docker-compose-no-secty.yml
@@ -96,6 +96,28 @@ services:
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
+  common-config:
+    container_name: edgex-core-common-config-bootstrapper
+    depends_on:
+      consul:
+        condition: service_started
+    environment:
+      CLIENTS_CORE_COMMAND_HOST: edgex-core-command
+      CLIENTS_CORE_DATA_HOST: edgex-core-data
+      CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
+      CLIENTS_SUPPORT_NOTIFICATIONS_HOST: edgex-support-notifications
+      CLIENTS_SUPPORT_SCHEDULER_HOST: edgex-support-scheduler
+      DATABASE_HOST: edgex-redis
+      EDGEX_SECURITY_SECRET_STORE: "false"
+      REGISTRY_HOST: edgex-core-consul
+    hostname: edgex-core-common-config-bootstrapper
+    image: nexus3.edgexfoundry.org:10004/core-common-config-bootstrapper:latest
+    networks:
+      edgex-network: null
+    read_only: true
+    security_opt:
+    - no-new-privileges:true
+    user: 2002:2001
   consul:
     command:
     - agent

--- a/docker-compose-with-app-sample-arm64.yml
+++ b/docker-compose-with-app-sample-arm64.yml
@@ -270,6 +270,76 @@ services:
       bind:
         selinux: z
         create_host_path: true
+  common-config:
+    command:
+    - /entrypoint.sh
+    - /core-common-config-bootstrapper
+    - -cp=consul.http://edgex-core-consul:8500
+    container_name: edgex-core-common-config-bootstrapper
+    depends_on:
+      consul:
+        condition: service_started
+      secretstore-setup:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
+    entrypoint:
+    - /edgex-init/ready_to_run_wait_install.sh
+    environment:
+      API_GATEWAY_HOST: edgex-kong
+      API_GATEWAY_STATUS_PORT: "8100"
+      CLIENTS_CORE_COMMAND_HOST: edgex-core-command
+      CLIENTS_CORE_DATA_HOST: edgex-core-data
+      CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
+      CLIENTS_SUPPORT_NOTIFICATIONS_HOST: edgex-support-notifications
+      CLIENTS_SUPPORT_SCHEDULER_HOST: edgex-support-scheduler
+      DATABASE_HOST: edgex-redis
+      EDGEX_SECURITY_SECRET_STORE: "true"
+      PROXY_SETUP_HOST: edgex-security-proxy-setup
+      REGISTRY_HOST: edgex-core-consul
+      SECRETSTORE_HOST: edgex-vault
+      SECRETSTORE_PORT: "8200"
+      SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
+      SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
+      SPIFFE_TRUSTDOMAIN: edgexfoundry.org
+      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
+      STAGEGATE_DATABASE_HOST: edgex-redis
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
+      STAGEGATE_KONGDB_HOST: edgex-kong-db
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
+      STAGEGATE_REGISTRY_HOST: edgex-core-consul
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
+      STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
+      STAGEGATE_WAITFOR_TIMEOUT: 60s
+    hostname: edgex-core-common-config-bootstrapper
+    image: nexus3.edgexfoundry.org:10004/core-common-config-bootstrapper-arm64:latest
+    networks:
+      edgex-network: null
+    read_only: true
+    security_opt:
+    - no-new-privileges:true
+    user: 2002:2001
+    volumes:
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/core-common-config-bootstrapper
+      target: /tmp/edgex/secrets/core-common-config-bootstrapper
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   consul:
     command:
     - agent

--- a/docker-compose-with-app-sample.yml
+++ b/docker-compose-with-app-sample.yml
@@ -270,6 +270,76 @@ services:
       bind:
         selinux: z
         create_host_path: true
+  common-config:
+    command:
+    - /entrypoint.sh
+    - /core-common-config-bootstrapper
+    - -cp=consul.http://edgex-core-consul:8500
+    container_name: edgex-core-common-config-bootstrapper
+    depends_on:
+      consul:
+        condition: service_started
+      secretstore-setup:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
+    entrypoint:
+    - /edgex-init/ready_to_run_wait_install.sh
+    environment:
+      API_GATEWAY_HOST: edgex-kong
+      API_GATEWAY_STATUS_PORT: "8100"
+      CLIENTS_CORE_COMMAND_HOST: edgex-core-command
+      CLIENTS_CORE_DATA_HOST: edgex-core-data
+      CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
+      CLIENTS_SUPPORT_NOTIFICATIONS_HOST: edgex-support-notifications
+      CLIENTS_SUPPORT_SCHEDULER_HOST: edgex-support-scheduler
+      DATABASE_HOST: edgex-redis
+      EDGEX_SECURITY_SECRET_STORE: "true"
+      PROXY_SETUP_HOST: edgex-security-proxy-setup
+      REGISTRY_HOST: edgex-core-consul
+      SECRETSTORE_HOST: edgex-vault
+      SECRETSTORE_PORT: "8200"
+      SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
+      SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
+      SPIFFE_TRUSTDOMAIN: edgexfoundry.org
+      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
+      STAGEGATE_DATABASE_HOST: edgex-redis
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
+      STAGEGATE_KONGDB_HOST: edgex-kong-db
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
+      STAGEGATE_REGISTRY_HOST: edgex-core-consul
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
+      STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
+      STAGEGATE_WAITFOR_TIMEOUT: 60s
+    hostname: edgex-core-common-config-bootstrapper
+    image: nexus3.edgexfoundry.org:10004/core-common-config-bootstrapper:latest
+    networks:
+      edgex-network: null
+    read_only: true
+    security_opt:
+    - no-new-privileges:true
+    user: 2002:2001
+    volumes:
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/core-common-config-bootstrapper
+      target: /tmp/edgex/secrets/core-common-config-bootstrapper
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   consul:
     command:
     - agent

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -190,6 +190,76 @@ services:
       bind:
         selinux: z
         create_host_path: true
+  common-config:
+    command:
+    - /entrypoint.sh
+    - /core-common-config-bootstrapper
+    - -cp=consul.http://edgex-core-consul:8500
+    container_name: edgex-core-common-config-bootstrapper
+    depends_on:
+      consul:
+        condition: service_started
+      secretstore-setup:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
+    entrypoint:
+    - /edgex-init/ready_to_run_wait_install.sh
+    environment:
+      API_GATEWAY_HOST: edgex-kong
+      API_GATEWAY_STATUS_PORT: "8100"
+      CLIENTS_CORE_COMMAND_HOST: edgex-core-command
+      CLIENTS_CORE_DATA_HOST: edgex-core-data
+      CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
+      CLIENTS_SUPPORT_NOTIFICATIONS_HOST: edgex-support-notifications
+      CLIENTS_SUPPORT_SCHEDULER_HOST: edgex-support-scheduler
+      DATABASE_HOST: edgex-redis
+      EDGEX_SECURITY_SECRET_STORE: "true"
+      PROXY_SETUP_HOST: edgex-security-proxy-setup
+      REGISTRY_HOST: edgex-core-consul
+      SECRETSTORE_HOST: edgex-vault
+      SECRETSTORE_PORT: "8200"
+      SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
+      SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
+      SPIFFE_TRUSTDOMAIN: edgexfoundry.org
+      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
+      STAGEGATE_DATABASE_HOST: edgex-redis
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
+      STAGEGATE_KONGDB_HOST: edgex-kong-db
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
+      STAGEGATE_REGISTRY_HOST: edgex-core-consul
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
+      STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
+      STAGEGATE_WAITFOR_TIMEOUT: 60s
+    hostname: edgex-core-common-config-bootstrapper
+    image: nexus3.edgexfoundry.org:10004/core-common-config-bootstrapper:latest
+    networks:
+      edgex-network: null
+    read_only: true
+    security_opt:
+    - no-new-privileges:true
+    user: 2002:2001
+    volumes:
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/core-common-config-bootstrapper
+      target: /tmp/edgex/secrets/core-common-config-bootstrapper
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   consul:
     command:
     - agent

--- a/taf/docker-compose-taf-arm64.yml
+++ b/taf/docker-compose-taf-arm64.yml
@@ -597,6 +597,76 @@ services:
       bind:
         selinux: z
         create_host_path: true
+  common-config:
+    command:
+    - /entrypoint.sh
+    - /core-common-config-bootstrapper
+    - -cp=consul.http://edgex-core-consul:8500
+    container_name: edgex-core-common-config-bootstrapper
+    depends_on:
+      consul:
+        condition: service_started
+      secretstore-setup:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
+    entrypoint:
+    - /edgex-init/ready_to_run_wait_install.sh
+    environment:
+      API_GATEWAY_HOST: edgex-kong
+      API_GATEWAY_STATUS_PORT: "8100"
+      CLIENTS_CORE_COMMAND_HOST: edgex-core-command
+      CLIENTS_CORE_DATA_HOST: edgex-core-data
+      CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
+      CLIENTS_SUPPORT_NOTIFICATIONS_HOST: edgex-support-notifications
+      CLIENTS_SUPPORT_SCHEDULER_HOST: edgex-support-scheduler
+      DATABASE_HOST: edgex-redis
+      EDGEX_SECURITY_SECRET_STORE: "true"
+      PROXY_SETUP_HOST: edgex-security-proxy-setup
+      REGISTRY_HOST: edgex-core-consul
+      SECRETSTORE_HOST: edgex-vault
+      SECRETSTORE_PORT: "8200"
+      SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
+      SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
+      SPIFFE_TRUSTDOMAIN: edgexfoundry.org
+      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
+      STAGEGATE_DATABASE_HOST: edgex-redis
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
+      STAGEGATE_KONGDB_HOST: edgex-kong-db
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
+      STAGEGATE_REGISTRY_HOST: edgex-core-consul
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
+      STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
+      STAGEGATE_WAITFOR_TIMEOUT: 60s
+    hostname: edgex-core-common-config-bootstrapper
+    image: nexus3.edgexfoundry.org:10004/core-common-config-bootstrapper-arm64:latest
+    networks:
+      edgex-network: null
+    read_only: true
+    security_opt:
+    - no-new-privileges:true
+    user: 2002:2001
+    volumes:
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/core-common-config-bootstrapper
+      target: /tmp/edgex/secrets/core-common-config-bootstrapper
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   consul:
     command:
     - agent

--- a/taf/docker-compose-taf-mqtt-bus-arm64.yml
+++ b/taf/docker-compose-taf-mqtt-bus-arm64.yml
@@ -636,6 +636,76 @@ services:
       bind:
         selinux: z
         create_host_path: true
+  common-config:
+    command:
+    - /entrypoint.sh
+    - /core-common-config-bootstrapper
+    - -cp=consul.http://edgex-core-consul:8500
+    container_name: edgex-core-common-config-bootstrapper
+    depends_on:
+      consul:
+        condition: service_started
+      secretstore-setup:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
+    entrypoint:
+    - /edgex-init/ready_to_run_wait_install.sh
+    environment:
+      API_GATEWAY_HOST: edgex-kong
+      API_GATEWAY_STATUS_PORT: "8100"
+      CLIENTS_CORE_COMMAND_HOST: edgex-core-command
+      CLIENTS_CORE_DATA_HOST: edgex-core-data
+      CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
+      CLIENTS_SUPPORT_NOTIFICATIONS_HOST: edgex-support-notifications
+      CLIENTS_SUPPORT_SCHEDULER_HOST: edgex-support-scheduler
+      DATABASE_HOST: edgex-redis
+      EDGEX_SECURITY_SECRET_STORE: "true"
+      PROXY_SETUP_HOST: edgex-security-proxy-setup
+      REGISTRY_HOST: edgex-core-consul
+      SECRETSTORE_HOST: edgex-vault
+      SECRETSTORE_PORT: "8200"
+      SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
+      SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
+      SPIFFE_TRUSTDOMAIN: edgexfoundry.org
+      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
+      STAGEGATE_DATABASE_HOST: edgex-redis
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
+      STAGEGATE_KONGDB_HOST: edgex-kong-db
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
+      STAGEGATE_REGISTRY_HOST: edgex-core-consul
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
+      STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
+      STAGEGATE_WAITFOR_TIMEOUT: 60s
+    hostname: edgex-core-common-config-bootstrapper
+    image: nexus3.edgexfoundry.org:10004/core-common-config-bootstrapper-arm64:latest
+    networks:
+      edgex-network: null
+    read_only: true
+    security_opt:
+    - no-new-privileges:true
+    user: 2002:2001
+    volumes:
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/core-common-config-bootstrapper
+      target: /tmp/edgex/secrets/core-common-config-bootstrapper
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   consul:
     command:
     - agent

--- a/taf/docker-compose-taf-mqtt-bus.yml
+++ b/taf/docker-compose-taf-mqtt-bus.yml
@@ -636,6 +636,76 @@ services:
       bind:
         selinux: z
         create_host_path: true
+  common-config:
+    command:
+    - /entrypoint.sh
+    - /core-common-config-bootstrapper
+    - -cp=consul.http://edgex-core-consul:8500
+    container_name: edgex-core-common-config-bootstrapper
+    depends_on:
+      consul:
+        condition: service_started
+      secretstore-setup:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
+    entrypoint:
+    - /edgex-init/ready_to_run_wait_install.sh
+    environment:
+      API_GATEWAY_HOST: edgex-kong
+      API_GATEWAY_STATUS_PORT: "8100"
+      CLIENTS_CORE_COMMAND_HOST: edgex-core-command
+      CLIENTS_CORE_DATA_HOST: edgex-core-data
+      CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
+      CLIENTS_SUPPORT_NOTIFICATIONS_HOST: edgex-support-notifications
+      CLIENTS_SUPPORT_SCHEDULER_HOST: edgex-support-scheduler
+      DATABASE_HOST: edgex-redis
+      EDGEX_SECURITY_SECRET_STORE: "true"
+      PROXY_SETUP_HOST: edgex-security-proxy-setup
+      REGISTRY_HOST: edgex-core-consul
+      SECRETSTORE_HOST: edgex-vault
+      SECRETSTORE_PORT: "8200"
+      SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
+      SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
+      SPIFFE_TRUSTDOMAIN: edgexfoundry.org
+      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
+      STAGEGATE_DATABASE_HOST: edgex-redis
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
+      STAGEGATE_KONGDB_HOST: edgex-kong-db
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
+      STAGEGATE_REGISTRY_HOST: edgex-core-consul
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
+      STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
+      STAGEGATE_WAITFOR_TIMEOUT: 60s
+    hostname: edgex-core-common-config-bootstrapper
+    image: nexus3.edgexfoundry.org:10004/core-common-config-bootstrapper:latest
+    networks:
+      edgex-network: null
+    read_only: true
+    security_opt:
+    - no-new-privileges:true
+    user: 2002:2001
+    volumes:
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/core-common-config-bootstrapper
+      target: /tmp/edgex/secrets/core-common-config-bootstrapper
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   consul:
     command:
     - agent

--- a/taf/docker-compose-taf-no-secty-arm64.yml
+++ b/taf/docker-compose-taf-no-secty-arm64.yml
@@ -273,6 +273,28 @@ services:
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
+  common-config:
+    container_name: edgex-core-common-config-bootstrapper
+    depends_on:
+      consul:
+        condition: service_started
+    environment:
+      CLIENTS_CORE_COMMAND_HOST: edgex-core-command
+      CLIENTS_CORE_DATA_HOST: edgex-core-data
+      CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
+      CLIENTS_SUPPORT_NOTIFICATIONS_HOST: edgex-support-notifications
+      CLIENTS_SUPPORT_SCHEDULER_HOST: edgex-support-scheduler
+      DATABASE_HOST: edgex-redis
+      EDGEX_SECURITY_SECRET_STORE: "false"
+      REGISTRY_HOST: edgex-core-consul
+    hostname: edgex-core-common-config-bootstrapper
+    image: nexus3.edgexfoundry.org:10004/core-common-config-bootstrapper-arm64:latest
+    networks:
+      edgex-network: null
+    read_only: true
+    security_opt:
+    - no-new-privileges:true
+    user: 2002:2001
   consul:
     command:
     - agent

--- a/taf/docker-compose-taf-no-secty-mqtt-bus-arm64.yml
+++ b/taf/docker-compose-taf-no-secty-mqtt-bus-arm64.yml
@@ -305,6 +305,28 @@ services:
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
+  common-config:
+    container_name: edgex-core-common-config-bootstrapper
+    depends_on:
+      consul:
+        condition: service_started
+    environment:
+      CLIENTS_CORE_COMMAND_HOST: edgex-core-command
+      CLIENTS_CORE_DATA_HOST: edgex-core-data
+      CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
+      CLIENTS_SUPPORT_NOTIFICATIONS_HOST: edgex-support-notifications
+      CLIENTS_SUPPORT_SCHEDULER_HOST: edgex-support-scheduler
+      DATABASE_HOST: edgex-redis
+      EDGEX_SECURITY_SECRET_STORE: "false"
+      REGISTRY_HOST: edgex-core-consul
+    hostname: edgex-core-common-config-bootstrapper
+    image: nexus3.edgexfoundry.org:10004/core-common-config-bootstrapper-arm64:latest
+    networks:
+      edgex-network: null
+    read_only: true
+    security_opt:
+    - no-new-privileges:true
+    user: 2002:2001
   consul:
     command:
     - agent

--- a/taf/docker-compose-taf-no-secty-mqtt-bus.yml
+++ b/taf/docker-compose-taf-no-secty-mqtt-bus.yml
@@ -305,6 +305,28 @@ services:
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
+  common-config:
+    container_name: edgex-core-common-config-bootstrapper
+    depends_on:
+      consul:
+        condition: service_started
+    environment:
+      CLIENTS_CORE_COMMAND_HOST: edgex-core-command
+      CLIENTS_CORE_DATA_HOST: edgex-core-data
+      CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
+      CLIENTS_SUPPORT_NOTIFICATIONS_HOST: edgex-support-notifications
+      CLIENTS_SUPPORT_SCHEDULER_HOST: edgex-support-scheduler
+      DATABASE_HOST: edgex-redis
+      EDGEX_SECURITY_SECRET_STORE: "false"
+      REGISTRY_HOST: edgex-core-consul
+    hostname: edgex-core-common-config-bootstrapper
+    image: nexus3.edgexfoundry.org:10004/core-common-config-bootstrapper:latest
+    networks:
+      edgex-network: null
+    read_only: true
+    security_opt:
+    - no-new-privileges:true
+    user: 2002:2001
   consul:
     command:
     - agent

--- a/taf/docker-compose-taf-no-secty.yml
+++ b/taf/docker-compose-taf-no-secty.yml
@@ -273,6 +273,28 @@ services:
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
+  common-config:
+    container_name: edgex-core-common-config-bootstrapper
+    depends_on:
+      consul:
+        condition: service_started
+    environment:
+      CLIENTS_CORE_COMMAND_HOST: edgex-core-command
+      CLIENTS_CORE_DATA_HOST: edgex-core-data
+      CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
+      CLIENTS_SUPPORT_NOTIFICATIONS_HOST: edgex-support-notifications
+      CLIENTS_SUPPORT_SCHEDULER_HOST: edgex-support-scheduler
+      DATABASE_HOST: edgex-redis
+      EDGEX_SECURITY_SECRET_STORE: "false"
+      REGISTRY_HOST: edgex-core-consul
+    hostname: edgex-core-common-config-bootstrapper
+    image: nexus3.edgexfoundry.org:10004/core-common-config-bootstrapper:latest
+    networks:
+      edgex-network: null
+    read_only: true
+    security_opt:
+    - no-new-privileges:true
+    user: 2002:2001
   consul:
     command:
     - agent

--- a/taf/docker-compose-taf-perf-arm64.yml
+++ b/taf/docker-compose-taf-perf-arm64.yml
@@ -273,6 +273,76 @@ services:
       bind:
         selinux: z
         create_host_path: true
+  common-config:
+    command:
+    - /entrypoint.sh
+    - /core-common-config-bootstrapper
+    - -cp=consul.http://edgex-core-consul:8500
+    container_name: edgex-core-common-config-bootstrapper
+    depends_on:
+      consul:
+        condition: service_started
+      secretstore-setup:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
+    entrypoint:
+    - /edgex-init/ready_to_run_wait_install.sh
+    environment:
+      API_GATEWAY_HOST: edgex-kong
+      API_GATEWAY_STATUS_PORT: "8100"
+      CLIENTS_CORE_COMMAND_HOST: edgex-core-command
+      CLIENTS_CORE_DATA_HOST: edgex-core-data
+      CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
+      CLIENTS_SUPPORT_NOTIFICATIONS_HOST: edgex-support-notifications
+      CLIENTS_SUPPORT_SCHEDULER_HOST: edgex-support-scheduler
+      DATABASE_HOST: edgex-redis
+      EDGEX_SECURITY_SECRET_STORE: "true"
+      PROXY_SETUP_HOST: edgex-security-proxy-setup
+      REGISTRY_HOST: edgex-core-consul
+      SECRETSTORE_HOST: edgex-vault
+      SECRETSTORE_PORT: "8200"
+      SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
+      SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
+      SPIFFE_TRUSTDOMAIN: edgexfoundry.org
+      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
+      STAGEGATE_DATABASE_HOST: edgex-redis
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
+      STAGEGATE_KONGDB_HOST: edgex-kong-db
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
+      STAGEGATE_REGISTRY_HOST: edgex-core-consul
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
+      STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
+      STAGEGATE_WAITFOR_TIMEOUT: 60s
+    hostname: edgex-core-common-config-bootstrapper
+    image: nexus3.edgexfoundry.org:10004/core-common-config-bootstrapper-arm64:latest
+    networks:
+      edgex-network: null
+    read_only: true
+    security_opt:
+    - no-new-privileges:true
+    user: 2002:2001
+    volumes:
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/core-common-config-bootstrapper
+      target: /tmp/edgex/secrets/core-common-config-bootstrapper
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   consul:
     command:
     - agent

--- a/taf/docker-compose-taf-perf-no-secty-arm64.yml
+++ b/taf/docker-compose-taf-perf-no-secty-arm64.yml
@@ -133,6 +133,28 @@ services:
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
+  common-config:
+    container_name: edgex-core-common-config-bootstrapper
+    depends_on:
+      consul:
+        condition: service_started
+    environment:
+      CLIENTS_CORE_COMMAND_HOST: edgex-core-command
+      CLIENTS_CORE_DATA_HOST: edgex-core-data
+      CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
+      CLIENTS_SUPPORT_NOTIFICATIONS_HOST: edgex-support-notifications
+      CLIENTS_SUPPORT_SCHEDULER_HOST: edgex-support-scheduler
+      DATABASE_HOST: edgex-redis
+      EDGEX_SECURITY_SECRET_STORE: "false"
+      REGISTRY_HOST: edgex-core-consul
+    hostname: edgex-core-common-config-bootstrapper
+    image: nexus3.edgexfoundry.org:10004/core-common-config-bootstrapper-arm64:latest
+    networks:
+      edgex-network: null
+    read_only: true
+    security_opt:
+    - no-new-privileges:true
+    user: 2002:2001
   consul:
     command:
     - agent

--- a/taf/docker-compose-taf-perf-no-secty.yml
+++ b/taf/docker-compose-taf-perf-no-secty.yml
@@ -133,6 +133,28 @@ services:
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
+  common-config:
+    container_name: edgex-core-common-config-bootstrapper
+    depends_on:
+      consul:
+        condition: service_started
+    environment:
+      CLIENTS_CORE_COMMAND_HOST: edgex-core-command
+      CLIENTS_CORE_DATA_HOST: edgex-core-data
+      CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
+      CLIENTS_SUPPORT_NOTIFICATIONS_HOST: edgex-support-notifications
+      CLIENTS_SUPPORT_SCHEDULER_HOST: edgex-support-scheduler
+      DATABASE_HOST: edgex-redis
+      EDGEX_SECURITY_SECRET_STORE: "false"
+      REGISTRY_HOST: edgex-core-consul
+    hostname: edgex-core-common-config-bootstrapper
+    image: nexus3.edgexfoundry.org:10004/core-common-config-bootstrapper:latest
+    networks:
+      edgex-network: null
+    read_only: true
+    security_opt:
+    - no-new-privileges:true
+    user: 2002:2001
   consul:
     command:
     - agent

--- a/taf/docker-compose-taf-perf.yml
+++ b/taf/docker-compose-taf-perf.yml
@@ -273,6 +273,76 @@ services:
       bind:
         selinux: z
         create_host_path: true
+  common-config:
+    command:
+    - /entrypoint.sh
+    - /core-common-config-bootstrapper
+    - -cp=consul.http://edgex-core-consul:8500
+    container_name: edgex-core-common-config-bootstrapper
+    depends_on:
+      consul:
+        condition: service_started
+      secretstore-setup:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
+    entrypoint:
+    - /edgex-init/ready_to_run_wait_install.sh
+    environment:
+      API_GATEWAY_HOST: edgex-kong
+      API_GATEWAY_STATUS_PORT: "8100"
+      CLIENTS_CORE_COMMAND_HOST: edgex-core-command
+      CLIENTS_CORE_DATA_HOST: edgex-core-data
+      CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
+      CLIENTS_SUPPORT_NOTIFICATIONS_HOST: edgex-support-notifications
+      CLIENTS_SUPPORT_SCHEDULER_HOST: edgex-support-scheduler
+      DATABASE_HOST: edgex-redis
+      EDGEX_SECURITY_SECRET_STORE: "true"
+      PROXY_SETUP_HOST: edgex-security-proxy-setup
+      REGISTRY_HOST: edgex-core-consul
+      SECRETSTORE_HOST: edgex-vault
+      SECRETSTORE_PORT: "8200"
+      SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
+      SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
+      SPIFFE_TRUSTDOMAIN: edgexfoundry.org
+      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
+      STAGEGATE_DATABASE_HOST: edgex-redis
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
+      STAGEGATE_KONGDB_HOST: edgex-kong-db
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
+      STAGEGATE_REGISTRY_HOST: edgex-core-consul
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
+      STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
+      STAGEGATE_WAITFOR_TIMEOUT: 60s
+    hostname: edgex-core-common-config-bootstrapper
+    image: nexus3.edgexfoundry.org:10004/core-common-config-bootstrapper:latest
+    networks:
+      edgex-network: null
+    read_only: true
+    security_opt:
+    - no-new-privileges:true
+    user: 2002:2001
+    volumes:
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/core-common-config-bootstrapper
+      target: /tmp/edgex/secrets/core-common-config-bootstrapper
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   consul:
     command:
     - agent

--- a/taf/docker-compose-taf.yml
+++ b/taf/docker-compose-taf.yml
@@ -597,6 +597,76 @@ services:
       bind:
         selinux: z
         create_host_path: true
+  common-config:
+    command:
+    - /entrypoint.sh
+    - /core-common-config-bootstrapper
+    - -cp=consul.http://edgex-core-consul:8500
+    container_name: edgex-core-common-config-bootstrapper
+    depends_on:
+      consul:
+        condition: service_started
+      secretstore-setup:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
+    entrypoint:
+    - /edgex-init/ready_to_run_wait_install.sh
+    environment:
+      API_GATEWAY_HOST: edgex-kong
+      API_GATEWAY_STATUS_PORT: "8100"
+      CLIENTS_CORE_COMMAND_HOST: edgex-core-command
+      CLIENTS_CORE_DATA_HOST: edgex-core-data
+      CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
+      CLIENTS_SUPPORT_NOTIFICATIONS_HOST: edgex-support-notifications
+      CLIENTS_SUPPORT_SCHEDULER_HOST: edgex-support-scheduler
+      DATABASE_HOST: edgex-redis
+      EDGEX_SECURITY_SECRET_STORE: "true"
+      PROXY_SETUP_HOST: edgex-security-proxy-setup
+      REGISTRY_HOST: edgex-core-consul
+      SECRETSTORE_HOST: edgex-vault
+      SECRETSTORE_PORT: "8200"
+      SPIFFE_ENDPOINTSOCKET: /tmp/edgex/secrets/spiffe/public/api.sock
+      SPIFFE_TRUSTBUNDLE_PATH: /tmp/edgex/secrets/spiffe/trust/bundle
+      SPIFFE_TRUSTDOMAIN: edgexfoundry.org
+      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
+      STAGEGATE_DATABASE_HOST: edgex-redis
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
+      STAGEGATE_KONGDB_HOST: edgex-kong-db
+      STAGEGATE_KONGDB_PORT: "5432"
+      STAGEGATE_KONGDB_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
+      STAGEGATE_REGISTRY_HOST: edgex-core-consul
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
+      STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
+      STAGEGATE_WAITFOR_TIMEOUT: 60s
+    hostname: edgex-core-common-config-bootstrapper
+    image: nexus3.edgexfoundry.org:10004/core-common-config-bootstrapper:latest
+    networks:
+      edgex-network: null
+    read_only: true
+    security_opt:
+    - no-new-privileges:true
+    user: 2002:2001
+    volumes:
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      bind:
+        selinux: z
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/core-common-config-bootstrapper
+      target: /tmp/edgex/secrets/core-common-config-bootstrapper
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   consul:
     command:
     - agent


### PR DESCRIPTION
closes #320

Note this PR is dependent on https://github.com/edgexfoundry/edgex-go/pull/4300 so that this works properly in secure mode.

Signed-off-by: Leonard Goodell <leonard.goodell@intel.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-compose/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-compose/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  TBD


## Testing Instructions
Run the following compose builder commands from this branch 

- `make pull`
### Non Secure Mode
- `make run no-secty`
- Verify `core-common-config-bootstrapper service` logs show the following.
```
level=INFO ts=2023-01-23T15:12:28.3485979Z app=core-common-config-bootstrapper source=main.go:52 msg="Core Common Config is starting"
level=INFO ts=2023-01-23T15:12:28.3486855Z app=core-common-config-bootstrapper source=main.go:66 msg="Secret Provider created"
level=INFO ts=2023-01-23T15:12:28.3486979Z app=core-common-config-bootstrapper source=main.go:74 msg="Got Config Provider Access Token"
level=INFO ts=2023-01-23T15:12:28.348706Z app=core-common-config-bootstrapper source=main.go:75 msg="Core Common Config Ready for stage two"
level=INFO ts=2023-01-23T15:12:28.348714Z app=core-common-config-bootstrapper source=main.go:76 msg="Core Common Config exiting"
```
- Verify the core-common-config-bootstrapper service container is still running.
- Run `make clean` to stop all the services.

### Secure Mode
- `make run`
- Verify `core-common-config-bootstrapper service` logs show the following.
```
Script for waiting on security bootstrapping ready-to-run
Mon Jan 23 15:54:53 UTC 2023 Executing waitFor with ./entrypoint.sh waiting on tcp://edgex-security-bootstrapper:54329
level=INFO ts=2023-01-23T15:54:53.6034935Z app=security-bootstrapper source=config.go:396 msg="Loaded service configuration from /edgex-init/res/configuration.toml"
level=INFO ts=2023-01-23T15:54:53.6038998Z app=security-bootstrapper source=variables.go:377 msg="Variables override of 'StageGate.SecretStoreSetup.Tokens.ReadyPort' by environment variable: STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT=54322"
level=INFO ts=2023-01-23T15:54:53.6039694Z app=security-bootstrapper source=variables.go:377 msg="Variables override of 'StageGate.Registry.Port' by environment variable: STAGEGATE_REGISTRY_PORT=8500"
level=INFO ts=2023-01-23T15:54:53.6039807Z app=security-bootstrapper source=variables.go:377 msg="Variables override of 'StageGate.BootStrapper.Host' by environment variable: STAGEGATE_BOOTSTRAPPER_HOST=edgex-security-bootstrapper"
level=INFO ts=2023-01-23T15:54:53.6039873Z app=security-bootstrapper source=variables.go:377 msg="Variables override of 'StageGate.KongDB.ReadyPort' by environment variable: STAGEGATE_KONGDB_READYPORT=54325"
level=INFO ts=2023-01-23T15:54:53.6039931Z app=security-bootstrapper source=variables.go:377 msg="Variables override of 'StageGate.Registry.ReadyPort' by environment variable: STAGEGATE_REGISTRY_READYPORT=54324"
level=INFO ts=2023-01-23T15:54:53.6039994Z app=security-bootstrapper source=variables.go:377 msg="Variables override of 'StageGate.BootStrapper.StartPort' by environment variable: STAGEGATE_BOOTSTRAPPER_STARTPORT=54321"
level=INFO ts=2023-01-23T15:54:53.6040068Z app=security-bootstrapper source=variables.go:377 msg="Variables override of 'StageGate.SecretStoreSetup.Host' by environment variable: STAGEGATE_SECRETSTORESETUP_HOST=edgex-security-secretstore-setup"
level=INFO ts=2023-01-23T15:54:53.6040183Z app=security-bootstrapper source=variables.go:377 msg="Variables override of 'StageGate.Ready.ToRunPort' by environment variable: STAGEGATE_READY_TORUNPORT=54329"
level=INFO ts=2023-01-23T15:54:53.6040286Z app=security-bootstrapper source=variables.go:377 msg="Variables override of 'StageGate.Registry.Host' by environment variable: STAGEGATE_REGISTRY_HOST=edgex-core-consul"
level=INFO ts=2023-01-23T15:54:53.6040619Z app=security-bootstrapper source=variables.go:377 msg="Variables override of 'StageGate.Database.ReadyPort' by environment variable: STAGEGATE_DATABASE_READYPORT=6379"
level=INFO ts=2023-01-23T15:54:53.6040764Z app=security-bootstrapper source=variables.go:377 msg="Variables override of 'StageGate.KongDB.Port' by environment variable: STAGEGATE_KONGDB_PORT=5432"
level=INFO ts=2023-01-23T15:54:53.6041116Z app=security-bootstrapper source=variables.go:377 msg="Variables override of 'StageGate.Database.Port' by environment variable: STAGEGATE_DATABASE_PORT=6379"
level=INFO ts=2023-01-23T15:54:53.6041219Z app=security-bootstrapper source=variables.go:377 msg="Variables override of 'StageGate.KongDB.Host' by environment variable: STAGEGATE_KONGDB_HOST=edgex-kong-db"
level=INFO ts=2023-01-23T15:54:53.6041286Z app=security-bootstrapper source=variables.go:377 msg="Variables override of 'StageGate.Database.Host' by environment variable: STAGEGATE_DATABASE_HOST=edgex-redis"
level=INFO ts=2023-01-23T15:54:53.6041341Z app=security-bootstrapper source=variables.go:377 msg="Variables override of 'StageGate.WaitFor.Timeout' by environment variable: STAGEGATE_WAITFOR_TIMEOUT=60s"
level=INFO ts=2023-01-23T15:54:53.6041877Z app=security-bootstrapper source=config.go:551 msg="Using local configuration from file (15 envVars overrides applied)"
level=INFO ts=2023-01-23T15:54:53.6042523Z app=security-bootstrapper source=command.go:119 msg="Security bootstrapper running waitFor"
level=INFO ts=2023-01-23T15:54:53.6043577Z app=security-bootstrapper source=command.go:144 msg="Waiting for: [tcp://edgex-security-bootstrapper:54329] with timeout: [1m0s]"
level=INFO ts=2023-01-23T15:54:53.6053865Z app=security-bootstrapper source=command.go:209 msg="Problem with dial: dial tcp 172.26.0.2:54329: connect: connection refused. Sleeping 1s"
level=INFO ts=2023-01-23T15:54:54.606196Z app=security-bootstrapper source=command.go:209 msg="Problem with dial: dial tcp 172.26.0.2:54329: connect: connection refused. Sleeping 1s"
level=INFO ts=2023-01-23T15:54:55.6080185Z app=security-bootstrapper source=command.go:209 msg="Problem with dial: dial tcp 172.26.0.2:54329: connect: connection refused. Sleeping 1s"
level=INFO ts=2023-01-23T15:54:56.6091847Z app=security-bootstrapper source=command.go:209 msg="Problem with dial: dial tcp 172.26.0.2:54329: connect: connection refused. Sleeping 1s"
level=INFO ts=2023-01-23T15:54:57.610026Z app=security-bootstrapper source=command.go:209 msg="Problem with dial: dial tcp 172.26.0.2:54329: connect: connection refused. Sleeping 1s"
level=INFO ts=2023-01-23T15:54:58.6117218Z app=security-bootstrapper source=command.go:209 msg="Problem with dial: dial tcp 172.26.0.2:54329: connect: connection refused. Sleeping 1s"
level=INFO ts=2023-01-23T15:54:59.6125696Z app=security-bootstrapper source=command.go:209 msg="Problem with dial: dial tcp 172.26.0.2:54329: connect: connection refused. Sleeping 1s"
level=INFO ts=2023-01-23T15:55:00.613436Z app=security-bootstrapper source=command.go:209 msg="Problem with dial: dial tcp 172.26.0.2:54329: connect: connection refused. Sleeping 1s"
level=INFO ts=2023-01-23T15:55:01.6143914Z app=security-bootstrapper source=command.go:209 msg="Problem with dial: dial tcp 172.26.0.2:54329: connect: connection refused. Sleeping 1s"
level=INFO ts=2023-01-23T15:55:02.6154804Z app=security-bootstrapper source=command.go:214 msg="Connected to tcp://edgex-security-bootstrapper:54329"
Mon Jan 23 15:55:02 UTC 2023 Starting ./entrypoint.sh ...
level=INFO ts=2023-01-23T15:55:02.6307245Z app=core-common-config-bootstrapper source=main.go:52 msg="Core Common Config is starting"
level=INFO ts=2023-01-23T15:55:02.6307995Z app=core-common-config-bootstrapper source=secret.go:65 msg="Creating SecretClient"
level=INFO ts=2023-01-23T15:55:02.6311709Z app=core-common-config-bootstrapper source=variables.go:377 msg="Variables override of 'SecretStore.Host' by environment variable: SECRETSTORE_HOST=edgex-vault"
level=INFO ts=2023-01-23T15:55:02.6312052Z app=core-common-config-bootstrapper source=variables.go:377 msg="Variables override of 'SecretStore.Port' by environment variable: SECRETSTORE_PORT=8200"
level=INFO ts=2023-01-23T15:55:02.6313Z app=core-common-config-bootstrapper source=secret.go:159 msg="SecretStore information created with 2 overrides applied"
level=INFO ts=2023-01-23T15:55:02.6313475Z app=core-common-config-bootstrapper source=secret.go:75 msg="Reading secret store configuration and authentication token"
level=INFO ts=2023-01-23T15:55:02.6313655Z app=core-common-config-bootstrapper source=secret.go:200 msg="load token from file"
level=INFO ts=2023-01-23T15:55:02.6315243Z app=core-common-config-bootstrapper source=secret.go:93 msg="Attempting to create secret client"
level=INFO ts=2023-01-23T15:55:02.6359284Z app=core-common-config-bootstrapper source=secret.go:104 msg="Created SecretClient"
level=INFO ts=2023-01-23T15:55:02.6360208Z app=core-common-config-bootstrapper source=secret.go:109 msg="SecretsFile not set, skipping seeding of service secrets."
level=INFO ts=2023-01-23T15:55:02.6360468Z app=core-common-config-bootstrapper source=main.go:66 msg="Secret Provider created"
level=INFO ts=2023-01-23T15:55:02.6363416Z app=core-common-config-bootstrapper source=secrets.go:276 msg="kick off token renewal with interval: 30m0s"
level=INFO ts=2023-01-23T15:55:02.6502685Z app=core-common-config-bootstrapper source=secrets.go:148 msg="successfully generated Consul token for service core-common-config-bootstrapper"
level=INFO ts=2023-01-23T15:55:02.6503653Z app=core-common-config-bootstrapper source=main.go:74 msg="Got Config Provider Access Token"
level=INFO ts=2023-01-23T15:55:02.6503831Z app=core-common-config-bootstrapper source=main.go:75 msg="Core Common Config Ready for stage two"

```
- Verify the core-common-config-bootstrapper service container is still running.
- Run `make clean` to stop all the services.

