### PR TITLE
feat!: remove notifications dependency from metadata

### DIFF
--- a/compose-builder/docker-compose-base.yml
+++ b/compose-builder/docker-compose-base.yml
@@ -101,13 +101,11 @@ services:
       - common.env
     environment:
       SERVICE_HOST: edgex-core-metadata
-      NOTIFICATIONS_SENDER: edgex-core-metadata
       MESSAGEBUS_HOST: edgex-redis
     depends_on:
       - consul
       - database
-      - notifications
-    security_opt: 
+    security_opt:
       - no-new-privileges:true
 
   data:

--- a/docker-compose-arm64.yml
+++ b/docker-compose-arm64.yml
@@ -869,8 +869,6 @@ services:
         condition: service_started
       database:
         condition: service_started
-      notifications:
-        condition: service_started
       secretstore-setup:
         condition: service_started
       security-bootstrapper:
@@ -888,7 +886,6 @@ services:
       DATABASE_HOST: edgex-redis
       EDGEX_SECURITY_SECRET_STORE: "true"
       MESSAGEBUS_HOST: edgex-redis
-      NOTIFICATIONS_SENDER: edgex-core-metadata
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault

--- a/docker-compose-no-secty-arm64.yml
+++ b/docker-compose-no-secty-arm64.yml
@@ -300,8 +300,6 @@ services:
         condition: service_started
       database:
         condition: service_started
-      notifications:
-        condition: service_started
     environment:
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
@@ -311,7 +309,6 @@ services:
       DATABASE_HOST: edgex-redis
       EDGEX_SECURITY_SECRET_STORE: "false"
       MESSAGEBUS_HOST: edgex-redis
-      NOTIFICATIONS_SENDER: edgex-core-metadata
       REGISTRY_HOST: edgex-core-consul
       SERVICE_HOST: edgex-core-metadata
     hostname: edgex-core-metadata

--- a/docker-compose-no-secty-with-app-sample-arm64.yml
+++ b/docker-compose-no-secty-with-app-sample-arm64.yml
@@ -334,8 +334,6 @@ services:
         condition: service_started
       database:
         condition: service_started
-      notifications:
-        condition: service_started
     environment:
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
@@ -345,7 +343,6 @@ services:
       DATABASE_HOST: edgex-redis
       EDGEX_SECURITY_SECRET_STORE: "false"
       MESSAGEBUS_HOST: edgex-redis
-      NOTIFICATIONS_SENDER: edgex-core-metadata
       REGISTRY_HOST: edgex-core-consul
       SERVICE_HOST: edgex-core-metadata
     hostname: edgex-core-metadata

--- a/docker-compose-no-secty-with-app-sample.yml
+++ b/docker-compose-no-secty-with-app-sample.yml
@@ -334,8 +334,6 @@ services:
         condition: service_started
       database:
         condition: service_started
-      notifications:
-        condition: service_started
     environment:
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
@@ -345,7 +343,6 @@ services:
       DATABASE_HOST: edgex-redis
       EDGEX_SECURITY_SECRET_STORE: "false"
       MESSAGEBUS_HOST: edgex-redis
-      NOTIFICATIONS_SENDER: edgex-core-metadata
       REGISTRY_HOST: edgex-core-consul
       SERVICE_HOST: edgex-core-metadata
     hostname: edgex-core-metadata

--- a/docker-compose-no-secty.yml
+++ b/docker-compose-no-secty.yml
@@ -300,8 +300,6 @@ services:
         condition: service_started
       database:
         condition: service_started
-      notifications:
-        condition: service_started
     environment:
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
@@ -311,7 +309,6 @@ services:
       DATABASE_HOST: edgex-redis
       EDGEX_SECURITY_SECRET_STORE: "false"
       MESSAGEBUS_HOST: edgex-redis
-      NOTIFICATIONS_SENDER: edgex-core-metadata
       REGISTRY_HOST: edgex-core-consul
       SERVICE_HOST: edgex-core-metadata
     hostname: edgex-core-metadata

--- a/docker-compose-with-app-sample-arm64.yml
+++ b/docker-compose-with-app-sample-arm64.yml
@@ -949,8 +949,6 @@ services:
         condition: service_started
       database:
         condition: service_started
-      notifications:
-        condition: service_started
       secretstore-setup:
         condition: service_started
       security-bootstrapper:
@@ -968,7 +966,6 @@ services:
       DATABASE_HOST: edgex-redis
       EDGEX_SECURITY_SECRET_STORE: "true"
       MESSAGEBUS_HOST: edgex-redis
-      NOTIFICATIONS_SENDER: edgex-core-metadata
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault

--- a/docker-compose-with-app-sample.yml
+++ b/docker-compose-with-app-sample.yml
@@ -949,8 +949,6 @@ services:
         condition: service_started
       database:
         condition: service_started
-      notifications:
-        condition: service_started
       secretstore-setup:
         condition: service_started
       security-bootstrapper:
@@ -968,7 +966,6 @@ services:
       DATABASE_HOST: edgex-redis
       EDGEX_SECURITY_SECRET_STORE: "true"
       MESSAGEBUS_HOST: edgex-redis
-      NOTIFICATIONS_SENDER: edgex-core-metadata
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -869,8 +869,6 @@ services:
         condition: service_started
       database:
         condition: service_started
-      notifications:
-        condition: service_started
       secretstore-setup:
         condition: service_started
       security-bootstrapper:
@@ -888,7 +886,6 @@ services:
       DATABASE_HOST: edgex-redis
       EDGEX_SECURITY_SECRET_STORE: "true"
       MESSAGEBUS_HOST: edgex-redis
-      NOTIFICATIONS_SENDER: edgex-core-metadata
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault

--- a/taf/docker-compose-taf-arm64.yml
+++ b/taf/docker-compose-taf-arm64.yml
@@ -1454,8 +1454,6 @@ services:
         condition: service_started
       database:
         condition: service_started
-      notifications:
-        condition: service_started
       secretstore-setup:
         condition: service_started
       security-bootstrapper:
@@ -1473,7 +1471,6 @@ services:
       DATABASE_HOST: edgex-redis
       EDGEX_SECURITY_SECRET_STORE: "true"
       MESSAGEBUS_HOST: edgex-redis
-      NOTIFICATIONS_SENDER: edgex-core-metadata
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault

--- a/taf/docker-compose-taf-mqtt-bus-arm64.yml
+++ b/taf/docker-compose-taf-mqtt-bus-arm64.yml
@@ -1531,8 +1531,6 @@ services:
         condition: service_started
       mqtt-broker:
         condition: service_started
-      notifications:
-        condition: service_started
       secretstore-setup:
         condition: service_started
       security-bootstrapper:
@@ -1556,7 +1554,6 @@ services:
       MESSAGEBUS_PROTOCOL: tcp
       MESSAGEBUS_SECRETNAME: message-bus
       MESSAGEBUS_TYPE: mqtt
-      NOTIFICATIONS_SENDER: edgex-core-metadata
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault

--- a/taf/docker-compose-taf-mqtt-bus.yml
+++ b/taf/docker-compose-taf-mqtt-bus.yml
@@ -1531,8 +1531,6 @@ services:
         condition: service_started
       mqtt-broker:
         condition: service_started
-      notifications:
-        condition: service_started
       secretstore-setup:
         condition: service_started
       security-bootstrapper:
@@ -1556,7 +1554,6 @@ services:
       MESSAGEBUS_PROTOCOL: tcp
       MESSAGEBUS_SECRETNAME: message-bus
       MESSAGEBUS_TYPE: mqtt
-      NOTIFICATIONS_SENDER: edgex-core-metadata
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault

--- a/taf/docker-compose-taf-no-secty-arm64.yml
+++ b/taf/docker-compose-taf-no-secty-arm64.yml
@@ -571,8 +571,6 @@ services:
         condition: service_started
       database:
         condition: service_started
-      notifications:
-        condition: service_started
     environment:
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
@@ -582,7 +580,6 @@ services:
       DATABASE_HOST: edgex-redis
       EDGEX_SECURITY_SECRET_STORE: "false"
       MESSAGEBUS_HOST: edgex-redis
-      NOTIFICATIONS_SENDER: edgex-core-metadata
       REGISTRY_HOST: edgex-core-consul
       SERVICE_HOST: edgex-core-metadata
     hostname: edgex-core-metadata

--- a/taf/docker-compose-taf-no-secty-mqtt-bus-arm64.yml
+++ b/taf/docker-compose-taf-no-secty-mqtt-bus-arm64.yml
@@ -636,8 +636,6 @@ services:
         condition: service_started
       mqtt-broker:
         condition: service_started
-      notifications:
-        condition: service_started
     environment:
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
@@ -652,7 +650,6 @@ services:
       MESSAGEBUS_PORT: "1883"
       MESSAGEBUS_PROTOCOL: tcp
       MESSAGEBUS_TYPE: mqtt
-      NOTIFICATIONS_SENDER: edgex-core-metadata
       REGISTRY_HOST: edgex-core-consul
       SERVICE_HOST: edgex-core-metadata
     hostname: edgex-core-metadata

--- a/taf/docker-compose-taf-no-secty-mqtt-bus.yml
+++ b/taf/docker-compose-taf-no-secty-mqtt-bus.yml
@@ -636,8 +636,6 @@ services:
         condition: service_started
       mqtt-broker:
         condition: service_started
-      notifications:
-        condition: service_started
     environment:
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
@@ -652,7 +650,6 @@ services:
       MESSAGEBUS_PORT: "1883"
       MESSAGEBUS_PROTOCOL: tcp
       MESSAGEBUS_TYPE: mqtt
-      NOTIFICATIONS_SENDER: edgex-core-metadata
       REGISTRY_HOST: edgex-core-consul
       SERVICE_HOST: edgex-core-metadata
     hostname: edgex-core-metadata

--- a/taf/docker-compose-taf-no-secty.yml
+++ b/taf/docker-compose-taf-no-secty.yml
@@ -571,8 +571,6 @@ services:
         condition: service_started
       database:
         condition: service_started
-      notifications:
-        condition: service_started
     environment:
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
@@ -582,7 +580,6 @@ services:
       DATABASE_HOST: edgex-redis
       EDGEX_SECURITY_SECRET_STORE: "false"
       MESSAGEBUS_HOST: edgex-redis
-      NOTIFICATIONS_SENDER: edgex-core-metadata
       REGISTRY_HOST: edgex-core-consul
       SERVICE_HOST: edgex-core-metadata
     hostname: edgex-core-metadata

--- a/taf/docker-compose-taf-perf-arm64.yml
+++ b/taf/docker-compose-taf-perf-arm64.yml
@@ -952,8 +952,6 @@ services:
         condition: service_started
       database:
         condition: service_started
-      notifications:
-        condition: service_started
       secretstore-setup:
         condition: service_started
       security-bootstrapper:
@@ -971,7 +969,6 @@ services:
       DATABASE_HOST: edgex-redis
       EDGEX_SECURITY_SECRET_STORE: "true"
       MESSAGEBUS_HOST: edgex-redis
-      NOTIFICATIONS_SENDER: edgex-core-metadata
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault

--- a/taf/docker-compose-taf-perf-no-secty-arm64.yml
+++ b/taf/docker-compose-taf-perf-no-secty-arm64.yml
@@ -337,8 +337,6 @@ services:
         condition: service_started
       database:
         condition: service_started
-      notifications:
-        condition: service_started
     environment:
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
@@ -348,7 +346,6 @@ services:
       DATABASE_HOST: edgex-redis
       EDGEX_SECURITY_SECRET_STORE: "false"
       MESSAGEBUS_HOST: edgex-redis
-      NOTIFICATIONS_SENDER: edgex-core-metadata
       REGISTRY_HOST: edgex-core-consul
       SERVICE_HOST: edgex-core-metadata
     hostname: edgex-core-metadata

--- a/taf/docker-compose-taf-perf-no-secty.yml
+++ b/taf/docker-compose-taf-perf-no-secty.yml
@@ -337,8 +337,6 @@ services:
         condition: service_started
       database:
         condition: service_started
-      notifications:
-        condition: service_started
     environment:
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
       CLIENTS_CORE_DATA_HOST: edgex-core-data
@@ -348,7 +346,6 @@ services:
       DATABASE_HOST: edgex-redis
       EDGEX_SECURITY_SECRET_STORE: "false"
       MESSAGEBUS_HOST: edgex-redis
-      NOTIFICATIONS_SENDER: edgex-core-metadata
       REGISTRY_HOST: edgex-core-consul
       SERVICE_HOST: edgex-core-metadata
     hostname: edgex-core-metadata

--- a/taf/docker-compose-taf-perf.yml
+++ b/taf/docker-compose-taf-perf.yml
@@ -952,8 +952,6 @@ services:
         condition: service_started
       database:
         condition: service_started
-      notifications:
-        condition: service_started
       secretstore-setup:
         condition: service_started
       security-bootstrapper:
@@ -971,7 +969,6 @@ services:
       DATABASE_HOST: edgex-redis
       EDGEX_SECURITY_SECRET_STORE: "true"
       MESSAGEBUS_HOST: edgex-redis
-      NOTIFICATIONS_SENDER: edgex-core-metadata
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault

--- a/taf/docker-compose-taf.yml
+++ b/taf/docker-compose-taf.yml
@@ -1454,8 +1454,6 @@ services:
         condition: service_started
       database:
         condition: service_started
-      notifications:
-        condition: service_started
       secretstore-setup:
         condition: service_started
       security-bootstrapper:
@@ -1473,7 +1471,6 @@ services:
       DATABASE_HOST: edgex-redis
       EDGEX_SECURITY_SECRET_STORE: "true"
       MESSAGEBUS_HOST: edgex-redis
-      NOTIFICATIONS_SENDER: edgex-core-metadata
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       REGISTRY_HOST: edgex-core-consul
       SECRETSTORE_HOST: edgex-vault


### PR DESCRIPTION
BREAKING CHANGE: remove notifications dependency from metadata

metadata will send system events to message queue directly instead of notifications REST call in v3.

closes #339

Signed-off-by: Chris Hung <chris@iotechsys.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-compose/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-compose/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>


## Testing Instructions
<!-- How can the reviewers test your change? -->
