### PR TITLE
fix: Remove :z and ,z from all named volumes

### DIFF
--- a/compose-builder/add-app-rfid-llrp-inventory.yml
+++ b/compose-builder/add-app-rfid-llrp-inventory.yml
@@ -41,5 +41,5 @@ services:
       - no-new-privileges:true
     user: "${EDGEX_USER}:${EDGEX_GROUP}"
     volumes:
-      - llrp-inventory-data:/cache:z
+      - llrp-inventory-data:/cache
 

--- a/compose-builder/add-delayed-start-services.yml
+++ b/compose-builder/add-delayed-start-services.yml
@@ -42,9 +42,9 @@ services:
     tmpfs:
       - /run
     volumes:
-      - edgex-init:/edgex-init:z
-      - spire-ca:/srv/spiffe/ca:z
-      - spire-server:/srv/spiffe/server:z
+      - edgex-init:/edgex-init
+      - spire-ca:/srv/spiffe/ca
+      - spire-server:/srv/spiffe/server
       - /tmp/edgex/secrets/spiffe:/tmp/edgex/secrets/spiffe:z
     depends_on:
       - security-bootstrapper
@@ -71,9 +71,9 @@ services:
     tmpfs:
       - /run
     volumes:
-      - edgex-init:/edgex-init:z
-      - spire-ca:/srv/spiffe/ca:z
-      - spire-agent:/srv/spiffe/agent:z
+      - edgex-init:/edgex-init
+      - spire-ca:/srv/spiffe/ca
+      - spire-agent:/srv/spiffe/agent
       - /tmp/edgex/secrets/spiffe:/tmp/edgex/secrets/spiffe:z
       - /var/run/docker.sock:/var/run/docker.sock
     depends_on:
@@ -102,7 +102,7 @@ services:
     tmpfs:
       - /run
     volumes:
-      - edgex-init:/edgex-init:z
+      - edgex-init:/edgex-init
       - /tmp/edgex/secrets/spiffe:/tmp/edgex/secrets/spiffe:z
     depends_on:
       - security-spire-agent
@@ -132,7 +132,7 @@ services:
     tmpfs:
       - /run
     volumes:
-      - edgex-init:/edgex-init:z
+      - edgex-init:/edgex-init
       - /tmp/edgex/secrets/spiffe:/tmp/edgex/secrets/spiffe:z
       - /tmp/edgex/secrets/security-spiffe-token-provider:/tmp/edgex/secrets/security-spiffe-token-provider:z
     depends_on:

--- a/compose-builder/add-nats-messagebus.yml
+++ b/compose-builder/add-nats-messagebus.yml
@@ -34,7 +34,7 @@ services:
       - no-new-privileges:true
     user: "root:root"
     volumes:
-      - nats-data:/tmp/nats:z
+      - nats-data:/tmp/nats
 
   data:
     env_file:

--- a/compose-builder/add-secure-mqtt-broker.yml
+++ b/compose-builder/add-secure-mqtt-broker.yml
@@ -30,8 +30,8 @@ services:
       CONF_DIR: /edgex-init/bootstrap-mosquitto/res
       ENTRYPOINT: /docker-entrypoint.sh /usr/sbin/mosquitto ${MQTT_VERBOSE} -c  /mosquitto/config/mosquitto.conf
     volumes:
-    - mqtt:/mosquitto:z
-    - edgex-init:/edgex-init:ro,z
+    - mqtt:/mosquitto
+    - edgex-init:/edgex-init:ro
     - /tmp/edgex/secrets/security-bootstrapper-messagebus:/tmp/edgex/secrets/security-bootstrapper-messagebus:ro,z
     depends_on:
       - security-bootstrapper

--- a/compose-builder/add-secure-mqtt-messagebus.yml
+++ b/compose-builder/add-secure-mqtt-messagebus.yml
@@ -24,8 +24,8 @@ services:
     environment:
       SECUREMESSAGEBUS_TYPE: mqtt
     volumes:
-      - kuiper-sources:/tmp/kuiper:z
-      - kuiper-connections:/tmp/kuiper-connections:z
+      - kuiper-sources:/tmp/kuiper
+      - kuiper-connections:/tmp/kuiper-connections
   
   data:
     environment:
@@ -62,9 +62,9 @@ services:
     env_file:
       - common-sec-stage-gate.env
     volumes:
-      - kuiper-sources:/kuiper/etc/sources:z
-      - kuiper-connections:/kuiper/etc/connections:z
-      - edgex-init:/edgex-init:ro,z
+      - kuiper-sources:/kuiper/etc/sources
+      - kuiper-connections:/kuiper/etc/connections
+      - edgex-init:/edgex-init:ro
     depends_on:
       - security-bootstrapper
       - secretstore-setup

--- a/compose-builder/add-secure-redis-messagebus.yml
+++ b/compose-builder/add-secure-redis-messagebus.yml
@@ -22,8 +22,8 @@ volumes:
 services:
   secretstore-setup:
     volumes:
-      - kuiper-sources:/tmp/kuiper:z
-      - kuiper-connections:/tmp/kuiper-connections:z
+      - kuiper-sources:/tmp/kuiper
+      - kuiper-connections:/tmp/kuiper-connections
 
     environment:
       SECUREMESSAGEBUS_TYPE: redis
@@ -33,9 +33,9 @@ services:
     env_file:
       - common-sec-stage-gate.env
     volumes:
-      - kuiper-sources:/kuiper/etc/sources:z
-      - kuiper-connections:/kuiper/etc/connections:z
-      - edgex-init:/edgex-init:ro,z
+      - kuiper-sources:/kuiper/etc/sources
+      - kuiper-connections:/kuiper/etc/connections
+      - edgex-init:/edgex-init:ro
     depends_on:
       - security-bootstrapper
       - secretstore-setup

--- a/compose-builder/add-security.yml
+++ b/compose-builder/add-security.yml
@@ -42,7 +42,7 @@ services:
       EDGEX_USER: ${EDGEX_USER}
       EDGEX_GROUP: ${EDGEX_GROUP}
     volumes:
-      - edgex-init:/edgex-init:z
+      - edgex-init:/edgex-init
     security_opt:
       - no-new-privileges:true
 
@@ -58,8 +58,8 @@ services:
     tmpfs:
       - /run
     volumes:
-      - edgex-init:/edgex-init:ro,z
-      - redis-config:/run/redis/conf:z
+      - edgex-init:/edgex-init:ro
+      - redis-config:/run/redis/conf
       - /tmp/edgex/secrets/security-bootstrapper-redis:/tmp/edgex/secrets/security-bootstrapper-redis:ro,z
     depends_on:
       - security-bootstrapper
@@ -88,8 +88,8 @@ services:
       - /run
       - /vault
     volumes:
-      - edgex-init:/edgex-init:ro,z
-      - vault-config:/vault/config:z
+      - edgex-init:/edgex-init:ro
+      - vault-config:/vault/config
       - /tmp/edgex/secrets:/tmp/edgex/secrets:z
     depends_on:
       - security-bootstrapper
@@ -113,11 +113,11 @@ services:
       STAGEGATE_REGISTRY_ACL_BOOTSTRAPTOKENPATH: /tmp/edgex/secrets/consul-acl-token/bootstrap_token.json
       STAGEGATE_REGISTRY_ACL_MANAGEMENTTOKENPATH: /tmp/edgex/secrets/consul-acl-token/mgmt_token.json
     volumes:
-      - edgex-init:/edgex-init:ro,z
+      - edgex-init:/edgex-init:ro
       - /tmp/edgex/secrets/edgex-consul:/tmp/edgex/secrets/edgex-consul:ro,z
       # using regular volume to avoid lose of token due to host system reboot
       # and it is only shared between consul and proxy-setup
-      - consul-acl-token:/tmp/edgex/secrets/consul-acl-token:z
+      - consul-acl-token:/tmp/edgex/secrets/consul-acl-token
     depends_on:
       - security-bootstrapper
       - vault
@@ -144,9 +144,9 @@ services:
       VAULT_CONFIG_DIR: /vault/config
       VAULT_UI: "true"
     volumes:
-      - edgex-init:/edgex-init:ro,z
-      - vault-file:/vault/file:z
-      - vault-logs:/vault/logs:z
+      - edgex-init:/edgex-init:ro
+      - vault-file:/vault/file
+      - vault-logs:/vault/logs
     depends_on:
       - security-bootstrapper
     restart: always
@@ -174,7 +174,7 @@ services:
     env_file:
       - common-sec-stage-gate.env
     volumes:
-      - edgex-init:/edgex-init:ro,z
+      - edgex-init:/edgex-init:ro
       - nginx-templates:/etc/nginx/templates
       - nginx-tls:/etc/ssl/nginx
     depends_on:
@@ -211,16 +211,16 @@ services:
       ROUTES_RULES_ENGINE_HOST: edgex-kuiper
       ROUTES_DEVICE_VIRTUAL_HOST: device-virtual
     volumes:
-      - edgex-init:/edgex-init:ro,z
-      - vault-config:/vault/config:z
+      - edgex-init:/edgex-init:ro
+      - vault-config:/vault/config
       - nginx-templates:/etc/nginx/templates
       - nginx-tls:/etc/ssl/nginx
       - /tmp/edgex/secrets/security-proxy-setup:/tmp/edgex/secrets/security-proxy-setup:ro,z
-      - consul-acl-token:/tmp/edgex/secrets/consul-acl-token:ro,z
+      - consul-acl-token:/tmp/edgex/secrets/consul-acl-token:ro
     depends_on:
       - security-bootstrapper
       - secretstore-setup
-    security_opt: 
+    security_opt:
       - no-new-privileges:true
 
   proxy-auth:
@@ -242,7 +242,7 @@ services:
     environment:
       SERVICE_HOST: edgex-proxy-auth
     volumes:
-      - edgex-init:/edgex-init:ro,z
+      - edgex-init:/edgex-init:ro
       - /tmp/edgex/secrets/security-proxy-auth:/tmp/edgex/secrets/security-proxy-auth:ro,z
     depends_on:
       - secretstore-setup
@@ -258,7 +258,7 @@ services:
     entrypoint: ["/edgex-init/ready_to_run_wait_install.sh"]
     command: "/support-notifications ${DEFAULT_EDGEX_RUN_CMD_PARMS}"
     volumes:
-      - edgex-init:/edgex-init:ro,z
+      - edgex-init:/edgex-init:ro
       - /tmp/edgex/secrets/support-notifications:/tmp/edgex/secrets/support-notifications:ro,z
     depends_on:
       - security-bootstrapper
@@ -272,7 +272,7 @@ services:
     entrypoint: ["/edgex-init/ready_to_run_wait_install.sh"]
     command: "/core-metadata ${DEFAULT_EDGEX_RUN_CMD_PARMS}"
     volumes:
-      - edgex-init:/edgex-init:ro,z
+      - edgex-init:/edgex-init:ro
       - /tmp/edgex/secrets/core-metadata:/tmp/edgex/secrets/core-metadata:ro,z
     depends_on:
       - security-bootstrapper
@@ -286,7 +286,7 @@ services:
     entrypoint: ["/edgex-init/ready_to_run_wait_install.sh"]
     command: "/core-data ${DEFAULT_EDGEX_RUN_CMD_PARMS}"
     volumes:
-      - edgex-init:/edgex-init:ro,z
+      - edgex-init:/edgex-init:ro
       - /tmp/edgex/secrets/core-data:/tmp/edgex/secrets/core-data:ro,z
     depends_on:
       - security-bootstrapper
@@ -300,7 +300,7 @@ services:
     entrypoint: ["/edgex-init/ready_to_run_wait_install.sh"]
     command: "/core-command ${DEFAULT_EDGEX_RUN_CMD_PARMS}"
     volumes:
-      - edgex-init:/edgex-init:ro,z
+      - edgex-init:/edgex-init:ro
       - /tmp/edgex/secrets/core-command:/tmp/edgex/secrets/core-command:ro,z
     depends_on:
       - security-bootstrapper
@@ -314,7 +314,7 @@ services:
     entrypoint: ["/edgex-init/ready_to_run_wait_install.sh"]
     command: ["/entrypoint.sh", "/core-common-config-bootstrapper", "-cp=consul.http://edgex-core-consul:8500", "-cf=configuration.yaml"]
     volumes:
-      - edgex-init:/edgex-init:ro,z
+      - edgex-init:/edgex-init:ro
       - /tmp/edgex/secrets/core-common-config-bootstrapper:/tmp/edgex/secrets/core-common-config-bootstrapper:ro,z
     depends_on:
       - security-bootstrapper
@@ -327,7 +327,7 @@ services:
     entrypoint: ["/edgex-init/ready_to_run_wait_install.sh"]
     command: "/support-scheduler ${DEFAULT_EDGEX_RUN_CMD_PARMS}"
     volumes:
-      - edgex-init:/edgex-init:ro,z
+      - edgex-init:/edgex-init:ro
       - /tmp/edgex/secrets/support-scheduler:/tmp/edgex/secrets/support-scheduler:ro,z
     depends_on:
       - security-bootstrapper
@@ -343,7 +343,7 @@ services:
       - common-security.env
       - common-sec-stage-gate.env
     volumes:
-      - edgex-init:/edgex-init:ro,z
+      - edgex-init:/edgex-init:ro
       - /tmp/edgex/secrets/app-rules-engine:/tmp/edgex/secrets/app-rules-engine:ro,z
     depends_on:
       - security-bootstrapper

--- a/compose-builder/add-service-secure-template.yml
+++ b/compose-builder/add-service-secure-template.yml
@@ -37,7 +37,7 @@ services:
       - common-sec-stage-gate.env
     ##${ENVIRONMENT_SECTION}
     volumes:
-      - edgex-init:/edgex-init:ro,z
+      - edgex-init:/edgex-init:ro
       - /tmp/edgex/secrets/${SERVICE_KEY}:/tmp/edgex/secrets/${SERVICE_KEY}:ro,z
     depends_on:
       - security-bootstrapper

--- a/compose-builder/add-taf-app-services-secure.yml
+++ b/compose-builder/add-taf-app-services-secure.yml
@@ -32,7 +32,7 @@ services:
       - common-security.env
       - common-sec-stage-gate.env
     volumes:
-      - edgex-init:/edgex-init:ro,z
+      - edgex-init:/edgex-init:ro
       - /tmp/edgex/secrets/app-functional-tests:/tmp/edgex/secrets/app-functional-tests:ro,z
     depends_on:
       - security-bootstrapper
@@ -44,7 +44,7 @@ services:
       - common-security.env
       - common-sec-stage-gate.env
     volumes:
-      - edgex-init:/edgex-init:ro,z
+      - edgex-init:/edgex-init:ro
       - /tmp/edgex/secrets/app-scalability-test-mqtt-export:/tmp/edgex/secrets/app-scalability-test-mqtt-export:ro,z
     depends_on:
       - security-bootstrapper

--- a/compose-builder/docker-compose-base.yml
+++ b/compose-builder/docker-compose-base.yml
@@ -41,8 +41,8 @@ services:
     networks:
       edgex-network:
     volumes:
-      - consul-config:/consul/config:z
-      - consul-data:/consul/data:z
+      - consul-config:/consul/config
+      - consul-data:/consul/data
     security_opt: 
       - no-new-privileges:true
 
@@ -60,7 +60,7 @@ services:
     env_file:
       - common.env
     volumes:
-      - db-data:/data:z
+      - db-data:/data
     security_opt: 
       - no-new-privileges:true
 
@@ -229,7 +229,7 @@ services:
     networks:
       - edgex-network
     volumes:
-      - kuiper-data:/kuiper/data:z
+      - kuiper-data:/kuiper/data
     environment:
 #      KUIPER__BASIC__DEBUG: "true"
       KUIPER__BASIC__CONSOLELOG: "true"

--- a/docker-compose-arm64.yml
+++ b/docker-compose-arm64.yml
@@ -92,8 +92,6 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/app-rules-engine
@@ -172,8 +170,6 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/core-command
@@ -239,8 +235,6 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/core-common-config-bootstrapper
@@ -311,27 +305,19 @@ services:
     - type: volume
       source: consul-config
       target: /consul/config
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: consul-data
       target: /consul/data
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: consul-acl-token
       target: /tmp/edgex/secrets/consul-acl-token
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/edgex-consul
@@ -409,8 +395,6 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/core-data
@@ -479,21 +463,15 @@ services:
     - type: volume
       source: db-data
       target: /data
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: redis-config
       target: /run/redis/conf
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/security-bootstrapper-redis
@@ -569,8 +547,6 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/device-rest
@@ -646,8 +622,6 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/device-virtual
@@ -723,8 +697,6 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/core-metadata
@@ -790,8 +762,6 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: nginx-templates
@@ -868,8 +838,6 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/support-notifications
@@ -925,8 +893,6 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/security-proxy-auth
@@ -989,14 +955,10 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: vault-config
       target: /vault/config
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: nginx-templates
@@ -1017,8 +979,6 @@ services:
       source: consul-acl-token
       target: /tmp/edgex/secrets/consul-acl-token
       read_only: true
-      bind:
-        selinux: z
       volume: {}
   rulesengine:
     container_name: edgex-kuiper
@@ -1081,26 +1041,18 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: kuiper-data
       target: /kuiper/data
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: kuiper-connections
       target: /kuiper/etc/connections
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: kuiper-sources
       target: /kuiper/etc/sources
-      bind:
-        selinux: z
       volume: {}
   scheduler:
     command:
@@ -1171,8 +1123,6 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/support-scheduler
@@ -1231,8 +1181,6 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets
@@ -1243,20 +1191,14 @@ services:
     - type: volume
       source: kuiper-sources
       target: /tmp/kuiper
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: kuiper-connections
       target: /tmp/kuiper-connections
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: vault-config
       target: /vault/config
-      bind:
-        selinux: z
       volume: {}
   security-bootstrapper:
     container_name: edgex-security-bootstrapper
@@ -1294,8 +1236,6 @@ services:
     - type: volume
       source: edgex-init
       target: /edgex-init
-      bind:
-        selinux: z
       volume: {}
   ui:
     container_name: edgex-ui-go
@@ -1368,20 +1308,14 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: vault-file
       target: /vault/file
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: vault-logs
       target: /vault/logs
-      bind:
-        selinux: z
       volume: {}
 networks:
   edgex-network:

--- a/docker-compose-no-secty-arm64.yml
+++ b/docker-compose-no-secty-arm64.yml
@@ -146,14 +146,10 @@ services:
     - type: volume
       source: consul-config
       target: /consul/config
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: consul-data
       target: /consul/data
-      bind:
-        selinux: z
       volume: {}
   data:
     container_name: edgex-core-data
@@ -220,8 +216,6 @@ services:
     - type: volume
       source: db-data
       target: /data
-      bind:
-        selinux: z
       volume: {}
   device-rest:
     container_name: edgex-device-rest
@@ -395,8 +389,6 @@ services:
     - type: volume
       source: kuiper-data
       target: /kuiper/data
-      bind:
-        selinux: z
       volume: {}
   scheduler:
     container_name: edgex-support-scheduler

--- a/docker-compose-no-secty-with-app-sample-arm64.yml
+++ b/docker-compose-no-secty-with-app-sample-arm64.yml
@@ -180,14 +180,10 @@ services:
     - type: volume
       source: consul-config
       target: /consul/config
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: consul-data
       target: /consul/data
-      bind:
-        selinux: z
       volume: {}
   data:
     container_name: edgex-core-data
@@ -254,8 +250,6 @@ services:
     - type: volume
       source: db-data
       target: /data
-      bind:
-        selinux: z
       volume: {}
   device-rest:
     container_name: edgex-device-rest
@@ -429,8 +423,6 @@ services:
     - type: volume
       source: kuiper-data
       target: /kuiper/data
-      bind:
-        selinux: z
       volume: {}
   scheduler:
     container_name: edgex-support-scheduler

--- a/docker-compose-no-secty-with-app-sample.yml
+++ b/docker-compose-no-secty-with-app-sample.yml
@@ -180,14 +180,10 @@ services:
     - type: volume
       source: consul-config
       target: /consul/config
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: consul-data
       target: /consul/data
-      bind:
-        selinux: z
       volume: {}
   data:
     container_name: edgex-core-data
@@ -254,8 +250,6 @@ services:
     - type: volume
       source: db-data
       target: /data
-      bind:
-        selinux: z
       volume: {}
   device-rest:
     container_name: edgex-device-rest
@@ -429,8 +423,6 @@ services:
     - type: volume
       source: kuiper-data
       target: /kuiper/data
-      bind:
-        selinux: z
       volume: {}
   scheduler:
     container_name: edgex-support-scheduler

--- a/docker-compose-no-secty.yml
+++ b/docker-compose-no-secty.yml
@@ -146,14 +146,10 @@ services:
     - type: volume
       source: consul-config
       target: /consul/config
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: consul-data
       target: /consul/data
-      bind:
-        selinux: z
       volume: {}
   data:
     container_name: edgex-core-data
@@ -220,8 +216,6 @@ services:
     - type: volume
       source: db-data
       target: /data
-      bind:
-        selinux: z
       volume: {}
   device-rest:
     container_name: edgex-device-rest
@@ -395,8 +389,6 @@ services:
     - type: volume
       source: kuiper-data
       target: /kuiper/data
-      bind:
-        selinux: z
       volume: {}
   scheduler:
     container_name: edgex-support-scheduler

--- a/docker-compose-with-app-sample-arm64.yml
+++ b/docker-compose-with-app-sample-arm64.yml
@@ -92,8 +92,6 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/app-rules-engine
@@ -168,8 +166,6 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/app-sample
@@ -248,8 +244,6 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/core-command
@@ -315,8 +309,6 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/core-common-config-bootstrapper
@@ -387,27 +379,19 @@ services:
     - type: volume
       source: consul-config
       target: /consul/config
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: consul-data
       target: /consul/data
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: consul-acl-token
       target: /tmp/edgex/secrets/consul-acl-token
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/edgex-consul
@@ -485,8 +469,6 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/core-data
@@ -555,21 +537,15 @@ services:
     - type: volume
       source: db-data
       target: /data
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: redis-config
       target: /run/redis/conf
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/security-bootstrapper-redis
@@ -645,8 +621,6 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/device-rest
@@ -722,8 +696,6 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/device-virtual
@@ -799,8 +771,6 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/core-metadata
@@ -866,8 +836,6 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: nginx-templates
@@ -944,8 +912,6 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/support-notifications
@@ -1001,8 +967,6 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/security-proxy-auth
@@ -1065,14 +1029,10 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: vault-config
       target: /vault/config
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: nginx-templates
@@ -1093,8 +1053,6 @@ services:
       source: consul-acl-token
       target: /tmp/edgex/secrets/consul-acl-token
       read_only: true
-      bind:
-        selinux: z
       volume: {}
   rulesengine:
     container_name: edgex-kuiper
@@ -1157,26 +1115,18 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: kuiper-data
       target: /kuiper/data
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: kuiper-connections
       target: /kuiper/etc/connections
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: kuiper-sources
       target: /kuiper/etc/sources
-      bind:
-        selinux: z
       volume: {}
   scheduler:
     command:
@@ -1247,8 +1197,6 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/support-scheduler
@@ -1307,8 +1255,6 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets
@@ -1319,20 +1265,14 @@ services:
     - type: volume
       source: kuiper-sources
       target: /tmp/kuiper
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: kuiper-connections
       target: /tmp/kuiper-connections
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: vault-config
       target: /vault/config
-      bind:
-        selinux: z
       volume: {}
   security-bootstrapper:
     container_name: edgex-security-bootstrapper
@@ -1370,8 +1310,6 @@ services:
     - type: volume
       source: edgex-init
       target: /edgex-init
-      bind:
-        selinux: z
       volume: {}
   ui:
     container_name: edgex-ui-go
@@ -1444,20 +1382,14 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: vault-file
       target: /vault/file
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: vault-logs
       target: /vault/logs
-      bind:
-        selinux: z
       volume: {}
 networks:
   edgex-network:

--- a/docker-compose-with-app-sample.yml
+++ b/docker-compose-with-app-sample.yml
@@ -92,8 +92,6 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/app-rules-engine
@@ -168,8 +166,6 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/app-sample
@@ -248,8 +244,6 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/core-command
@@ -315,8 +309,6 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/core-common-config-bootstrapper
@@ -387,27 +379,19 @@ services:
     - type: volume
       source: consul-config
       target: /consul/config
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: consul-data
       target: /consul/data
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: consul-acl-token
       target: /tmp/edgex/secrets/consul-acl-token
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/edgex-consul
@@ -485,8 +469,6 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/core-data
@@ -555,21 +537,15 @@ services:
     - type: volume
       source: db-data
       target: /data
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: redis-config
       target: /run/redis/conf
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/security-bootstrapper-redis
@@ -645,8 +621,6 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/device-rest
@@ -722,8 +696,6 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/device-virtual
@@ -799,8 +771,6 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/core-metadata
@@ -866,8 +836,6 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: nginx-templates
@@ -944,8 +912,6 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/support-notifications
@@ -1001,8 +967,6 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/security-proxy-auth
@@ -1065,14 +1029,10 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: vault-config
       target: /vault/config
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: nginx-templates
@@ -1093,8 +1053,6 @@ services:
       source: consul-acl-token
       target: /tmp/edgex/secrets/consul-acl-token
       read_only: true
-      bind:
-        selinux: z
       volume: {}
   rulesengine:
     container_name: edgex-kuiper
@@ -1157,26 +1115,18 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: kuiper-data
       target: /kuiper/data
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: kuiper-connections
       target: /kuiper/etc/connections
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: kuiper-sources
       target: /kuiper/etc/sources
-      bind:
-        selinux: z
       volume: {}
   scheduler:
     command:
@@ -1247,8 +1197,6 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/support-scheduler
@@ -1307,8 +1255,6 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets
@@ -1319,20 +1265,14 @@ services:
     - type: volume
       source: kuiper-sources
       target: /tmp/kuiper
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: kuiper-connections
       target: /tmp/kuiper-connections
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: vault-config
       target: /vault/config
-      bind:
-        selinux: z
       volume: {}
   security-bootstrapper:
     container_name: edgex-security-bootstrapper
@@ -1370,8 +1310,6 @@ services:
     - type: volume
       source: edgex-init
       target: /edgex-init
-      bind:
-        selinux: z
       volume: {}
   ui:
     container_name: edgex-ui-go
@@ -1444,20 +1382,14 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: vault-file
       target: /vault/file
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: vault-logs
       target: /vault/logs
-      bind:
-        selinux: z
       volume: {}
 networks:
   edgex-network:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -92,8 +92,6 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/app-rules-engine
@@ -172,8 +170,6 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/core-command
@@ -239,8 +235,6 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/core-common-config-bootstrapper
@@ -311,27 +305,19 @@ services:
     - type: volume
       source: consul-config
       target: /consul/config
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: consul-data
       target: /consul/data
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: consul-acl-token
       target: /tmp/edgex/secrets/consul-acl-token
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/edgex-consul
@@ -409,8 +395,6 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/core-data
@@ -479,21 +463,15 @@ services:
     - type: volume
       source: db-data
       target: /data
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: redis-config
       target: /run/redis/conf
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/security-bootstrapper-redis
@@ -569,8 +547,6 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/device-rest
@@ -646,8 +622,6 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/device-virtual
@@ -723,8 +697,6 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/core-metadata
@@ -790,8 +762,6 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: nginx-templates
@@ -868,8 +838,6 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/support-notifications
@@ -925,8 +893,6 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/security-proxy-auth
@@ -989,14 +955,10 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: vault-config
       target: /vault/config
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: nginx-templates
@@ -1017,8 +979,6 @@ services:
       source: consul-acl-token
       target: /tmp/edgex/secrets/consul-acl-token
       read_only: true
-      bind:
-        selinux: z
       volume: {}
   rulesengine:
     container_name: edgex-kuiper
@@ -1081,26 +1041,18 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: kuiper-data
       target: /kuiper/data
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: kuiper-connections
       target: /kuiper/etc/connections
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: kuiper-sources
       target: /kuiper/etc/sources
-      bind:
-        selinux: z
       volume: {}
   scheduler:
     command:
@@ -1171,8 +1123,6 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/support-scheduler
@@ -1231,8 +1181,6 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets
@@ -1243,20 +1191,14 @@ services:
     - type: volume
       source: kuiper-sources
       target: /tmp/kuiper
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: kuiper-connections
       target: /tmp/kuiper-connections
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: vault-config
       target: /vault/config
-      bind:
-        selinux: z
       volume: {}
   security-bootstrapper:
     container_name: edgex-security-bootstrapper
@@ -1294,8 +1236,6 @@ services:
     - type: volume
       source: edgex-init
       target: /edgex-init
-      bind:
-        selinux: z
       volume: {}
   ui:
     container_name: edgex-ui-go
@@ -1368,20 +1308,14 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: vault-file
       target: /vault/file
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: vault-logs
       target: /vault/logs
-      bind:
-        selinux: z
       volume: {}
 networks:
   edgex-network:

--- a/taf/docker-compose-taf-arm64.yml
+++ b/taf/docker-compose-taf-arm64.yml
@@ -96,8 +96,6 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/app-external-mqtt-trigger
@@ -170,8 +168,6 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/app-functional-tests
@@ -248,8 +244,6 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/app-http-export
@@ -327,8 +321,6 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/app-mqtt-export
@@ -403,8 +395,6 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/app-rules-engine
@@ -479,8 +469,6 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/app-sample
@@ -559,8 +547,6 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/core-command
@@ -626,8 +612,6 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/core-common-config-bootstrapper
@@ -698,27 +682,19 @@ services:
     - type: volume
       source: consul-config
       target: /consul/config
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: consul-data
       target: /consul/data
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: consul-acl-token
       target: /tmp/edgex/secrets/consul-acl-token
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/edgex-consul
@@ -796,8 +772,6 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/core-data
@@ -866,21 +840,15 @@ services:
     - type: volume
       source: db-data
       target: /data
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: redis-config
       target: /run/redis/conf
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/security-bootstrapper-redis
@@ -959,8 +927,6 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/device-modbus
@@ -1042,8 +1008,6 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/device-onvif-camera
@@ -1119,8 +1083,6 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/device-rest
@@ -1197,8 +1159,6 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/device-virtual
@@ -1280,8 +1240,6 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/core-metadata
@@ -1406,8 +1364,6 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: nginx-templates
@@ -1484,8 +1440,6 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/support-notifications
@@ -1541,8 +1495,6 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/security-proxy-auth
@@ -1605,8 +1557,6 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: nginx-templates
@@ -1620,8 +1570,6 @@ services:
       source: consul-acl-token
       target: /tmp/edgex/secrets/consul-acl-token
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/security-proxy-setup
@@ -1633,8 +1581,6 @@ services:
     - type: volume
       source: vault-config
       target: /vault/config
-      bind:
-        selinux: z
       volume: {}
   rulesengine:
     container_name: edgex-kuiper
@@ -1697,26 +1643,18 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: kuiper-data
       target: /kuiper/data
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: kuiper-connections
       target: /kuiper/etc/connections
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: kuiper-sources
       target: /kuiper/etc/sources
-      bind:
-        selinux: z
       volume: {}
   scalability-test-mqtt-export:
     command:
@@ -1788,8 +1726,6 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/app-scalability-test-mqtt-export
@@ -1867,8 +1803,6 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/support-scheduler
@@ -1927,8 +1861,6 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets
@@ -1939,20 +1871,14 @@ services:
     - type: volume
       source: kuiper-sources
       target: /tmp/kuiper
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: kuiper-connections
       target: /tmp/kuiper-connections
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: vault-config
       target: /vault/config
-      bind:
-        selinux: z
       volume: {}
   security-bootstrapper:
     container_name: edgex-security-bootstrapper
@@ -1990,8 +1916,6 @@ services:
     - type: volume
       source: edgex-init
       target: /edgex-init
-      bind:
-        selinux: z
       volume: {}
   security-spiffe-token-provider:
     command:
@@ -2058,8 +1982,6 @@ services:
     - type: volume
       source: edgex-init
       target: /edgex-init
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/spiffe
@@ -2127,20 +2049,14 @@ services:
     - type: volume
       source: edgex-init
       target: /edgex-init
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: spire-ca
       target: /srv/spiffe/ca
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: spire-agent
       target: /srv/spiffe/agent
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/spiffe
@@ -2205,8 +2121,6 @@ services:
     - type: volume
       source: edgex-init
       target: /edgex-init
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/spiffe
@@ -2273,20 +2187,14 @@ services:
     - type: volume
       source: edgex-init
       target: /edgex-init
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: spire-ca
       target: /srv/spiffe/ca
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: spire-server
       target: /srv/spiffe/server
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/spiffe
@@ -2365,20 +2273,14 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: vault-file
       target: /vault/file
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: vault-logs
       target: /vault/logs
-      bind:
-        selinux: z
       volume: {}
 networks:
   edgex-network:

--- a/taf/docker-compose-taf-mqtt-bus-arm64.yml
+++ b/taf/docker-compose-taf-mqtt-bus-arm64.yml
@@ -96,8 +96,6 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/app-external-mqtt-trigger
@@ -170,8 +168,6 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/app-functional-tests
@@ -255,8 +251,6 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/app-http-export
@@ -343,8 +337,6 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/app-mqtt-export
@@ -426,8 +418,6 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/app-rules-engine
@@ -509,8 +499,6 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/app-sample
@@ -598,8 +586,6 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/core-command
@@ -665,8 +651,6 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/core-common-config-bootstrapper
@@ -737,27 +721,19 @@ services:
     - type: volume
       source: consul-config
       target: /consul/config
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: consul-data
       target: /consul/data
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: consul-acl-token
       target: /tmp/edgex/secrets/consul-acl-token
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/edgex-consul
@@ -843,8 +819,6 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/core-data
@@ -913,21 +887,15 @@ services:
     - type: volume
       source: db-data
       target: /data
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: redis-config
       target: /run/redis/conf
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/security-bootstrapper-redis
@@ -1013,8 +981,6 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/device-modbus
@@ -1103,8 +1069,6 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/device-onvif-camera
@@ -1187,8 +1151,6 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/device-rest
@@ -1272,8 +1234,6 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/device-virtual
@@ -1363,8 +1323,6 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/core-metadata
@@ -1447,15 +1405,11 @@ services:
     - type: volume
       source: mqtt
       target: /mosquitto
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/security-bootstrapper-messagebus
@@ -1542,8 +1496,6 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: nginx-templates
@@ -1628,8 +1580,6 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/support-notifications
@@ -1685,8 +1635,6 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/security-proxy-auth
@@ -1749,8 +1697,6 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: nginx-templates
@@ -1764,8 +1710,6 @@ services:
       source: consul-acl-token
       target: /tmp/edgex/secrets/consul-acl-token
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/security-proxy-setup
@@ -1777,8 +1721,6 @@ services:
     - type: volume
       source: vault-config
       target: /vault/config
-      bind:
-        selinux: z
       volume: {}
   rulesengine:
     container_name: edgex-kuiper
@@ -1851,26 +1793,18 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: kuiper-data
       target: /kuiper/data
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: kuiper-connections
       target: /kuiper/etc/connections
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: kuiper-sources
       target: /kuiper/etc/sources
-      bind:
-        selinux: z
       volume: {}
   scalability-test-mqtt-export:
     command:
@@ -1951,8 +1885,6 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/app-scalability-test-mqtt-export
@@ -2038,8 +1970,6 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/support-scheduler
@@ -2098,8 +2028,6 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets
@@ -2110,20 +2038,14 @@ services:
     - type: volume
       source: kuiper-sources
       target: /tmp/kuiper
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: kuiper-connections
       target: /tmp/kuiper-connections
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: vault-config
       target: /vault/config
-      bind:
-        selinux: z
       volume: {}
   security-bootstrapper:
     container_name: edgex-security-bootstrapper
@@ -2161,8 +2083,6 @@ services:
     - type: volume
       source: edgex-init
       target: /edgex-init
-      bind:
-        selinux: z
       volume: {}
   security-spiffe-token-provider:
     command:
@@ -2229,8 +2149,6 @@ services:
     - type: volume
       source: edgex-init
       target: /edgex-init
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/spiffe
@@ -2298,20 +2216,14 @@ services:
     - type: volume
       source: edgex-init
       target: /edgex-init
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: spire-ca
       target: /srv/spiffe/ca
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: spire-agent
       target: /srv/spiffe/agent
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/spiffe
@@ -2376,8 +2288,6 @@ services:
     - type: volume
       source: edgex-init
       target: /edgex-init
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/spiffe
@@ -2444,20 +2354,14 @@ services:
     - type: volume
       source: edgex-init
       target: /edgex-init
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: spire-ca
       target: /srv/spiffe/ca
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: spire-server
       target: /srv/spiffe/server
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/spiffe
@@ -2536,20 +2440,14 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: vault-file
       target: /vault/file
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: vault-logs
       target: /vault/logs
-      bind:
-        selinux: z
       volume: {}
 networks:
   edgex-network:

--- a/taf/docker-compose-taf-mqtt-bus.yml
+++ b/taf/docker-compose-taf-mqtt-bus.yml
@@ -96,8 +96,6 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/app-external-mqtt-trigger
@@ -170,8 +168,6 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/app-functional-tests
@@ -255,8 +251,6 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/app-http-export
@@ -343,8 +337,6 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/app-mqtt-export
@@ -426,8 +418,6 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/app-rules-engine
@@ -509,8 +499,6 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/app-sample
@@ -598,8 +586,6 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/core-command
@@ -665,8 +651,6 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/core-common-config-bootstrapper
@@ -737,27 +721,19 @@ services:
     - type: volume
       source: consul-config
       target: /consul/config
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: consul-data
       target: /consul/data
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: consul-acl-token
       target: /tmp/edgex/secrets/consul-acl-token
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/edgex-consul
@@ -843,8 +819,6 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/core-data
@@ -913,21 +887,15 @@ services:
     - type: volume
       source: db-data
       target: /data
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: redis-config
       target: /run/redis/conf
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/security-bootstrapper-redis
@@ -1013,8 +981,6 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/device-modbus
@@ -1103,8 +1069,6 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/device-onvif-camera
@@ -1187,8 +1151,6 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/device-rest
@@ -1272,8 +1234,6 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/device-virtual
@@ -1363,8 +1323,6 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/core-metadata
@@ -1447,15 +1405,11 @@ services:
     - type: volume
       source: mqtt
       target: /mosquitto
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/security-bootstrapper-messagebus
@@ -1542,8 +1496,6 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: nginx-templates
@@ -1628,8 +1580,6 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/support-notifications
@@ -1685,8 +1635,6 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/security-proxy-auth
@@ -1749,8 +1697,6 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: nginx-templates
@@ -1764,8 +1710,6 @@ services:
       source: consul-acl-token
       target: /tmp/edgex/secrets/consul-acl-token
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/security-proxy-setup
@@ -1777,8 +1721,6 @@ services:
     - type: volume
       source: vault-config
       target: /vault/config
-      bind:
-        selinux: z
       volume: {}
   rulesengine:
     container_name: edgex-kuiper
@@ -1851,26 +1793,18 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: kuiper-data
       target: /kuiper/data
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: kuiper-connections
       target: /kuiper/etc/connections
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: kuiper-sources
       target: /kuiper/etc/sources
-      bind:
-        selinux: z
       volume: {}
   scalability-test-mqtt-export:
     command:
@@ -1951,8 +1885,6 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/app-scalability-test-mqtt-export
@@ -2038,8 +1970,6 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/support-scheduler
@@ -2098,8 +2028,6 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets
@@ -2110,20 +2038,14 @@ services:
     - type: volume
       source: kuiper-sources
       target: /tmp/kuiper
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: kuiper-connections
       target: /tmp/kuiper-connections
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: vault-config
       target: /vault/config
-      bind:
-        selinux: z
       volume: {}
   security-bootstrapper:
     container_name: edgex-security-bootstrapper
@@ -2161,8 +2083,6 @@ services:
     - type: volume
       source: edgex-init
       target: /edgex-init
-      bind:
-        selinux: z
       volume: {}
   security-spiffe-token-provider:
     command:
@@ -2229,8 +2149,6 @@ services:
     - type: volume
       source: edgex-init
       target: /edgex-init
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/spiffe
@@ -2298,20 +2216,14 @@ services:
     - type: volume
       source: edgex-init
       target: /edgex-init
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: spire-ca
       target: /srv/spiffe/ca
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: spire-agent
       target: /srv/spiffe/agent
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/spiffe
@@ -2376,8 +2288,6 @@ services:
     - type: volume
       source: edgex-init
       target: /edgex-init
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/spiffe
@@ -2444,20 +2354,14 @@ services:
     - type: volume
       source: edgex-init
       target: /edgex-init
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: spire-ca
       target: /srv/spiffe/ca
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: spire-server
       target: /srv/spiffe/server
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/spiffe
@@ -2536,20 +2440,14 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: vault-file
       target: /vault/file
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: vault-logs
       target: /vault/logs
-      bind:
-        selinux: z
       volume: {}
 networks:
   edgex-network:

--- a/taf/docker-compose-taf-no-secty-arm64.yml
+++ b/taf/docker-compose-taf-no-secty-arm64.yml
@@ -323,14 +323,10 @@ services:
     - type: volume
       source: consul-config
       target: /consul/config
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: consul-data
       target: /consul/data
-      bind:
-        selinux: z
       volume: {}
   data:
     container_name: edgex-core-data
@@ -397,8 +393,6 @@ services:
     - type: volume
       source: db-data
       target: /data
-      bind:
-        selinux: z
       volume: {}
   device-modbus:
     command:
@@ -725,8 +719,6 @@ services:
     - type: volume
       source: kuiper-data
       target: /kuiper/data
-      bind:
-        selinux: z
       volume: {}
   scalability-test-mqtt-export:
     container_name: edgex-scalability-test-mqtt-export

--- a/taf/docker-compose-taf-no-secty-mqtt-bus-arm64.yml
+++ b/taf/docker-compose-taf-no-secty-mqtt-bus-arm64.yml
@@ -355,14 +355,10 @@ services:
     - type: volume
       source: consul-config
       target: /consul/config
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: consul-data
       target: /consul/data
-      bind:
-        selinux: z
       volume: {}
   data:
     container_name: edgex-core-data
@@ -436,8 +432,6 @@ services:
     - type: volume
       source: db-data
       target: /data
-      bind:
-        selinux: z
       volume: {}
   device-modbus:
     command:
@@ -813,8 +807,6 @@ services:
     - type: volume
       source: kuiper-data
       target: /kuiper/data
-      bind:
-        selinux: z
       volume: {}
   scalability-test-mqtt-export:
     container_name: edgex-scalability-test-mqtt-export

--- a/taf/docker-compose-taf-no-secty-mqtt-bus.yml
+++ b/taf/docker-compose-taf-no-secty-mqtt-bus.yml
@@ -355,14 +355,10 @@ services:
     - type: volume
       source: consul-config
       target: /consul/config
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: consul-data
       target: /consul/data
-      bind:
-        selinux: z
       volume: {}
   data:
     container_name: edgex-core-data
@@ -436,8 +432,6 @@ services:
     - type: volume
       source: db-data
       target: /data
-      bind:
-        selinux: z
       volume: {}
   device-modbus:
     command:
@@ -813,8 +807,6 @@ services:
     - type: volume
       source: kuiper-data
       target: /kuiper/data
-      bind:
-        selinux: z
       volume: {}
   scalability-test-mqtt-export:
     container_name: edgex-scalability-test-mqtt-export

--- a/taf/docker-compose-taf-no-secty.yml
+++ b/taf/docker-compose-taf-no-secty.yml
@@ -323,14 +323,10 @@ services:
     - type: volume
       source: consul-config
       target: /consul/config
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: consul-data
       target: /consul/data
-      bind:
-        selinux: z
       volume: {}
   data:
     container_name: edgex-core-data
@@ -397,8 +393,6 @@ services:
     - type: volume
       source: db-data
       target: /data
-      bind:
-        selinux: z
       volume: {}
   device-modbus:
     command:
@@ -725,8 +719,6 @@ services:
     - type: volume
       source: kuiper-data
       target: /kuiper/data
-      bind:
-        selinux: z
       volume: {}
   scalability-test-mqtt-export:
     container_name: edgex-scalability-test-mqtt-export

--- a/taf/docker-compose-taf-perf-arm64.yml
+++ b/taf/docker-compose-taf-perf-arm64.yml
@@ -95,8 +95,6 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/app-mqtt-export
@@ -171,8 +169,6 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/app-rules-engine
@@ -251,8 +247,6 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/core-command
@@ -318,8 +312,6 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/core-common-config-bootstrapper
@@ -390,27 +382,19 @@ services:
     - type: volume
       source: consul-config
       target: /consul/config
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: consul-data
       target: /consul/data
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: consul-acl-token
       target: /tmp/edgex/secrets/consul-acl-token
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/edgex-consul
@@ -488,8 +472,6 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/core-data
@@ -558,21 +540,15 @@ services:
     - type: volume
       source: db-data
       target: /data
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: redis-config
       target: /run/redis/conf
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/security-bootstrapper-redis
@@ -648,8 +624,6 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/device-rest
@@ -725,8 +699,6 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/device-virtual
@@ -802,8 +774,6 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/core-metadata
@@ -911,8 +881,6 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: nginx-templates
@@ -989,8 +957,6 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/support-notifications
@@ -1046,8 +1012,6 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/security-proxy-auth
@@ -1110,8 +1074,6 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: nginx-templates
@@ -1125,8 +1087,6 @@ services:
       source: consul-acl-token
       target: /tmp/edgex/secrets/consul-acl-token
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/security-proxy-setup
@@ -1138,8 +1098,6 @@ services:
     - type: volume
       source: vault-config
       target: /vault/config
-      bind:
-        selinux: z
       volume: {}
   rulesengine:
     container_name: edgex-kuiper
@@ -1202,26 +1160,18 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: kuiper-data
       target: /kuiper/data
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: kuiper-connections
       target: /kuiper/etc/connections
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: kuiper-sources
       target: /kuiper/etc/sources
-      bind:
-        selinux: z
       volume: {}
   scheduler:
     command:
@@ -1292,8 +1242,6 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/support-scheduler
@@ -1352,8 +1300,6 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets
@@ -1364,20 +1310,14 @@ services:
     - type: volume
       source: kuiper-sources
       target: /tmp/kuiper
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: kuiper-connections
       target: /tmp/kuiper-connections
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: vault-config
       target: /vault/config
-      bind:
-        selinux: z
       volume: {}
   security-bootstrapper:
     container_name: edgex-security-bootstrapper
@@ -1415,8 +1355,6 @@ services:
     - type: volume
       source: edgex-init
       target: /edgex-init
-      bind:
-        selinux: z
       volume: {}
   security-spiffe-token-provider:
     command:
@@ -1483,8 +1421,6 @@ services:
     - type: volume
       source: edgex-init
       target: /edgex-init
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/spiffe
@@ -1552,20 +1488,14 @@ services:
     - type: volume
       source: edgex-init
       target: /edgex-init
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: spire-ca
       target: /srv/spiffe/ca
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: spire-agent
       target: /srv/spiffe/agent
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/spiffe
@@ -1630,8 +1560,6 @@ services:
     - type: volume
       source: edgex-init
       target: /edgex-init
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/spiffe
@@ -1698,20 +1626,14 @@ services:
     - type: volume
       source: edgex-init
       target: /edgex-init
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: spire-ca
       target: /srv/spiffe/ca
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: spire-server
       target: /srv/spiffe/server
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/spiffe
@@ -1790,20 +1712,14 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: vault-file
       target: /vault/file
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: vault-logs
       target: /vault/logs
-      bind:
-        selinux: z
       volume: {}
 networks:
   edgex-network:

--- a/taf/docker-compose-taf-perf-no-secty-arm64.yml
+++ b/taf/docker-compose-taf-perf-no-secty-arm64.yml
@@ -183,14 +183,10 @@ services:
     - type: volume
       source: consul-config
       target: /consul/config
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: consul-data
       target: /consul/data
-      bind:
-        selinux: z
       volume: {}
   data:
     container_name: edgex-core-data
@@ -257,8 +253,6 @@ services:
     - type: volume
       source: db-data
       target: /data
-      bind:
-        selinux: z
       volume: {}
   device-rest:
     container_name: edgex-device-rest
@@ -474,8 +468,6 @@ services:
     - type: volume
       source: kuiper-data
       target: /kuiper/data
-      bind:
-        selinux: z
       volume: {}
   scheduler:
     container_name: edgex-support-scheduler

--- a/taf/docker-compose-taf-perf-no-secty.yml
+++ b/taf/docker-compose-taf-perf-no-secty.yml
@@ -183,14 +183,10 @@ services:
     - type: volume
       source: consul-config
       target: /consul/config
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: consul-data
       target: /consul/data
-      bind:
-        selinux: z
       volume: {}
   data:
     container_name: edgex-core-data
@@ -257,8 +253,6 @@ services:
     - type: volume
       source: db-data
       target: /data
-      bind:
-        selinux: z
       volume: {}
   device-rest:
     container_name: edgex-device-rest
@@ -474,8 +468,6 @@ services:
     - type: volume
       source: kuiper-data
       target: /kuiper/data
-      bind:
-        selinux: z
       volume: {}
   scheduler:
     container_name: edgex-support-scheduler

--- a/taf/docker-compose-taf-perf.yml
+++ b/taf/docker-compose-taf-perf.yml
@@ -95,8 +95,6 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/app-mqtt-export
@@ -171,8 +169,6 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/app-rules-engine
@@ -251,8 +247,6 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/core-command
@@ -318,8 +312,6 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/core-common-config-bootstrapper
@@ -390,27 +382,19 @@ services:
     - type: volume
       source: consul-config
       target: /consul/config
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: consul-data
       target: /consul/data
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: consul-acl-token
       target: /tmp/edgex/secrets/consul-acl-token
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/edgex-consul
@@ -488,8 +472,6 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/core-data
@@ -558,21 +540,15 @@ services:
     - type: volume
       source: db-data
       target: /data
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: redis-config
       target: /run/redis/conf
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/security-bootstrapper-redis
@@ -648,8 +624,6 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/device-rest
@@ -725,8 +699,6 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/device-virtual
@@ -802,8 +774,6 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/core-metadata
@@ -911,8 +881,6 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: nginx-templates
@@ -989,8 +957,6 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/support-notifications
@@ -1046,8 +1012,6 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/security-proxy-auth
@@ -1110,8 +1074,6 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: nginx-templates
@@ -1125,8 +1087,6 @@ services:
       source: consul-acl-token
       target: /tmp/edgex/secrets/consul-acl-token
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/security-proxy-setup
@@ -1138,8 +1098,6 @@ services:
     - type: volume
       source: vault-config
       target: /vault/config
-      bind:
-        selinux: z
       volume: {}
   rulesengine:
     container_name: edgex-kuiper
@@ -1202,26 +1160,18 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: kuiper-data
       target: /kuiper/data
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: kuiper-connections
       target: /kuiper/etc/connections
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: kuiper-sources
       target: /kuiper/etc/sources
-      bind:
-        selinux: z
       volume: {}
   scheduler:
     command:
@@ -1292,8 +1242,6 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/support-scheduler
@@ -1352,8 +1300,6 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets
@@ -1364,20 +1310,14 @@ services:
     - type: volume
       source: kuiper-sources
       target: /tmp/kuiper
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: kuiper-connections
       target: /tmp/kuiper-connections
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: vault-config
       target: /vault/config
-      bind:
-        selinux: z
       volume: {}
   security-bootstrapper:
     container_name: edgex-security-bootstrapper
@@ -1415,8 +1355,6 @@ services:
     - type: volume
       source: edgex-init
       target: /edgex-init
-      bind:
-        selinux: z
       volume: {}
   security-spiffe-token-provider:
     command:
@@ -1483,8 +1421,6 @@ services:
     - type: volume
       source: edgex-init
       target: /edgex-init
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/spiffe
@@ -1552,20 +1488,14 @@ services:
     - type: volume
       source: edgex-init
       target: /edgex-init
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: spire-ca
       target: /srv/spiffe/ca
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: spire-agent
       target: /srv/spiffe/agent
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/spiffe
@@ -1630,8 +1560,6 @@ services:
     - type: volume
       source: edgex-init
       target: /edgex-init
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/spiffe
@@ -1698,20 +1626,14 @@ services:
     - type: volume
       source: edgex-init
       target: /edgex-init
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: spire-ca
       target: /srv/spiffe/ca
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: spire-server
       target: /srv/spiffe/server
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/spiffe
@@ -1790,20 +1712,14 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: vault-file
       target: /vault/file
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: vault-logs
       target: /vault/logs
-      bind:
-        selinux: z
       volume: {}
 networks:
   edgex-network:

--- a/taf/docker-compose-taf.yml
+++ b/taf/docker-compose-taf.yml
@@ -96,8 +96,6 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/app-external-mqtt-trigger
@@ -170,8 +168,6 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/app-functional-tests
@@ -248,8 +244,6 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/app-http-export
@@ -327,8 +321,6 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/app-mqtt-export
@@ -403,8 +395,6 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/app-rules-engine
@@ -479,8 +469,6 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/app-sample
@@ -559,8 +547,6 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/core-command
@@ -626,8 +612,6 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/core-common-config-bootstrapper
@@ -698,27 +682,19 @@ services:
     - type: volume
       source: consul-config
       target: /consul/config
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: consul-data
       target: /consul/data
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: consul-acl-token
       target: /tmp/edgex/secrets/consul-acl-token
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/edgex-consul
@@ -796,8 +772,6 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/core-data
@@ -866,21 +840,15 @@ services:
     - type: volume
       source: db-data
       target: /data
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: redis-config
       target: /run/redis/conf
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/security-bootstrapper-redis
@@ -959,8 +927,6 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/device-modbus
@@ -1042,8 +1008,6 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/device-onvif-camera
@@ -1119,8 +1083,6 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/device-rest
@@ -1197,8 +1159,6 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/device-virtual
@@ -1280,8 +1240,6 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/core-metadata
@@ -1406,8 +1364,6 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: nginx-templates
@@ -1484,8 +1440,6 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/support-notifications
@@ -1541,8 +1495,6 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/security-proxy-auth
@@ -1605,8 +1557,6 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: nginx-templates
@@ -1620,8 +1570,6 @@ services:
       source: consul-acl-token
       target: /tmp/edgex/secrets/consul-acl-token
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/security-proxy-setup
@@ -1633,8 +1581,6 @@ services:
     - type: volume
       source: vault-config
       target: /vault/config
-      bind:
-        selinux: z
       volume: {}
   rulesengine:
     container_name: edgex-kuiper
@@ -1697,26 +1643,18 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: kuiper-data
       target: /kuiper/data
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: kuiper-connections
       target: /kuiper/etc/connections
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: kuiper-sources
       target: /kuiper/etc/sources
-      bind:
-        selinux: z
       volume: {}
   scalability-test-mqtt-export:
     command:
@@ -1788,8 +1726,6 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/app-scalability-test-mqtt-export
@@ -1867,8 +1803,6 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/support-scheduler
@@ -1927,8 +1861,6 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets
@@ -1939,20 +1871,14 @@ services:
     - type: volume
       source: kuiper-sources
       target: /tmp/kuiper
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: kuiper-connections
       target: /tmp/kuiper-connections
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: vault-config
       target: /vault/config
-      bind:
-        selinux: z
       volume: {}
   security-bootstrapper:
     container_name: edgex-security-bootstrapper
@@ -1990,8 +1916,6 @@ services:
     - type: volume
       source: edgex-init
       target: /edgex-init
-      bind:
-        selinux: z
       volume: {}
   security-spiffe-token-provider:
     command:
@@ -2058,8 +1982,6 @@ services:
     - type: volume
       source: edgex-init
       target: /edgex-init
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/spiffe
@@ -2127,20 +2049,14 @@ services:
     - type: volume
       source: edgex-init
       target: /edgex-init
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: spire-ca
       target: /srv/spiffe/ca
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: spire-agent
       target: /srv/spiffe/agent
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/spiffe
@@ -2205,8 +2121,6 @@ services:
     - type: volume
       source: edgex-init
       target: /edgex-init
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/spiffe
@@ -2273,20 +2187,14 @@ services:
     - type: volume
       source: edgex-init
       target: /edgex-init
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: spire-ca
       target: /srv/spiffe/ca
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: spire-server
       target: /srv/spiffe/server
-      bind:
-        selinux: z
       volume: {}
     - type: bind
       source: /tmp/edgex/secrets/spiffe
@@ -2365,20 +2273,14 @@ services:
       source: edgex-init
       target: /edgex-init
       read_only: true
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: vault-file
       target: /vault/file
-      bind:
-        selinux: z
       volume: {}
     - type: volume
       source: vault-logs
       target: /vault/logs
-      bind:
-        selinux: z
       volume: {}
 networks:
   edgex-network:


### PR DESCRIPTION
BREAKING CHANGE: This was previously add for CentOS, but is not causing issuse with move to `docker compose V2`. Users that require this for CentOS will need to customize the compose files appropraitly.

closes #329

Signed-off-by: Leonard Goodell <leonard.goodell@intel.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-compose/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-compose/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?) **N/A*
  <link to docs PR>


## Testing Instructions
Run `make build` from compose builder.
Verify the generated compose files no longer have `bind` for `selinux: z` 