### PR TITLE
refactor: Consume change to add base topic to rules-engine events topic

### DIFF
--- a/compose-builder/docker-compose-base.yml
+++ b/compose-builder/docker-compose-base.yml
@@ -242,7 +242,7 @@ services:
       EDGEX__DEFAULT__PROTOCOL: redis
       EDGEX__DEFAULT__SERVER: edgex-redis
       EDGEX__DEFAULT__TYPE: redis
-      EDGEX__DEFAULT__TOPIC: rules-events
+      EDGEX__DEFAULT__TOPIC: edgex/rules-events
     depends_on:
       - database
     security_opt: 

--- a/docker-compose-arm64.yml
+++ b/docker-compose-arm64.yml
@@ -1118,7 +1118,7 @@ services:
       EDGEX__DEFAULT__PORT: "6379"
       EDGEX__DEFAULT__PROTOCOL: redis
       EDGEX__DEFAULT__SERVER: edgex-redis
-      EDGEX__DEFAULT__TOPIC: rules-events
+      EDGEX__DEFAULT__TOPIC: edgex/rules-events
       EDGEX__DEFAULT__TYPE: redis
       KUIPER__BASIC__CONSOLELOG: "true"
       KUIPER__BASIC__RESTPORT: "59720"

--- a/docker-compose-no-secty-arm64.yml
+++ b/docker-compose-no-secty-arm64.yml
@@ -372,7 +372,7 @@ services:
       EDGEX__DEFAULT__PORT: "6379"
       EDGEX__DEFAULT__PROTOCOL: redis
       EDGEX__DEFAULT__SERVER: edgex-redis
-      EDGEX__DEFAULT__TOPIC: rules-events
+      EDGEX__DEFAULT__TOPIC: edgex/rules-events
       EDGEX__DEFAULT__TYPE: redis
       KUIPER__BASIC__CONSOLELOG: "true"
       KUIPER__BASIC__RESTPORT: "59720"

--- a/docker-compose-no-secty-with-app-sample-arm64.yml
+++ b/docker-compose-no-secty-with-app-sample-arm64.yml
@@ -406,7 +406,7 @@ services:
       EDGEX__DEFAULT__PORT: "6379"
       EDGEX__DEFAULT__PROTOCOL: redis
       EDGEX__DEFAULT__SERVER: edgex-redis
-      EDGEX__DEFAULT__TOPIC: rules-events
+      EDGEX__DEFAULT__TOPIC: edgex/rules-events
       EDGEX__DEFAULT__TYPE: redis
       KUIPER__BASIC__CONSOLELOG: "true"
       KUIPER__BASIC__RESTPORT: "59720"

--- a/docker-compose-no-secty-with-app-sample.yml
+++ b/docker-compose-no-secty-with-app-sample.yml
@@ -406,7 +406,7 @@ services:
       EDGEX__DEFAULT__PORT: "6379"
       EDGEX__DEFAULT__PROTOCOL: redis
       EDGEX__DEFAULT__SERVER: edgex-redis
-      EDGEX__DEFAULT__TOPIC: rules-events
+      EDGEX__DEFAULT__TOPIC: edgex/rules-events
       EDGEX__DEFAULT__TYPE: redis
       KUIPER__BASIC__CONSOLELOG: "true"
       KUIPER__BASIC__RESTPORT: "59720"

--- a/docker-compose-no-secty.yml
+++ b/docker-compose-no-secty.yml
@@ -372,7 +372,7 @@ services:
       EDGEX__DEFAULT__PORT: "6379"
       EDGEX__DEFAULT__PROTOCOL: redis
       EDGEX__DEFAULT__SERVER: edgex-redis
-      EDGEX__DEFAULT__TOPIC: rules-events
+      EDGEX__DEFAULT__TOPIC: edgex/rules-events
       EDGEX__DEFAULT__TYPE: redis
       KUIPER__BASIC__CONSOLELOG: "true"
       KUIPER__BASIC__RESTPORT: "59720"

--- a/docker-compose-with-app-sample-arm64.yml
+++ b/docker-compose-with-app-sample-arm64.yml
@@ -1198,7 +1198,7 @@ services:
       EDGEX__DEFAULT__PORT: "6379"
       EDGEX__DEFAULT__PROTOCOL: redis
       EDGEX__DEFAULT__SERVER: edgex-redis
-      EDGEX__DEFAULT__TOPIC: rules-events
+      EDGEX__DEFAULT__TOPIC: edgex/rules-events
       EDGEX__DEFAULT__TYPE: redis
       KUIPER__BASIC__CONSOLELOG: "true"
       KUIPER__BASIC__RESTPORT: "59720"

--- a/docker-compose-with-app-sample.yml
+++ b/docker-compose-with-app-sample.yml
@@ -1198,7 +1198,7 @@ services:
       EDGEX__DEFAULT__PORT: "6379"
       EDGEX__DEFAULT__PROTOCOL: redis
       EDGEX__DEFAULT__SERVER: edgex-redis
-      EDGEX__DEFAULT__TOPIC: rules-events
+      EDGEX__DEFAULT__TOPIC: edgex/rules-events
       EDGEX__DEFAULT__TYPE: redis
       KUIPER__BASIC__CONSOLELOG: "true"
       KUIPER__BASIC__RESTPORT: "59720"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1118,7 +1118,7 @@ services:
       EDGEX__DEFAULT__PORT: "6379"
       EDGEX__DEFAULT__PROTOCOL: redis
       EDGEX__DEFAULT__SERVER: edgex-redis
-      EDGEX__DEFAULT__TOPIC: rules-events
+      EDGEX__DEFAULT__TOPIC: edgex/rules-events
       EDGEX__DEFAULT__TYPE: redis
       KUIPER__BASIC__CONSOLELOG: "true"
       KUIPER__BASIC__RESTPORT: "59720"

--- a/taf/docker-compose-taf-arm64.yml
+++ b/taf/docker-compose-taf-arm64.yml
@@ -1762,7 +1762,7 @@ services:
       EDGEX__DEFAULT__PORT: "6379"
       EDGEX__DEFAULT__PROTOCOL: redis
       EDGEX__DEFAULT__SERVER: edgex-redis
-      EDGEX__DEFAULT__TOPIC: rules-events
+      EDGEX__DEFAULT__TOPIC: edgex/rules-events
       EDGEX__DEFAULT__TYPE: redis
       KUIPER__BASIC__CONSOLELOG: "true"
       KUIPER__BASIC__RESTPORT: "59720"

--- a/taf/docker-compose-taf-mqtt-bus-arm64.yml
+++ b/taf/docker-compose-taf-mqtt-bus-arm64.yml
@@ -1920,7 +1920,7 @@ services:
       EDGEX__DEFAULT__PORT: "1883"
       EDGEX__DEFAULT__PROTOCOL: tcp
       EDGEX__DEFAULT__SERVER: edgex-mqtt-broker
-      EDGEX__DEFAULT__TOPIC: rules-events
+      EDGEX__DEFAULT__TOPIC: edgex/rules-events
       EDGEX__DEFAULT__TYPE: mqtt
       KUIPER__BASIC__CONSOLELOG: "true"
       KUIPER__BASIC__RESTPORT: "59720"

--- a/taf/docker-compose-taf-mqtt-bus.yml
+++ b/taf/docker-compose-taf-mqtt-bus.yml
@@ -1920,7 +1920,7 @@ services:
       EDGEX__DEFAULT__PORT: "1883"
       EDGEX__DEFAULT__PROTOCOL: tcp
       EDGEX__DEFAULT__SERVER: edgex-mqtt-broker
-      EDGEX__DEFAULT__TOPIC: rules-events
+      EDGEX__DEFAULT__TOPIC: edgex/rules-events
       EDGEX__DEFAULT__TYPE: mqtt
       KUIPER__BASIC__CONSOLELOG: "true"
       KUIPER__BASIC__RESTPORT: "59720"

--- a/taf/docker-compose-taf-no-secty-arm64.yml
+++ b/taf/docker-compose-taf-no-secty-arm64.yml
@@ -702,7 +702,7 @@ services:
       EDGEX__DEFAULT__PORT: "6379"
       EDGEX__DEFAULT__PROTOCOL: redis
       EDGEX__DEFAULT__SERVER: edgex-redis
-      EDGEX__DEFAULT__TOPIC: rules-events
+      EDGEX__DEFAULT__TOPIC: edgex/rules-events
       EDGEX__DEFAULT__TYPE: redis
       KUIPER__BASIC__CONSOLELOG: "true"
       KUIPER__BASIC__RESTPORT: "59720"

--- a/taf/docker-compose-taf-no-secty-mqtt-bus-arm64.yml
+++ b/taf/docker-compose-taf-no-secty-mqtt-bus-arm64.yml
@@ -790,7 +790,7 @@ services:
       EDGEX__DEFAULT__PORT: "1883"
       EDGEX__DEFAULT__PROTOCOL: tcp
       EDGEX__DEFAULT__SERVER: edgex-mqtt-broker
-      EDGEX__DEFAULT__TOPIC: rules-events
+      EDGEX__DEFAULT__TOPIC: edgex/rules-events
       EDGEX__DEFAULT__TYPE: mqtt
       KUIPER__BASIC__CONSOLELOG: "true"
       KUIPER__BASIC__RESTPORT: "59720"

--- a/taf/docker-compose-taf-no-secty-mqtt-bus.yml
+++ b/taf/docker-compose-taf-no-secty-mqtt-bus.yml
@@ -790,7 +790,7 @@ services:
       EDGEX__DEFAULT__PORT: "1883"
       EDGEX__DEFAULT__PROTOCOL: tcp
       EDGEX__DEFAULT__SERVER: edgex-mqtt-broker
-      EDGEX__DEFAULT__TOPIC: rules-events
+      EDGEX__DEFAULT__TOPIC: edgex/rules-events
       EDGEX__DEFAULT__TYPE: mqtt
       KUIPER__BASIC__CONSOLELOG: "true"
       KUIPER__BASIC__RESTPORT: "59720"

--- a/taf/docker-compose-taf-no-secty.yml
+++ b/taf/docker-compose-taf-no-secty.yml
@@ -702,7 +702,7 @@ services:
       EDGEX__DEFAULT__PORT: "6379"
       EDGEX__DEFAULT__PROTOCOL: redis
       EDGEX__DEFAULT__SERVER: edgex-redis
-      EDGEX__DEFAULT__TOPIC: rules-events
+      EDGEX__DEFAULT__TOPIC: edgex/rules-events
       EDGEX__DEFAULT__TYPE: redis
       KUIPER__BASIC__CONSOLELOG: "true"
       KUIPER__BASIC__RESTPORT: "59720"

--- a/taf/docker-compose-taf-perf-arm64.yml
+++ b/taf/docker-compose-taf-perf-arm64.yml
@@ -1243,7 +1243,7 @@ services:
       EDGEX__DEFAULT__PORT: "6379"
       EDGEX__DEFAULT__PROTOCOL: redis
       EDGEX__DEFAULT__SERVER: edgex-redis
-      EDGEX__DEFAULT__TOPIC: rules-events
+      EDGEX__DEFAULT__TOPIC: edgex/rules-events
       EDGEX__DEFAULT__TYPE: redis
       KUIPER__BASIC__CONSOLELOG: "true"
       KUIPER__BASIC__RESTPORT: "59720"

--- a/taf/docker-compose-taf-perf-no-secty-arm64.yml
+++ b/taf/docker-compose-taf-perf-no-secty-arm64.yml
@@ -451,7 +451,7 @@ services:
       EDGEX__DEFAULT__PORT: "6379"
       EDGEX__DEFAULT__PROTOCOL: redis
       EDGEX__DEFAULT__SERVER: edgex-redis
-      EDGEX__DEFAULT__TOPIC: rules-events
+      EDGEX__DEFAULT__TOPIC: edgex/rules-events
       EDGEX__DEFAULT__TYPE: redis
       KUIPER__BASIC__CONSOLELOG: "true"
       KUIPER__BASIC__RESTPORT: "59720"

--- a/taf/docker-compose-taf-perf-no-secty.yml
+++ b/taf/docker-compose-taf-perf-no-secty.yml
@@ -451,7 +451,7 @@ services:
       EDGEX__DEFAULT__PORT: "6379"
       EDGEX__DEFAULT__PROTOCOL: redis
       EDGEX__DEFAULT__SERVER: edgex-redis
-      EDGEX__DEFAULT__TOPIC: rules-events
+      EDGEX__DEFAULT__TOPIC: edgex/rules-events
       EDGEX__DEFAULT__TYPE: redis
       KUIPER__BASIC__CONSOLELOG: "true"
       KUIPER__BASIC__RESTPORT: "59720"

--- a/taf/docker-compose-taf-perf.yml
+++ b/taf/docker-compose-taf-perf.yml
@@ -1243,7 +1243,7 @@ services:
       EDGEX__DEFAULT__PORT: "6379"
       EDGEX__DEFAULT__PROTOCOL: redis
       EDGEX__DEFAULT__SERVER: edgex-redis
-      EDGEX__DEFAULT__TOPIC: rules-events
+      EDGEX__DEFAULT__TOPIC: edgex/rules-events
       EDGEX__DEFAULT__TYPE: redis
       KUIPER__BASIC__CONSOLELOG: "true"
       KUIPER__BASIC__RESTPORT: "59720"

--- a/taf/docker-compose-taf.yml
+++ b/taf/docker-compose-taf.yml
@@ -1762,7 +1762,7 @@ services:
       EDGEX__DEFAULT__PORT: "6379"
       EDGEX__DEFAULT__PROTOCOL: redis
       EDGEX__DEFAULT__SERVER: edgex-redis
-      EDGEX__DEFAULT__TOPIC: rules-events
+      EDGEX__DEFAULT__TOPIC: edgex/rules-events
       EDGEX__DEFAULT__TYPE: redis
       KUIPER__BASIC__CONSOLELOG: "true"
       KUIPER__BASIC__RESTPORT: "59720"


### PR DESCRIPTION
<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-compose/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-compose/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  TBD


## Testing Instructions
From compose builder run `make gen no-secty ds-virtual`
Modify generated compose file to add `KUIPER__BASIC__DEBUG: "true"` to eKuiper environment
Run `make up`
From Postman or curl create a stream by posting the following to `http://localhost:59720/streams`
```
{
  "sql": "create stream EdgexStream () WITH (FORMAT=\"JSON\", TYPE=\"edgex\")"
}
```
From Postman or curl create a rule by posting the following to `http://localhost:59720/rules`
```
{
  "id": "ruleBool",
  "sql": "SELECT bool FROM EdgexStream where bool = true",
  "actions": [
    {
      "rest": {
        "url": "http://edgex-core-command:59882/api/v2/device/name/Random-Integer-Device/Int64",       
        "method": "get",
        "dataTemplate": "\"newKey\":\"{{.key}}\"",
        "sendSingle": true
      }
    }
  ]
}
```
Verify from eKuiper logs it is receiving events
```
time="2023-02-20 16:41:43" level=debug msg="receive message {\"apiVersion\":\"v2\",\"id\":\"68011f37-e0a0-4646-8e21-c10e59d20c86\",\"deviceName\":\"Random-Boolean-Device\",\"profileName\":\"Random-Boolean-Device\",\"sourceName\":\"Bool\",\"origin\":1676911303342165200,\"readings\":[{\"id\":\"72f2a011-b352-4777-88ad-a144115a124e\",\"origin\":1676911303342165200,\"deviceName\":\"Random-Boolean-Device\",\"resourceName\":\"Bool\",\"profileName\":\"Random-Boolean-Device\",\"valueType\":\"Bool\",\"value\":\"false\"}]} from device Random-Boolean-Device" file="source/edgex_source.go:154" rule=ruleBool
```