### PR TITLE
fix: Eliminate unnamed Kuiper volumes

### DIFF
--- a/compose-builder/docker-compose-base.yml
+++ b/compose-builder/docker-compose-base.yml
@@ -26,6 +26,9 @@ volumes:
   consul-config:
   consul-data:
   kuiper-data:
+  kuiper-etc:
+  kuiper-log:
+  kuiper-plugins:
 
 services:
   consul:
@@ -230,6 +233,9 @@ services:
       - edgex-network
     volumes:
       - kuiper-data:/kuiper/data
+      - kuiper-etc:/kuiper/etc
+      - kuiper-log:/kuiper/log
+      - kuiper-plugins:/kuiper/plugins
     environment:
 #      KUIPER__BASIC__DEBUG: "true"
       KUIPER__BASIC__CONSOLELOG: "true"


### PR DESCRIPTION
When starting the EdgeX framework, a "docker volume ls" command will show three hex-string named volumes that are created as a result of VOLUME declarations in the base image. These volumes correspond to /kuiper/etc, /kuiper/log, and /kuiper/plugins.

This commit explictly mounts named volumes to these locations to stop docker from creating randomly named fill-in volumes.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [ ] I have fully tested (add details below) this the new feature or bug fix (if not, why?)  TBD.  Tested blocked by another PR.
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>


## Testing Instructions
Before fix:
- make clean
- make run
- docker volume ls
- (observe placeholder volumes)

After fix:
- make clean
- make run
- docker volume ls
- (observe placeholder volumes are replaced with named volumes)