### PR TITLE
fix: add configuration.yaml env override to the common config entrypoint

### DIFF
--- a/compose-builder/add-security.yml
+++ b/compose-builder/add-security.yml
@@ -331,7 +331,7 @@ services:
       - common-security.env
       - common-sec-stage-gate.env
     entrypoint: ["/edgex-init/ready_to_run_wait_install.sh"]
-    command: ["/entrypoint.sh", "/core-common-config-bootstrapper", "-cp=consul.http://edgex-core-consul:8500"]
+    command: ["/entrypoint.sh", "/core-common-config-bootstrapper", "-cp=consul.http://edgex-core-consul:8500", "-cf=configuration.yaml"]
     volumes:
       - edgex-init:/edgex-init:ro,z
       - /tmp/edgex/secrets/core-common-config-bootstrapper:/tmp/edgex/secrets/core-common-config-bootstrapper:ro,z


### PR DESCRIPTION
Signed-off-by: Elizabeth J Lee <elizabeth.j.lee@intel.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-compose/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-compose/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>


## Testing Instructions
1. run `make docker` in edgex-go with the updated changes for common config
2. run `make run dev` from compose builder
3. ensure the common config was loaded from the configuration.yaml file
