### PR TITLE
refactor: Remove un-needed port export on Core Data that was for ZMQ

### DIFF
--- a/compose-builder/docker-compose-base.yml
+++ b/compose-builder/docker-compose-base.yml
@@ -115,7 +115,6 @@ services:
     user: "${EDGEX_USER}:${EDGEX_GROUP}"
     ports:
       - "127.0.0.1:59880:59880"
-      - "127.0.0.1:5563:5563"
     container_name: edgex-core-data
     hostname: edgex-core-data
     read_only: true

--- a/docker-compose-arm64.yml
+++ b/docker-compose-arm64.yml
@@ -346,11 +346,6 @@ services:
     ports:
     - mode: ingress
       host_ip: 127.0.0.1
-      target: 5563
-      published: "5563"
-      protocol: tcp
-    - mode: ingress
-      host_ip: 127.0.0.1
       target: 59880
       published: "59880"
       protocol: tcp

--- a/docker-compose-no-secty-arm64.yml
+++ b/docker-compose-no-secty-arm64.yml
@@ -163,11 +163,6 @@ services:
       target: 59880
       published: "59880"
       protocol: tcp
-    - mode: ingress
-      host_ip: 127.0.0.1
-      target: 5563
-      published: "5563"
-      protocol: tcp
     read_only: true
     restart: always
     security_opt:

--- a/docker-compose-no-secty-with-app-sample-arm64.yml
+++ b/docker-compose-no-secty-with-app-sample-arm64.yml
@@ -198,11 +198,6 @@ services:
       target: 59880
       published: "59880"
       protocol: tcp
-    - mode: ingress
-      host_ip: 127.0.0.1
-      target: 5563
-      published: "5563"
-      protocol: tcp
     read_only: true
     restart: always
     security_opt:

--- a/docker-compose-no-secty-with-app-sample.yml
+++ b/docker-compose-no-secty-with-app-sample.yml
@@ -198,11 +198,6 @@ services:
       target: 59880
       published: "59880"
       protocol: tcp
-    - mode: ingress
-      host_ip: 127.0.0.1
-      target: 5563
-      published: "5563"
-      protocol: tcp
     read_only: true
     restart: always
     security_opt:

--- a/docker-compose-no-secty.yml
+++ b/docker-compose-no-secty.yml
@@ -163,11 +163,6 @@ services:
       target: 59880
       published: "59880"
       protocol: tcp
-    - mode: ingress
-      host_ip: 127.0.0.1
-      target: 5563
-      published: "5563"
-      protocol: tcp
     read_only: true
     restart: always
     security_opt:

--- a/docker-compose-with-app-sample-arm64.yml
+++ b/docker-compose-with-app-sample-arm64.yml
@@ -427,11 +427,6 @@ services:
     ports:
     - mode: ingress
       host_ip: 127.0.0.1
-      target: 5563
-      published: "5563"
-      protocol: tcp
-    - mode: ingress
-      host_ip: 127.0.0.1
       target: 59880
       published: "59880"
       protocol: tcp

--- a/docker-compose-with-app-sample.yml
+++ b/docker-compose-with-app-sample.yml
@@ -427,11 +427,6 @@ services:
     ports:
     - mode: ingress
       host_ip: 127.0.0.1
-      target: 5563
-      published: "5563"
-      protocol: tcp
-    - mode: ingress
-      host_ip: 127.0.0.1
       target: 59880
       published: "59880"
       protocol: tcp

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -346,11 +346,6 @@ services:
     ports:
     - mode: ingress
       host_ip: 127.0.0.1
-      target: 5563
-      published: "5563"
-      protocol: tcp
-    - mode: ingress
-      host_ip: 127.0.0.1
       target: 59880
       published: "59880"
       protocol: tcp

--- a/taf/docker-compose-taf-arm64.yml
+++ b/taf/docker-compose-taf-arm64.yml
@@ -758,11 +758,6 @@ services:
     ports:
     - mode: ingress
       host_ip: 127.0.0.1
-      target: 5563
-      published: "5563"
-      protocol: tcp
-    - mode: ingress
-      host_ip: 127.0.0.1
       target: 59880
       published: "59880"
       protocol: tcp

--- a/taf/docker-compose-taf-mqtt-bus-arm64.yml
+++ b/taf/docker-compose-taf-mqtt-bus-arm64.yml
@@ -804,11 +804,6 @@ services:
     ports:
     - mode: ingress
       host_ip: 127.0.0.1
-      target: 5563
-      published: "5563"
-      protocol: tcp
-    - mode: ingress
-      host_ip: 127.0.0.1
       target: 59880
       published: "59880"
       protocol: tcp

--- a/taf/docker-compose-taf-mqtt-bus.yml
+++ b/taf/docker-compose-taf-mqtt-bus.yml
@@ -804,11 +804,6 @@ services:
     ports:
     - mode: ingress
       host_ip: 127.0.0.1
-      target: 5563
-      published: "5563"
-      protocol: tcp
-    - mode: ingress
-      host_ip: 127.0.0.1
       target: 59880
       published: "59880"
       protocol: tcp

--- a/taf/docker-compose-taf-no-secty-arm64.yml
+++ b/taf/docker-compose-taf-no-secty-arm64.yml
@@ -345,11 +345,6 @@ services:
       target: 59880
       published: "59880"
       protocol: tcp
-    - mode: ingress
-      host_ip: 127.0.0.1
-      target: 5563
-      published: "5563"
-      protocol: tcp
     read_only: true
     restart: always
     security_opt:

--- a/taf/docker-compose-taf-no-secty-mqtt-bus-arm64.yml
+++ b/taf/docker-compose-taf-no-secty-mqtt-bus-arm64.yml
@@ -380,11 +380,6 @@ services:
     ports:
     - mode: ingress
       host_ip: 127.0.0.1
-      target: 5563
-      published: "5563"
-      protocol: tcp
-    - mode: ingress
-      host_ip: 127.0.0.1
       target: 59880
       published: "59880"
       protocol: tcp

--- a/taf/docker-compose-taf-no-secty-mqtt-bus.yml
+++ b/taf/docker-compose-taf-no-secty-mqtt-bus.yml
@@ -380,11 +380,6 @@ services:
     ports:
     - mode: ingress
       host_ip: 127.0.0.1
-      target: 5563
-      published: "5563"
-      protocol: tcp
-    - mode: ingress
-      host_ip: 127.0.0.1
       target: 59880
       published: "59880"
       protocol: tcp

--- a/taf/docker-compose-taf-no-secty.yml
+++ b/taf/docker-compose-taf-no-secty.yml
@@ -345,11 +345,6 @@ services:
       target: 59880
       published: "59880"
       protocol: tcp
-    - mode: ingress
-      host_ip: 127.0.0.1
-      target: 5563
-      published: "5563"
-      protocol: tcp
     read_only: true
     restart: always
     security_opt:

--- a/taf/docker-compose-taf-perf-arm64.yml
+++ b/taf/docker-compose-taf-perf-arm64.yml
@@ -430,11 +430,6 @@ services:
     ports:
     - mode: ingress
       host_ip: 127.0.0.1
-      target: 5563
-      published: "5563"
-      protocol: tcp
-    - mode: ingress
-      host_ip: 127.0.0.1
       target: 59880
       published: "59880"
       protocol: tcp

--- a/taf/docker-compose-taf-perf-no-secty-arm64.yml
+++ b/taf/docker-compose-taf-perf-no-secty-arm64.yml
@@ -201,11 +201,6 @@ services:
       target: 59880
       published: "59880"
       protocol: tcp
-    - mode: ingress
-      host_ip: 127.0.0.1
-      target: 5563
-      published: "5563"
-      protocol: tcp
     read_only: true
     restart: always
     security_opt:

--- a/taf/docker-compose-taf-perf-no-secty.yml
+++ b/taf/docker-compose-taf-perf-no-secty.yml
@@ -201,11 +201,6 @@ services:
       target: 59880
       published: "59880"
       protocol: tcp
-    - mode: ingress
-      host_ip: 127.0.0.1
-      target: 5563
-      published: "5563"
-      protocol: tcp
     read_only: true
     restart: always
     security_opt:

--- a/taf/docker-compose-taf-perf.yml
+++ b/taf/docker-compose-taf-perf.yml
@@ -430,11 +430,6 @@ services:
     ports:
     - mode: ingress
       host_ip: 127.0.0.1
-      target: 5563
-      published: "5563"
-      protocol: tcp
-    - mode: ingress
-      host_ip: 127.0.0.1
       target: 59880
       published: "59880"
       protocol: tcp

--- a/taf/docker-compose-taf.yml
+++ b/taf/docker-compose-taf.yml
@@ -758,11 +758,6 @@ services:
     ports:
     - mode: ingress
       host_ip: 127.0.0.1
-      target: 5563
-      published: "5563"
-      protocol: tcp
-    - mode: ingress
-      host_ip: 127.0.0.1
       target: 59880
       published: "59880"
       protocol: tcp


### PR DESCRIPTION
ZMQ was previously removed, but the port export was missed.

closes #325

Signed-off-by: Leonard Goodell <leonard.goodell@intel.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-compose/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-compose/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [ ] I have fully tested (add details below) this the new feature or bug fix (if not, why?) **N/A**
- [ ] I have opened a PR for the related docs change (if not, why?) **N/A**
  <link to docs PR>


## Testing Instructions
<!-- How can the reviewers test your change? -->
