### PR TITLE
revert: Undo the override of Device GPIO's port

### DIFF
--- a/compose-builder/add-device-gpio.yml
+++ b/compose-builder/add-device-gpio.yml
@@ -31,7 +31,6 @@ services:
       - device-common.env
     environment:
       SERVICE_HOST: edgex-device-gpio
-      SERVICE_PORT: "59994"
     depends_on:
       - consul
       - data


### PR DESCRIPTION
closes #333

Signed-off-by: Leonard Goodell <leonard.goodell@intel.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-compose/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-compose/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [ ] I have fully tested (add details below) this the new feature or bug fix (if not, why?)  **N/A**
- [ ] I have opened a PR for the related docs change (if not, why?) **N/A**
  <link to docs PR>


## Testing Instructions
<!-- How can the reviewers test your change? -->
