### PR TITLE
refactor!: Rework service names to conform to consistent naming

### DIFF
--- a/compose-builder/Makefile
+++ b/compose-builder/Makefile
@@ -360,12 +360,12 @@ ifeq (asc-http, $(filter asc-http,$(ARGS)))
 		endif
 		# when no security mode (no-secty) not explicitly specified,
 		# then we also need to add the secure version on top of base yml by default.
-		extension_file:= $(shell GEN_EXT_DIR="$(GEN_EXT_DIR)" ./gen_secure_compose_ext.sh app-service-http-export \
+		extension_file:= $(shell GEN_EXT_DIR="$(GEN_EXT_DIR)" ./gen_secure_compose_ext.sh app-http-export \
 			app-http-export app-service-configurable)
 		COMPOSE_FILES:=$(COMPOSE_FILES) -f $(extension_file)
 		# add runtime token config for delayed-start if specified
 		ifeq (delayed-start, $(filter delayed-start,$(ARGS)))
-			ext_file:= $(shell GEN_EXT_DIR="$(GEN_EXT_DIR)" ./gen_runtime_token_config_compose_ext.sh app-service-http-export)
+			ext_file:= $(shell GEN_EXT_DIR="$(GEN_EXT_DIR)" ./gen_runtime_token_config_compose_ext.sh app-http-export)
 			COMPOSE_FILES:=$(COMPOSE_FILES) -f $(ext_file)
 		endif
 	endif
@@ -390,12 +390,12 @@ ifeq (asc-mqtt, $(filter asc-mqtt,$(ARGS)))
 		endif
 		# when no security mode (no-secty) not explicitly specified,
 		# then we also need to add the secure version on top of base yml by default.
-		extension_file:= $(shell GEN_EXT_DIR="$(GEN_EXT_DIR)" IS_MQTT_BUS="$(IS_MQTT_BUS)" ./gen_secure_compose_ext.sh app-service-mqtt-export \
+		extension_file:= $(shell GEN_EXT_DIR="$(GEN_EXT_DIR)" IS_MQTT_BUS="$(IS_MQTT_BUS)" ./gen_secure_compose_ext.sh app-mqtt-export \
 			app-mqtt-export app-service-configurable)
 		COMPOSE_FILES:=$(COMPOSE_FILES) -f $(extension_file)
 		# add runtime token config for delayed-start if specified
 		ifeq (delayed-start, $(filter delayed-start,$(ARGS)))
-			ext_file:= $(shell GEN_EXT_DIR="$(GEN_EXT_DIR)" ./gen_runtime_token_config_compose_ext.sh app-service-mqtt-export)
+			ext_file:= $(shell GEN_EXT_DIR="$(GEN_EXT_DIR)" ./gen_runtime_token_config_compose_ext.sh app-mqtt-export)
 			COMPOSE_FILES:=$(COMPOSE_FILES) -f $(ext_file)
 		endif
 	endif
@@ -416,12 +416,12 @@ ifeq (asc-sample, $(filter asc-sample,$(ARGS)))
 		endif
 		# when no security mode (no-secty) not explicitly specified,
 		# then we also need to add the secure version on top of base yml by default.
-		extension_file:= $(shell GEN_EXT_DIR="$(GEN_EXT_DIR)" ./gen_secure_compose_ext.sh app-service-sample \
+		extension_file:= $(shell GEN_EXT_DIR="$(GEN_EXT_DIR)" ./gen_secure_compose_ext.sh app-sample \
 			app-sample app-service-configurable)
 		COMPOSE_FILES:=$(COMPOSE_FILES) -f $(extension_file)
 		# add runtime token config for delayed-start if specified
 		ifeq (delayed-start, $(filter delayed-start,$(ARGS)))
-			ext_file:= $(shell GEN_EXT_DIR="$(GEN_EXT_DIR)" ./gen_runtime_token_config_compose_ext.sh app-service-sample)
+			ext_file:= $(shell GEN_EXT_DIR="$(GEN_EXT_DIR)" ./gen_runtime_token_config_compose_ext.sh app-sample)
 			COMPOSE_FILES:=$(COMPOSE_FILES) -f $(ext_file)
 		endif
 	endif
@@ -496,12 +496,12 @@ ifeq (asc-ex-mqtt, $(filter asc-ex-mqtt,$(ARGS)))
 		endif
 		# when no security mode (no-secty) not explicitly specified,
 		# then we also need to add the secure version on top of base yml by default.
-		extension_file:= $(shell GEN_EXT_DIR="$(GEN_EXT_DIR)" IS_MQTT_BUS="$(IS_MQTT_BUS)" ./gen_secure_compose_ext.sh app-service-external-mqtt-trigger \
+		extension_file:= $(shell GEN_EXT_DIR="$(GEN_EXT_DIR)" IS_MQTT_BUS="$(IS_MQTT_BUS)" ./gen_secure_compose_ext.sh app-external-mqtt-trigger \
 			app-external-mqtt-trigger app-service-configurable)
 		COMPOSE_FILES:=$(COMPOSE_FILES) -f $(extension_file)
 		# add runtime token config for delayed-start if specified
 		ifeq (delayed-start, $(filter delayed-start,$(ARGS)))
-			ext_file:= $(shell GEN_EXT_DIR="$(GEN_EXT_DIR)" ./gen_runtime_token_config_compose_ext.sh app-service-external-mqtt-trigger)
+			ext_file:= $(shell GEN_EXT_DIR="$(GEN_EXT_DIR)" ./gen_runtime_token_config_compose_ext.sh app-external-mqtt-trigger)
 			COMPOSE_FILES:=$(COMPOSE_FILES) -f $(ext_file)
 		endif
 	endif
@@ -584,15 +584,15 @@ ifeq (taf-secty, $(filter taf-secty,$(ARGS)))
 		IS_MQTT_BUS:=0
 	endif
 
-	asc_http_export_ext:= $(shell GEN_EXT_DIR="$(GEN_EXT_DIR)" ./gen_secure_compose_ext.sh app-service-http-export \
+	asc_http_export_ext:= $(shell GEN_EXT_DIR="$(GEN_EXT_DIR)" ./gen_secure_compose_ext.sh app-http-export \
 		app-http-export app-service-configurable)
-	asc_mqtt_export_ext:= $(shell GEN_EXT_DIR="$(GEN_EXT_DIR)" IS_MQTT_BUS="$(IS_MQTT_BUS)" ./gen_secure_compose_ext.sh app-service-mqtt-export \
+	asc_mqtt_export_ext:= $(shell GEN_EXT_DIR="$(GEN_EXT_DIR)" IS_MQTT_BUS="$(IS_MQTT_BUS)" ./gen_secure_compose_ext.sh app-mqtt-export \
 		app-mqtt-export app-service-configurable)
-	scalability_mqtt_export_ext:= $(shell GEN_EXT_DIR="$(GEN_EXT_DIR)" IS_MQTT_BUS="$(IS_MQTT_BUS)" ./gen_secure_compose_ext.sh scalability-test-mqtt-export \
+	scalability_mqtt_export_ext:= $(shell GEN_EXT_DIR="$(GEN_EXT_DIR)" IS_MQTT_BUS="$(IS_MQTT_BUS)" ./gen_secure_compose_ext.sh app-scalability-test-mqtt-export \
 		app-scalability-test-mqtt-export app-service-configurable)
-	asc_external_mqtt_trigger_ext:= $(shell GEN_EXT_DIR="$(GEN_EXT_DIR)" IS_MQTT_BUS="$(IS_MQTT_BUS)" ./gen_secure_compose_ext.sh app-service-external-mqtt-trigger \
+	asc_external_mqtt_trigger_ext:= $(shell GEN_EXT_DIR="$(GEN_EXT_DIR)" IS_MQTT_BUS="$(IS_MQTT_BUS)" ./gen_secure_compose_ext.sh app-external-mqtt-trigger \
 		app-external-mqtt-trigger app-service-configurable)
-	asc_sample_ext:= $(shell GEN_EXT_DIR="$(GEN_EXT_DIR)" ./gen_secure_compose_ext.sh app-service-sample \
+	asc_sample_ext:= $(shell GEN_EXT_DIR="$(GEN_EXT_DIR)" ./gen_secure_compose_ext.sh app-sample \
 		app-sample app-service-configurable)
 	ds_rest_ext:= $(shell GEN_EXT_DIR="$(GEN_EXT_DIR)" ./gen_secure_compose_ext.sh device-rest)
 	# taf has its special place holder from taf-device-services-mods and thus we need to keep it
@@ -648,7 +648,7 @@ else
     			-f add-mqtt-broker.yml \
 				-f add-taf-mqtt-broker.yml \
 			-f add-delayed-start-services.yml
-			asc_mqtt_export_ext:= $(shell GEN_EXT_DIR="$(GEN_EXT_DIR)"  IS_MQTT_BUS="0" ./gen_secure_compose_ext.sh app-service-mqtt-export \
+			asc_mqtt_export_ext:= $(shell GEN_EXT_DIR="$(GEN_EXT_DIR)"  IS_MQTT_BUS="0" ./gen_secure_compose_ext.sh app-mqtt-export \
 				app-mqtt-export app-service-configurable)
 			ds_virtual_ext:= $(shell GEN_EXT_DIR="$(GEN_EXT_DIR)" ./gen_secure_compose_ext.sh device-virtual)
 			ds_rest_ext:= $(shell GEN_EXT_DIR="$(GEN_EXT_DIR)" ./gen_secure_compose_ext.sh device-rest)

--- a/compose-builder/add-app-rfid-llrp-inventory.yml
+++ b/compose-builder/add-app-rfid-llrp-inventory.yml
@@ -31,7 +31,7 @@ services:
       SERVICE_HOST: edgex-app-rfid-llrp-inventory
     depends_on:
       - consul
-      - data
+      - core-data
     read_only: true
     restart: always
     networks:

--- a/compose-builder/add-asc-external-mqtt-trigger.yml
+++ b/compose-builder/add-asc-external-mqtt-trigger.yml
@@ -16,7 +16,7 @@
 version: '3.7'
 
 services:
-  app-service-external-mqtt-trigger:
+  app-external-mqtt-trigger:
     image: ${APP_SVC_REPOSITORY}/app-service-configurable${ARCH}:${APP_SERVICE_CONFIG_VERSION}
     ports:
       - 127.0.0.1:59706:59706/tcp
@@ -33,7 +33,7 @@ services:
       WRITABLE_LOGLEVEL: INFO
     depends_on:
       - consul
-      - data
+      - core-data
     read_only: true
     restart: always
     networks:

--- a/compose-builder/add-asc-http-export.yml
+++ b/compose-builder/add-asc-http-export.yml
@@ -16,7 +16,7 @@
 version: '3.7'
 
 services:
-  app-service-http-export:
+  app-http-export:
     image: ${APP_SVC_REPOSITORY}/app-service-configurable${ARCH}:${APP_SERVICE_CONFIG_VERSION}
     ports:
       - 127.0.0.1:59704:59704/tcp
@@ -31,7 +31,7 @@ services:
       WRITABLE_LOGLEVEL: INFO  # allows scripts to find and change with sed
     depends_on:
       - consul
-      - data
+      - core-data
     read_only: true
     restart: always
     networks:

--- a/compose-builder/add-asc-metrics-influxdb.yml
+++ b/compose-builder/add-asc-metrics-influxdb.yml
@@ -29,7 +29,7 @@ services:
       EDGEX_PROFILE: metrics-influxdb
     depends_on:
       - consul
-      - data
+      - core-data
     read_only: true
     restart: always
     networks:

--- a/compose-builder/add-asc-mqtt-export.yml
+++ b/compose-builder/add-asc-mqtt-export.yml
@@ -16,7 +16,7 @@
 version: '3.7'
 
 services:
-  app-service-mqtt-export:
+  app-mqtt-export:
     image: ${APP_SVC_REPOSITORY}/app-service-configurable${ARCH}:${APP_SERVICE_CONFIG_VERSION}
     ports:
       - 127.0.0.1:59703:59703/tcp
@@ -32,7 +32,7 @@ services:
       WRITABLE_LOGLEVEL: INFO # allows scripts to find and change with sed
     depends_on:
       - consul
-      - data
+      - core-data
     read_only: true
     restart: always
     networks:

--- a/compose-builder/add-asc-sample.yml
+++ b/compose-builder/add-asc-sample.yml
@@ -16,7 +16,7 @@
 version: '3.7'
 
 services:
-  app-service-sample:
+  app-sample:
     image: ${APP_SVC_REPOSITORY}/app-service-configurable${ARCH}:${APP_SERVICE_CONFIG_VERSION}
     ports:
       - 127.0.0.1:59700:59700/tcp
@@ -32,7 +32,7 @@ services:
       CLIENTS_SUPPORT-NOTIFICATIONS_HOST: edgex-support-notifications
     depends_on:
       - consul
-      - data
+      - core-data
     read_only: true
     restart: always
     networks:

--- a/compose-builder/add-device-bacnet.yml
+++ b/compose-builder/add-device-bacnet.yml
@@ -30,8 +30,8 @@ services:
       SERVICE_HOST: edgex-device-bacnet
     depends_on:
       - consul
-      - data
-      - metadata
+      - core-data
+      - core-metadata
     security_opt: 
       - no-new-privileges:true
     read_only: true

--- a/compose-builder/add-device-coap.yml
+++ b/compose-builder/add-device-coap.yml
@@ -32,8 +32,8 @@ services:
       SERVICE_HOST: edgex-device-coap
     depends_on:
       - consul
-      - data
-      - metadata
+      - core-data
+      - core-metadata
     security_opt: 
       - no-new-privileges:true
     user: "${EDGEX_USER}:${EDGEX_GROUP}"

--- a/compose-builder/add-device-gpio.yml
+++ b/compose-builder/add-device-gpio.yml
@@ -32,8 +32,8 @@ services:
       SERVICE_HOST: edgex-device-gpio
     depends_on:
       - consul
-      - data
-      - metadata
+      - core-data
+      - core-metadata
     security_opt: 
       - no-new-privileges:true
     user: "${EDGEX_USER}:${EDGEX_GROUP}"

--- a/compose-builder/add-device-modbus.yml
+++ b/compose-builder/add-device-modbus.yml
@@ -30,8 +30,8 @@ services:
       SERVICE_HOST: edgex-device-modbus
     depends_on:
       - consul
-      - data
-      - metadata
+      - core-data
+      - core-metadata
     security_opt: 
       - no-new-privileges:true
     read_only: true

--- a/compose-builder/add-device-mqtt.yml
+++ b/compose-builder/add-device-mqtt.yml
@@ -33,8 +33,8 @@ services:
       MQTTBROKERINFO_HOST: edgex-mqtt-broker
     depends_on:
       - consul
-      - data
-      - metadata
+      - core-data
+      - core-metadata
       - mqtt-broker
     security_opt: 
       - no-new-privileges:true

--- a/compose-builder/add-device-onvif-camera.yml
+++ b/compose-builder/add-device-onvif-camera.yml
@@ -33,8 +33,8 @@ services:
       SERVICE_HOST: edgex-device-onvif-camera
     depends_on:
       - consul
-      - data
-      - metadata
+      - core-data
+      - core-metadata
     security_opt:
       - no-new-privileges:true
     user: "${EDGEX_USER}:${EDGEX_GROUP}"

--- a/compose-builder/add-device-rest.yml
+++ b/compose-builder/add-device-rest.yml
@@ -32,8 +32,8 @@ services:
       SERVICE_HOST: edgex-device-rest
     depends_on:
       - consul
-      - data
-      - metadata
+      - core-data
+      - core-metadata
     security_opt: 
       - no-new-privileges:true
     user: "${EDGEX_USER}:${EDGEX_GROUP}"

--- a/compose-builder/add-device-rfid-llrp.yml
+++ b/compose-builder/add-device-rfid-llrp.yml
@@ -32,8 +32,8 @@ services:
       SERVICE_HOST: edgex-device-rfid-llrp
     depends_on:
       - consul
-      - data
-      - metadata
+      - core-data
+      - core-metadata
     security_opt: 
       - no-new-privileges:true
     user: "${EDGEX_USER}:${EDGEX_GROUP}"

--- a/compose-builder/add-device-snmp.yml
+++ b/compose-builder/add-device-snmp.yml
@@ -30,8 +30,8 @@ services:
       SERVICE_HOST: edgex-device-snmp
     depends_on:
       - consul
-      - data
-      - metadata
+      - core-data
+      - core-metadata
     security_opt: 
       - no-new-privileges:true
     read_only: true

--- a/compose-builder/add-device-usb-camera.yml
+++ b/compose-builder/add-device-usb-camera.yml
@@ -34,8 +34,8 @@ services:
       SERVICE_HOST: edgex-device-usb-camera
     depends_on:
       - consul
-      - data
-      - metadata
+      - core-data
+      - core-metadata
     security_opt:
       - no-new-privileges:true
     user: root:root

--- a/compose-builder/add-device-virtual.yml
+++ b/compose-builder/add-device-virtual.yml
@@ -32,8 +32,8 @@ services:
       SERVICE_HOST: edgex-device-virtual
     depends_on:
       - consul
-      - data
-      - metadata
+      - core-data
+      - core-metadata
     security_opt: 
       - no-new-privileges:true
     user: "${EDGEX_USER}:${EDGEX_GROUP}"

--- a/compose-builder/add-mqtt-messagebus.yml
+++ b/compose-builder/add-mqtt-messagebus.yml
@@ -16,7 +16,7 @@
 version: '3.7'
 
 services:
-  common-config:
+  core-common-config-bootstrapper:
     environment:
       ALL_SERVICES_MESSAGEBUS_TYPE: mqtt
       ALL_SERVICES_MESSAGEBUS_PROTOCOL: tcp
@@ -24,7 +24,7 @@ services:
       ALL_SERVICES_MESSAGEBUS_PORT: "1883"
       ALL_SERVICES_MESSAGEBUS_AUTHMODE: none
 
-  rulesengine:
+  rules-engine:
     environment:
       CONNECTION__EDGEX__MQTTMSGBUS__PORT: 1883
       CONNECTION__EDGEX__MQTTMSGBUS__PROTOCOL: tcp

--- a/compose-builder/add-nats-messagebus.yml
+++ b/compose-builder/add-nats-messagebus.yml
@@ -36,7 +36,7 @@ services:
     volumes:
       - nats-data:/tmp/nats
 
-  common-config:
+  core-common-config-bootstrapper:
     environment:
       ALL_SERVICES_MESSAGEBUS_TYPE: nats-jetstream
       ALL_SERVICES_MESSAGEBUS_PROTOCOL: tcp
@@ -44,7 +44,7 @@ services:
       ALL_SERVICES_MESSAGEBUS_PORT: "4222"
       ALL_SERVICES_MESSAGEBUS_AUTHMODE: none
 
-  rulesengine:
+  rules-engine:
     environment:
       CONNECTION__EDGEX__NATSMSGBUS__PORT: 4222
       CONNECTION__EDGEX__NATSMSGBUS__PROTOCOL: tcp

--- a/compose-builder/add-secure-mqtt-broker.yml
+++ b/compose-builder/add-secure-mqtt-broker.yml
@@ -35,6 +35,6 @@ services:
     - /tmp/edgex/secrets/security-bootstrapper-messagebus:/tmp/edgex/secrets/security-bootstrapper-messagebus:ro,z
     depends_on:
       - security-bootstrapper
-      - secretstore-setup 
+      - security-secretstore-setup 
     # root privilege required for bootstrapper's process
     user: root:root

--- a/compose-builder/add-secure-mqtt-messagebus.yml
+++ b/compose-builder/add-secure-mqtt-messagebus.yml
@@ -20,19 +20,19 @@ volumes:
   kuiper-connections:
 
 services:
-  secretstore-setup:
+  security-secretstore-setup:
     environment:
       SECUREMESSAGEBUS_TYPE: mqtt
     volumes:
       - kuiper-sources:/tmp/kuiper
       - kuiper-connections:/tmp/kuiper-connections
 
-  common-config:
+  core-common-config-bootstrapper:
     environment:
       ALL_SERVICES_MESSAGEBUS_AUTHMODE: usernamepassword
       ALL_SERVICES_MESSAGEBUS_SECRETNAME: message-bus
   
-  rulesengine:
+  rules-engine:
     entrypoint: [ "/edgex-init/kuiper_wait_install.sh" ]
     env_file:
       - common-sec-stage-gate.env
@@ -42,6 +42,6 @@ services:
       - edgex-init:/edgex-init:ro
     depends_on:
       - security-bootstrapper
-      - secretstore-setup
+      - security-secretstore-setup
       - database
   

--- a/compose-builder/add-secure-redis-messagebus.yml
+++ b/compose-builder/add-secure-redis-messagebus.yml
@@ -20,14 +20,14 @@ volumes:
   kuiper-connections:
 
 services:
-  secretstore-setup:
+  security-secretstore-setup:
     volumes:
       - kuiper-sources:/tmp/kuiper
       - kuiper-connections:/tmp/kuiper-connections
     environment:
       SECUREMESSAGEBUS_TYPE: redis
 
-  rulesengine:
+  rules-engine:
     entrypoint: [ "/edgex-init/kuiper_wait_install.sh" ]
     env_file:
       - common-sec-stage-gate.env
@@ -37,5 +37,5 @@ services:
       - edgex-init:/edgex-init:ro
     depends_on:
       - security-bootstrapper
-      - secretstore-setup
+      - security-secretstore-setup
       - database

--- a/compose-builder/add-security.yml
+++ b/compose-builder/add-security.yml
@@ -62,9 +62,9 @@ services:
       - /tmp/edgex/secrets/security-bootstrapper-redis:/tmp/edgex/secrets/security-bootstrapper-redis:ro,z
     depends_on:
       - security-bootstrapper
-      - secretstore-setup
+      - security-secretstore-setup
 
-  secretstore-setup:
+  security-secretstore-setup:
     image: ${CORE_EDGEX_REPOSITORY}/security-secretstore-setup${ARCH}:${CORE_EDGEX_VERSION}
     user: "root:root" # must run as root
     container_name: edgex-security-secretstore-setup
@@ -177,7 +177,7 @@ services:
       - nginx-templates:/etc/nginx/templates
       - nginx-tls:/etc/ssl/nginx
     depends_on:
-      - secretstore-setup
+      - security-secretstore-setup
     security_opt: 
       - no-new-privileges:true
     tmpfs:
@@ -186,7 +186,7 @@ services:
       - /var/log/nginx
       - /var/run
 
-  proxy-setup:
+  security-proxy-setup:
     image: ${CORE_EDGEX_REPOSITORY}/security-proxy-setup${ARCH}:${CORE_EDGEX_VERSION}
     user: "root:root"
     container_name: edgex-security-proxy-setup
@@ -217,11 +217,11 @@ services:
       - consul-acl-token:/tmp/edgex/secrets/consul-acl-token:ro
     depends_on:
       - security-bootstrapper
-      - secretstore-setup
+      - security-secretstore-setup
     security_opt:
       - no-new-privileges:true
 
-  proxy-auth:
+  security-proxy-auth:
     image: ${CORE_EDGEX_REPOSITORY}/security-proxy-auth${ARCH}:${CORE_EDGEX_VERSION}
     container_name: edgex-proxy-auth
     hostname: edgex-proxy-auth
@@ -246,13 +246,13 @@ services:
       - edgex-init:/edgex-init:ro
       - /tmp/edgex/secrets/security-proxy-auth:/tmp/edgex/secrets/security-proxy-auth:ro,z
     depends_on:
-      - secretstore-setup
+      - security-secretstore-setup
     security_opt: 
       - no-new-privileges:true
 
 # end of containers for reverse proxy
 
-  notifications:
+  support-notifications:
     env_file:
       - common-security.env
       - common-sec-stage-gate.env
@@ -263,10 +263,10 @@ services:
       - /tmp/edgex/secrets/support-notifications:/tmp/edgex/secrets/support-notifications:ro,z
     depends_on:
       - security-bootstrapper
-      - secretstore-setup
+      - security-secretstore-setup
       - database
 
-  metadata:
+  core-metadata:
     env_file:
       - common-security.env
       - common-sec-stage-gate.env
@@ -277,10 +277,10 @@ services:
       - /tmp/edgex/secrets/core-metadata:/tmp/edgex/secrets/core-metadata:ro,z
     depends_on:
       - security-bootstrapper
-      - secretstore-setup
+      - security-secretstore-setup
       - database
 
-  data:
+  core-data:
     env_file:
       - common-security.env
       - common-sec-stage-gate.env
@@ -291,10 +291,10 @@ services:
       - /tmp/edgex/secrets/core-data:/tmp/edgex/secrets/core-data:ro,z
     depends_on:
       - security-bootstrapper
-      - secretstore-setup
+      - security-secretstore-setup
       - database
 
-  command:
+  core-command:
     env_file:
       - common-security.env
       - common-sec-stage-gate.env
@@ -305,10 +305,10 @@ services:
       - /tmp/edgex/secrets/core-command:/tmp/edgex/secrets/core-command:ro,z
     depends_on:
       - security-bootstrapper
-      - secretstore-setup
+      - security-secretstore-setup
       - database
 
-  common-config:
+  core-common-config-bootstrapper:
     env_file:
       - common-security.env
       - common-sec-stage-gate.env
@@ -319,9 +319,9 @@ services:
       - /tmp/edgex/secrets/core-common-config-bootstrapper:/tmp/edgex/secrets/core-common-config-bootstrapper:ro,z
     depends_on:
       - security-bootstrapper
-      - secretstore-setup
+      - security-secretstore-setup
 
-  scheduler:
+  support-scheduler:
     env_file:
       - common-security.env
       - common-sec-stage-gate.env
@@ -332,12 +332,12 @@ services:
       - /tmp/edgex/secrets/support-scheduler:/tmp/edgex/secrets/support-scheduler:ro,z
     depends_on:
       - security-bootstrapper
-      - secretstore-setup
+      - security-secretstore-setup
       - database
 
   # this is to make sure the service is started after security-bootstrapper process is done
   # because it needs to await Consul roles to be created
-  app-service-rules:
+  app-rules-engine:
     entrypoint: ["/edgex-init/ready_to_run_wait_install.sh"]
     command: "/app-service-configurable ${DEFAULT_EDGEX_RUN_CMD_PARMS}"
     env_file:

--- a/compose-builder/add-service-secure-template.yml
+++ b/compose-builder/add-service-secure-template.yml
@@ -16,7 +16,7 @@
 version: '3.7'
 
 services:
-  secretstore-setup:
+  security-secretstore-setup:
     environment:
       ADD_SECRETSTORE_TOKENS: ${TOKEN_LIST}
       ADD_KNOWN_SECRETS: ${KNOWN_SECRETS_LIST}
@@ -25,7 +25,7 @@ services:
     environment:
       ADD_REGISTRY_ACL_ROLES: ${TOKEN_LIST}
 
-  proxy-setup:
+  security-proxy-setup:
     environment:
       ADD_PROXY_ROUTE: ${EXTRA_PROXY_ROUTE_LIST}
 

--- a/compose-builder/add-taf-app-services-secure.yml
+++ b/compose-builder/add-taf-app-services-secure.yml
@@ -16,7 +16,7 @@
 version: '3.7'
 
 services:
-  secretstore-setup:
+  security-secretstore-setup:
     environment:
       ADD_SECRETSTORE_TOKENS: ${TOKEN_LIST}
       ADD_KNOWN_SECRETS: ${KNOWN_SECRETS_LIST}
@@ -25,7 +25,7 @@ services:
     environment:
       ADD_REGISTRY_ACL_ROLES: ${TOKEN_LIST}
 
-  app-service-functional-tests:
+  app-functional-tests:
     entrypoint: ["/edgex-init/ready_to_run_wait_install.sh"]
     command: "/app-service-configurable ${DEFAULT_EDGEX_RUN_CMD_PARMS}"
     env_file:
@@ -37,7 +37,7 @@ services:
     depends_on:
       - security-bootstrapper
 
-  scalability-test-mqtt-export:
+  app-scalability-test-mqtt-export:
     entrypoint: ["/edgex-init/ready_to_run_wait_install.sh"]
     command: "/app-service-configurable ${DEFAULT_EDGEX_RUN_CMD_PARMS}"
     env_file:

--- a/compose-builder/add-taf-app-services.yml
+++ b/compose-builder/add-taf-app-services.yml
@@ -16,20 +16,20 @@
 version: '3.7'
 
 services:
-  app-service-functional-tests:
+  app-functional-tests:
     image: ${APP_SVC_REPOSITORY}/app-service-configurable${ARCH}:${APP_SERVICE_CONFIG_VERSION}
     ports:
       - 59705:59705/tcp
-    container_name: app-functional-tests
-    hostname: app-functional-tests
+    container_name: edgex-app-functional-tests
+    hostname: edgex-app-functional-tests
     env_file:
       - common-non-security.env
     environment:
       EDGEX_PROFILE: functional-tests
-      SERVICE_HOST: app-functional-tests
+      SERVICE_HOST: edgex-app-functional-tests
     depends_on:
       - consul
-      - data
+      - core-data
     read_only: true
     networks:
       - edgex-network
@@ -37,19 +37,19 @@ services:
       - no-new-privileges:true
     user: "${EDGEX_USER}:${EDGEX_GROUP}"
 
-  scalability-test-mqtt-export:
+  app-scalability-test-mqtt-export:
     image: ${APP_SVC_REPOSITORY}/app-service-configurable${ARCH}:${APP_SERVICE_CONFIG_VERSION}
     ports:
       - "59710:59703" #Exposing as different port to avoid conflict with other MQTT export instance
-    container_name: edgex-scalability-test-mqtt-export
-    hostname: edgex-scalability-test-mqtt-export
+    container_name: edgex-app-scalability-test-mqtt-export
+    hostname: edgex-app-scalability-test-mqtt-export
     env_file:
       - common-non-security.env
     environment:
       EDGEX_PROFILE: mqtt-export
       EDGEX_SERVICE_KEY: app-scalability-test-mqtt-export
-      SERVICE_HOST: edgex-scalability-test-mqtt-export
-      WRITABLE_PIPELINE_FUNCTIONS_MQTTEXPORT_PARAMETERS_CLIENTID: scalability-test-mqtt-export
+      SERVICE_HOST: edgex-app-scalability-test-mqtt-export
+      WRITABLE_PIPELINE_FUNCTIONS_MQTTEXPORT_PARAMETERS_CLIENTID: app-scalability-test-mqtt-export
       WRITABLE_PIPELINE_FUNCTIONS_MQTTEXPORT_PARAMETERS_BROKERADDRESS: MQTT_BROKER_ADDRESS_PLACE_HOLDER
       WRITABLE_PIPELINE_FUNCTIONS_MQTTEXPORT_PARAMETERS_TOPIC: edgex-events
 
@@ -57,7 +57,7 @@ services:
       WRITABLE_LOGLEVEL: DEBUG
     depends_on:
       - consul
-      - data
+      - core-data
     read_only: true
     networks:
       - edgex-network

--- a/compose-builder/docker-compose-base.yml
+++ b/compose-builder/docker-compose-base.yml
@@ -65,7 +65,7 @@ services:
     security_opt: 
       - no-new-privileges:true
 
-  notifications:
+  support-notifications:
     image: ${CORE_EDGEX_REPOSITORY}/support-notifications${ARCH}:${CORE_EDGEX_VERSION}
     user: "${EDGEX_USER}:${EDGEX_GROUP}"
     ports:
@@ -86,7 +86,7 @@ services:
     security_opt: 
       - no-new-privileges:true
 
-  metadata:
+  core-metadata:
     image: ${CORE_EDGEX_REPOSITORY}/core-metadata${ARCH}:${CORE_EDGEX_VERSION}
     user: "${EDGEX_USER}:${EDGEX_GROUP}"
     ports:
@@ -107,7 +107,7 @@ services:
     security_opt:
       - no-new-privileges:true
 
-  data:
+  core-data:
     image: ${CORE_EDGEX_REPOSITORY}/core-data${ARCH}:${CORE_EDGEX_VERSION}
     user: "${EDGEX_USER}:${EDGEX_GROUP}"
     ports:
@@ -125,11 +125,11 @@ services:
     depends_on:
       - consul
       - database
-      - metadata
+      - core-metadata
     security_opt: 
       - no-new-privileges:true
 
-  command:
+  core-command:
     image: ${CORE_EDGEX_REPOSITORY}/core-command${ARCH}:${CORE_EDGEX_VERSION}
     user: "${EDGEX_USER}:${EDGEX_GROUP}"
     ports:
@@ -148,11 +148,11 @@ services:
     depends_on:
       - consul
       - database
-      - metadata
+      - core-metadata
     security_opt: 
       - no-new-privileges:true
 
-  common-config:
+  core-common-config-bootstrapper:
     image: ${CORE_EDGEX_REPOSITORY}/core-common-config-bootstrapper${ARCH}:${CORE_EDGEX_VERSION}
     user: "${EDGEX_USER}:${EDGEX_GROUP}"
     container_name: edgex-core-common-config-bootstrapper
@@ -173,7 +173,7 @@ services:
     security_opt:
       - no-new-privileges:true
 
-  scheduler:
+  support-scheduler:
     image: ${CORE_EDGEX_REPOSITORY}/support-scheduler${ARCH}:${CORE_EDGEX_VERSION}
     user: "${EDGEX_USER}:${EDGEX_GROUP}"
     ports:
@@ -196,7 +196,7 @@ services:
     security_opt: 
       - no-new-privileges:true
 
-  app-service-rules:
+  app-rules-engine:
     image: ${APP_SVC_REPOSITORY}/app-service-configurable${ARCH}:${APP_SERVICE_CONFIG_VERSION}
     user: "${EDGEX_USER}:${EDGEX_GROUP}"
     ports:
@@ -214,11 +214,11 @@ services:
       SERVICE_HOST: edgex-app-rules-engine
     depends_on:
       - consul
-      - data
+      - core-data
     security_opt: 
       - no-new-privileges:true
 
-  rulesengine:
+  rules-engine:
     image: lfedge/ekuiper:${KUIPER_VERSION}
     user: "kuiper:kuiper"
     ports:

--- a/compose-builder/gen_secure_compose_ext.sh
+++ b/compose-builder/gen_secure_compose_ext.sh
@@ -58,7 +58,7 @@ fi
 
 # app-service-mqtt-export has non-empty env section
 if [ "$IS_MQTT_BUS" = "1" ]; then
-  if [ "$service_name" = "app-service-mqtt-export" ] || [ "$service_name" = "scalability-test-mqtt-export" ]; then
+  if [ "$service_name" = "app-service-mqtt-export" ] || [ "$service_name" = "app-scalability-test-mqtt-export" ]; then
     ENV_SECTION='environment:\r      WRITABLE_INSECURESECRETS_MQTT_SECRETS_USERNAME: USERNAME_PLACEH_OLDER\r      WRITABLE_INSECURESECRETS_MQTT_SECRETS_PASSWORD: PASSWORD_PLACE_HOLDER'
     sed -i 's/##${ENVIRONMENT_SECTION}/'"$ENV_SECTION"'/g' "$SERVICE_EXT_COMPOSE_PATH"
   fi

--- a/docker-compose-arm64.yml
+++ b/docker-compose-arm64.yml
@@ -26,7 +26,7 @@
 #
 name: edgex
 services:
-  app-service-rules:
+  app-rules-engine:
     command:
     - /app-service-configurable
     - -cp=consul.http://edgex-core-consul:8500
@@ -35,7 +35,7 @@ services:
     depends_on:
       consul:
         condition: service_started
-      data:
+      core-data:
         condition: service_started
       security-bootstrapper:
         condition: service_started
@@ -83,128 +83,6 @@ services:
     - type: bind
       source: /tmp/edgex/secrets/app-rules-engine
       target: /tmp/edgex/secrets/app-rules-engine
-      read_only: true
-      bind:
-        selinux: z
-        create_host_path: true
-  command:
-    command:
-    - /core-command
-    - -cp=consul.http://edgex-core-consul:8500
-    - --registry
-    container_name: edgex-core-command
-    depends_on:
-      consul:
-        condition: service_started
-      database:
-        condition: service_started
-      metadata:
-        condition: service_started
-      secretstore-setup:
-        condition: service_started
-      security-bootstrapper:
-        condition: service_started
-    entrypoint:
-    - /edgex-init/ready_to_run_wait_install.sh
-    environment:
-      EDGEX_SECURITY_SECRET_STORE: "true"
-      EXTERNALMQTT_URL: tcp://edgex-mqtt-broker:1883
-      PROXY_SETUP_HOST: edgex-security-proxy-setup
-      SECRETSTORE_HOST: edgex-vault
-      SERVICE_HOST: edgex-core-command
-      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
-      STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: "6379"
-      STAGEGATE_DATABASE_READYPORT: "6379"
-      STAGEGATE_READY_TORUNPORT: "54329"
-      STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: "8500"
-      STAGEGATE_REGISTRY_READYPORT: "54324"
-      STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
-      STAGEGATE_WAITFOR_TIMEOUT: 60s
-    hostname: edgex-core-command
-    image: nexus3.edgexfoundry.org:10004/core-command-arm64:latest
-    networks:
-      edgex-network: null
-    ports:
-    - mode: ingress
-      host_ip: 127.0.0.1
-      target: 59882
-      published: "59882"
-      protocol: tcp
-    read_only: true
-    restart: always
-    security_opt:
-    - no-new-privileges:true
-    user: 2002:2001
-    volumes:
-    - type: volume
-      source: edgex-init
-      target: /edgex-init
-      read_only: true
-      volume: {}
-    - type: bind
-      source: /tmp/edgex/secrets/core-command
-      target: /tmp/edgex/secrets/core-command
-      read_only: true
-      bind:
-        selinux: z
-        create_host_path: true
-  common-config:
-    command:
-    - /entrypoint.sh
-    - /core-common-config-bootstrapper
-    - -cp=consul.http://edgex-core-consul:8500
-    container_name: edgex-core-common-config-bootstrapper
-    depends_on:
-      consul:
-        condition: service_started
-      secretstore-setup:
-        condition: service_started
-      security-bootstrapper:
-        condition: service_started
-    entrypoint:
-    - /edgex-init/ready_to_run_wait_install.sh
-    environment:
-      ALL_SERVICES_DATABASE_HOST: edgex-redis
-      ALL_SERVICES_MESSAGEBUS_HOST: edgex-redis
-      ALL_SERVICES_REGISTRY_HOST: edgex-core-consul
-      APP_SERVICES_CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
-      DEVICE_SERVICES_CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
-      EDGEX_SECURITY_SECRET_STORE: "true"
-      PROXY_SETUP_HOST: edgex-security-proxy-setup
-      SECRETSTORE_HOST: edgex-vault
-      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
-      STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: "6379"
-      STAGEGATE_DATABASE_READYPORT: "6379"
-      STAGEGATE_READY_TORUNPORT: "54329"
-      STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: "8500"
-      STAGEGATE_REGISTRY_READYPORT: "54324"
-      STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
-      STAGEGATE_WAITFOR_TIMEOUT: 60s
-    hostname: edgex-core-common-config-bootstrapper
-    image: nexus3.edgexfoundry.org:10004/core-common-config-bootstrapper-arm64:latest
-    networks:
-      edgex-network: null
-    read_only: true
-    security_opt:
-    - no-new-privileges:true
-    user: 2002:2001
-    volumes:
-    - type: volume
-      source: edgex-init
-      target: /edgex-init
-      read_only: true
-      volume: {}
-    - type: bind
-      source: /tmp/edgex/secrets/core-common-config-bootstrapper
-      target: /tmp/edgex/secrets/core-common-config-bootstrapper
       read_only: true
       bind:
         selinux: z
@@ -287,7 +165,129 @@ services:
       bind:
         selinux: z
         create_host_path: true
-  data:
+  core-command:
+    command:
+    - /core-command
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
+    container_name: edgex-core-command
+    depends_on:
+      consul:
+        condition: service_started
+      core-metadata:
+        condition: service_started
+      database:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
+      security-secretstore-setup:
+        condition: service_started
+    entrypoint:
+    - /edgex-init/ready_to_run_wait_install.sh
+    environment:
+      EDGEX_SECURITY_SECRET_STORE: "true"
+      EXTERNALMQTT_URL: tcp://edgex-mqtt-broker:1883
+      PROXY_SETUP_HOST: edgex-security-proxy-setup
+      SECRETSTORE_HOST: edgex-vault
+      SERVICE_HOST: edgex-core-command
+      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
+      STAGEGATE_DATABASE_HOST: edgex-redis
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
+      STAGEGATE_READY_TORUNPORT: "54329"
+      STAGEGATE_REGISTRY_HOST: edgex-core-consul
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
+      STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
+      STAGEGATE_WAITFOR_TIMEOUT: 60s
+    hostname: edgex-core-command
+    image: nexus3.edgexfoundry.org:10004/core-command-arm64:latest
+    networks:
+      edgex-network: null
+    ports:
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59882
+      published: "59882"
+      protocol: tcp
+    read_only: true
+    restart: always
+    security_opt:
+    - no-new-privileges:true
+    user: 2002:2001
+    volumes:
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/core-command
+      target: /tmp/edgex/secrets/core-command
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
+  core-common-config-bootstrapper:
+    command:
+    - /entrypoint.sh
+    - /core-common-config-bootstrapper
+    - -cp=consul.http://edgex-core-consul:8500
+    container_name: edgex-core-common-config-bootstrapper
+    depends_on:
+      consul:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
+      security-secretstore-setup:
+        condition: service_started
+    entrypoint:
+    - /edgex-init/ready_to_run_wait_install.sh
+    environment:
+      ALL_SERVICES_DATABASE_HOST: edgex-redis
+      ALL_SERVICES_MESSAGEBUS_HOST: edgex-redis
+      ALL_SERVICES_REGISTRY_HOST: edgex-core-consul
+      APP_SERVICES_CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
+      DEVICE_SERVICES_CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
+      EDGEX_SECURITY_SECRET_STORE: "true"
+      PROXY_SETUP_HOST: edgex-security-proxy-setup
+      SECRETSTORE_HOST: edgex-vault
+      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
+      STAGEGATE_DATABASE_HOST: edgex-redis
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
+      STAGEGATE_READY_TORUNPORT: "54329"
+      STAGEGATE_REGISTRY_HOST: edgex-core-consul
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
+      STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
+      STAGEGATE_WAITFOR_TIMEOUT: 60s
+    hostname: edgex-core-common-config-bootstrapper
+    image: nexus3.edgexfoundry.org:10004/core-common-config-bootstrapper-arm64:latest
+    networks:
+      edgex-network: null
+    read_only: true
+    security_opt:
+    - no-new-privileges:true
+    user: 2002:2001
+    volumes:
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/core-common-config-bootstrapper
+      target: /tmp/edgex/secrets/core-common-config-bootstrapper
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
+  core-data:
     command:
     - /core-data
     - -cp=consul.http://edgex-core-consul:8500
@@ -296,13 +296,13 @@ services:
     depends_on:
       consul:
         condition: service_started
+      core-metadata:
+        condition: service_started
       database:
         condition: service_started
-      metadata:
-        condition: service_started
-      secretstore-setup:
-        condition: service_started
       security-bootstrapper:
+        condition: service_started
+      security-secretstore-setup:
         condition: service_started
     entrypoint:
     - /edgex-init/ready_to_run_wait_install.sh
@@ -351,12 +351,74 @@ services:
       bind:
         selinux: z
         create_host_path: true
+  core-metadata:
+    command:
+    - /core-metadata
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
+    container_name: edgex-core-metadata
+    depends_on:
+      consul:
+        condition: service_started
+      database:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
+      security-secretstore-setup:
+        condition: service_started
+    entrypoint:
+    - /edgex-init/ready_to_run_wait_install.sh
+    environment:
+      EDGEX_SECURITY_SECRET_STORE: "true"
+      PROXY_SETUP_HOST: edgex-security-proxy-setup
+      SECRETSTORE_HOST: edgex-vault
+      SERVICE_HOST: edgex-core-metadata
+      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
+      STAGEGATE_DATABASE_HOST: edgex-redis
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
+      STAGEGATE_READY_TORUNPORT: "54329"
+      STAGEGATE_REGISTRY_HOST: edgex-core-consul
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
+      STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
+      STAGEGATE_WAITFOR_TIMEOUT: 60s
+    hostname: edgex-core-metadata
+    image: nexus3.edgexfoundry.org:10004/core-metadata-arm64:latest
+    networks:
+      edgex-network: null
+    ports:
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59881
+      published: "59881"
+      protocol: tcp
+    read_only: true
+    restart: always
+    security_opt:
+    - no-new-privileges:true
+    user: 2002:2001
+    volumes:
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/core-metadata
+      target: /tmp/edgex/secrets/core-metadata
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   database:
     container_name: edgex-redis
     depends_on:
-      secretstore-setup:
-        condition: service_started
       security-bootstrapper:
+        condition: service_started
+      security-secretstore-setup:
         condition: service_started
     entrypoint:
     - /edgex-init/redis_wait_install.sh
@@ -425,9 +487,9 @@ services:
     depends_on:
       consul:
         condition: service_started
-      data:
+      core-data:
         condition: service_started
-      metadata:
+      core-metadata:
         condition: service_started
       security-bootstrapper:
         condition: service_started
@@ -487,9 +549,9 @@ services:
     depends_on:
       consul:
         condition: service_started
-      data:
+      core-data:
         condition: service_started
-      metadata:
+      core-metadata:
         condition: service_started
       security-bootstrapper:
         condition: service_started
@@ -540,68 +602,6 @@ services:
       bind:
         selinux: z
         create_host_path: true
-  metadata:
-    command:
-    - /core-metadata
-    - -cp=consul.http://edgex-core-consul:8500
-    - --registry
-    container_name: edgex-core-metadata
-    depends_on:
-      consul:
-        condition: service_started
-      database:
-        condition: service_started
-      secretstore-setup:
-        condition: service_started
-      security-bootstrapper:
-        condition: service_started
-    entrypoint:
-    - /edgex-init/ready_to_run_wait_install.sh
-    environment:
-      EDGEX_SECURITY_SECRET_STORE: "true"
-      PROXY_SETUP_HOST: edgex-security-proxy-setup
-      SECRETSTORE_HOST: edgex-vault
-      SERVICE_HOST: edgex-core-metadata
-      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
-      STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: "6379"
-      STAGEGATE_DATABASE_READYPORT: "6379"
-      STAGEGATE_READY_TORUNPORT: "54329"
-      STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: "8500"
-      STAGEGATE_REGISTRY_READYPORT: "54324"
-      STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
-      STAGEGATE_WAITFOR_TIMEOUT: 60s
-    hostname: edgex-core-metadata
-    image: nexus3.edgexfoundry.org:10004/core-metadata-arm64:latest
-    networks:
-      edgex-network: null
-    ports:
-    - mode: ingress
-      host_ip: 127.0.0.1
-      target: 59881
-      published: "59881"
-      protocol: tcp
-    read_only: true
-    restart: always
-    security_opt:
-    - no-new-privileges:true
-    user: 2002:2001
-    volumes:
-    - type: volume
-      source: edgex-init
-      target: /edgex-init
-      read_only: true
-      volume: {}
-    - type: bind
-      source: /tmp/edgex/secrets/core-metadata
-      target: /tmp/edgex/secrets/core-metadata
-      read_only: true
-      bind:
-        selinux: z
-        create_host_path: true
   nginx:
     command:
     - /docker-entrypoint.sh
@@ -610,7 +610,7 @@ services:
     - daemon off;
     container_name: edgex-nginx
     depends_on:
-      secretstore-setup:
+      security-secretstore-setup:
         condition: service_started
     entrypoint:
     - /bin/sh
@@ -663,206 +663,14 @@ services:
       source: nginx-tls
       target: /etc/ssl/nginx
       volume: {}
-  notifications:
-    command:
-    - /support-notifications
-    - -cp=consul.http://edgex-core-consul:8500
-    - --registry
-    container_name: edgex-support-notifications
-    depends_on:
-      consul:
-        condition: service_started
-      database:
-        condition: service_started
-      secretstore-setup:
-        condition: service_started
-      security-bootstrapper:
-        condition: service_started
-    entrypoint:
-    - /edgex-init/ready_to_run_wait_install.sh
-    environment:
-      EDGEX_SECURITY_SECRET_STORE: "true"
-      PROXY_SETUP_HOST: edgex-security-proxy-setup
-      SECRETSTORE_HOST: edgex-vault
-      SERVICE_HOST: edgex-support-notifications
-      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
-      STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: "6379"
-      STAGEGATE_DATABASE_READYPORT: "6379"
-      STAGEGATE_READY_TORUNPORT: "54329"
-      STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: "8500"
-      STAGEGATE_REGISTRY_READYPORT: "54324"
-      STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
-      STAGEGATE_WAITFOR_TIMEOUT: 60s
-    hostname: edgex-support-notifications
-    image: nexus3.edgexfoundry.org:10004/support-notifications-arm64:latest
-    networks:
-      edgex-network: null
-    ports:
-    - mode: ingress
-      host_ip: 127.0.0.1
-      target: 59860
-      published: "59860"
-      protocol: tcp
-    read_only: true
-    restart: always
-    security_opt:
-    - no-new-privileges:true
-    user: 2002:2001
-    volumes:
-    - type: volume
-      source: edgex-init
-      target: /edgex-init
-      read_only: true
-      volume: {}
-    - type: bind
-      source: /tmp/edgex/secrets/support-notifications
-      target: /tmp/edgex/secrets/support-notifications
-      read_only: true
-      bind:
-        selinux: z
-        create_host_path: true
-  proxy-auth:
-    command:
-    - entrypoint.sh
-    - /security-proxy-auth
-    - -cp=consul.http://edgex-core-consul:8500
-    - --registry
-    container_name: edgex-proxy-auth
-    depends_on:
-      secretstore-setup:
-        condition: service_started
-    entrypoint:
-    - /bin/sh
-    - /edgex-init/ready_to_run_wait_install.sh
-    environment:
-      EDGEX_SECURITY_SECRET_STORE: "true"
-      PROXY_SETUP_HOST: edgex-security-proxy-setup
-      SECRETSTORE_HOST: edgex-vault
-      SERVICE_HOST: edgex-proxy-auth
-      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
-      STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: "6379"
-      STAGEGATE_DATABASE_READYPORT: "6379"
-      STAGEGATE_READY_TORUNPORT: "54329"
-      STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: "8500"
-      STAGEGATE_REGISTRY_READYPORT: "54324"
-      STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
-      STAGEGATE_WAITFOR_TIMEOUT: 60s
-    hostname: edgex-proxy-auth
-    image: nexus3.edgexfoundry.org:10004/security-proxy-auth-arm64:latest
-    networks:
-      edgex-network: null
-    ports:
-    - mode: ingress
-      host_ip: 127.0.0.1
-      target: 59842
-      published: "59842"
-      protocol: tcp
-    read_only: true
-    restart: always
-    security_opt:
-    - no-new-privileges:true
-    volumes:
-    - type: volume
-      source: edgex-init
-      target: /edgex-init
-      read_only: true
-      volume: {}
-    - type: bind
-      source: /tmp/edgex/secrets/security-proxy-auth
-      target: /tmp/edgex/secrets/security-proxy-auth
-      read_only: true
-      bind:
-        selinux: z
-        create_host_path: true
-  proxy-setup:
-    container_name: edgex-security-proxy-setup
-    depends_on:
-      secretstore-setup:
-        condition: service_started
-      security-bootstrapper:
-        condition: service_started
-    entrypoint:
-    - /edgex-init/proxy_setup_wait_install.sh
-    environment:
-      ADD_PROXY_ROUTE: ""
-      EDGEX_SECURITY_SECRET_STORE: "true"
-      PROXY_SETUP_HOST: edgex-security-proxy-setup
-      ROUTES_CORE_COMMAND_HOST: edgex-core-command
-      ROUTES_CORE_CONSUL_HOST: edgex-core-consul
-      ROUTES_CORE_DATA_HOST: edgex-core-data
-      ROUTES_CORE_METADATA_HOST: edgex-core-metadata
-      ROUTES_DEVICE_VIRTUAL_HOST: device-virtual
-      ROUTES_RULES_ENGINE_HOST: edgex-kuiper
-      ROUTES_SUPPORT_NOTIFICATIONS_HOST: edgex-support-notifications
-      ROUTES_SUPPORT_SCHEDULER_HOST: edgex-support-scheduler
-      ROUTES_SYS_MGMT_AGENT_HOST: edgex-sys-mgmt-agent
-      SECRETSTORE_HOST: edgex-vault
-      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
-      STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: "6379"
-      STAGEGATE_DATABASE_READYPORT: "6379"
-      STAGEGATE_READY_TORUNPORT: "54329"
-      STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: "8500"
-      STAGEGATE_REGISTRY_READYPORT: "54324"
-      STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
-      STAGEGATE_WAITFOR_TIMEOUT: 60s
-    hostname: edgex-security-proxy-setup
-    image: nexus3.edgexfoundry.org:10004/security-proxy-setup-arm64:latest
-    networks:
-      edgex-network: null
-    read_only: true
-    security_opt:
-    - no-new-privileges:true
-    user: root:root
-    volumes:
-    - type: volume
-      source: edgex-init
-      target: /edgex-init
-      read_only: true
-      volume: {}
-    - type: volume
-      source: vault-config
-      target: /vault/config
-      volume: {}
-    - type: volume
-      source: nginx-templates
-      target: /etc/nginx/templates
-      volume: {}
-    - type: volume
-      source: nginx-tls
-      target: /etc/ssl/nginx
-      volume: {}
-    - type: bind
-      source: /tmp/edgex/secrets/security-proxy-setup
-      target: /tmp/edgex/secrets/security-proxy-setup
-      read_only: true
-      bind:
-        selinux: z
-        create_host_path: true
-    - type: volume
-      source: consul-acl-token
-      target: /tmp/edgex/secrets/consul-acl-token
-      read_only: true
-      volume: {}
-  rulesengine:
+  rules-engine:
     container_name: edgex-kuiper
     depends_on:
       database:
         condition: service_started
-      secretstore-setup:
-        condition: service_started
       security-bootstrapper:
+        condition: service_started
+      security-secretstore-setup:
         condition: service_started
     entrypoint:
     - /edgex-init/kuiper_wait_install.sh
@@ -936,30 +744,12 @@ services:
       source: kuiper-plugins
       target: /kuiper/plugins
       volume: {}
-  scheduler:
-    command:
-    - /support-scheduler
-    - -cp=consul.http://edgex-core-consul:8500
-    - --registry
-    container_name: edgex-support-scheduler
-    depends_on:
-      consul:
-        condition: service_started
-      database:
-        condition: service_started
-      secretstore-setup:
-        condition: service_started
-      security-bootstrapper:
-        condition: service_started
-    entrypoint:
-    - /edgex-init/ready_to_run_wait_install.sh
+  security-bootstrapper:
+    container_name: edgex-security-bootstrapper
     environment:
-      EDGEX_SECURITY_SECRET_STORE: "true"
-      INTERVALACTIONS_SCRUBAGED_HOST: edgex-core-data
-      INTERVALACTIONS_SCRUBPUSHED_HOST: edgex-core-data
+      EDGEX_GROUP: "2001"
+      EDGEX_USER: "2002"
       PROXY_SETUP_HOST: edgex-security-proxy-setup
-      SECRETSTORE_HOST: edgex-vault
-      SERVICE_HOST: edgex-support-scheduler
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
       STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
@@ -972,21 +762,64 @@ services:
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
       STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
-    hostname: edgex-support-scheduler
-    image: nexus3.edgexfoundry.org:10004/support-scheduler-arm64:latest
+    hostname: edgex-security-bootstrapper
+    image: nexus3.edgexfoundry.org:10004/security-bootstrapper-arm64:latest
+    networks:
+      edgex-network: null
+    read_only: true
+    restart: always
+    security_opt:
+    - no-new-privileges:true
+    user: root:root
+    volumes:
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      volume: {}
+  security-proxy-auth:
+    command:
+    - entrypoint.sh
+    - /security-proxy-auth
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
+    container_name: edgex-proxy-auth
+    depends_on:
+      security-secretstore-setup:
+        condition: service_started
+    entrypoint:
+    - /bin/sh
+    - /edgex-init/ready_to_run_wait_install.sh
+    environment:
+      EDGEX_SECURITY_SECRET_STORE: "true"
+      PROXY_SETUP_HOST: edgex-security-proxy-setup
+      SECRETSTORE_HOST: edgex-vault
+      SERVICE_HOST: edgex-proxy-auth
+      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
+      STAGEGATE_DATABASE_HOST: edgex-redis
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
+      STAGEGATE_READY_TORUNPORT: "54329"
+      STAGEGATE_REGISTRY_HOST: edgex-core-consul
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
+      STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
+      STAGEGATE_WAITFOR_TIMEOUT: 60s
+    hostname: edgex-proxy-auth
+    image: nexus3.edgexfoundry.org:10004/security-proxy-auth-arm64:latest
     networks:
       edgex-network: null
     ports:
     - mode: ingress
       host_ip: 127.0.0.1
-      target: 59861
-      published: "59861"
+      target: 59842
+      published: "59842"
       protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
-    user: 2002:2001
     volumes:
     - type: volume
       source: edgex-init
@@ -994,13 +827,86 @@ services:
       read_only: true
       volume: {}
     - type: bind
-      source: /tmp/edgex/secrets/support-scheduler
-      target: /tmp/edgex/secrets/support-scheduler
+      source: /tmp/edgex/secrets/security-proxy-auth
+      target: /tmp/edgex/secrets/security-proxy-auth
       read_only: true
       bind:
         selinux: z
         create_host_path: true
-  secretstore-setup:
+  security-proxy-setup:
+    container_name: edgex-security-proxy-setup
+    depends_on:
+      security-bootstrapper:
+        condition: service_started
+      security-secretstore-setup:
+        condition: service_started
+    entrypoint:
+    - /edgex-init/proxy_setup_wait_install.sh
+    environment:
+      ADD_PROXY_ROUTE: ""
+      EDGEX_SECURITY_SECRET_STORE: "true"
+      PROXY_SETUP_HOST: edgex-security-proxy-setup
+      ROUTES_CORE_COMMAND_HOST: edgex-core-command
+      ROUTES_CORE_CONSUL_HOST: edgex-core-consul
+      ROUTES_CORE_DATA_HOST: edgex-core-data
+      ROUTES_CORE_METADATA_HOST: edgex-core-metadata
+      ROUTES_DEVICE_VIRTUAL_HOST: device-virtual
+      ROUTES_RULES_ENGINE_HOST: edgex-kuiper
+      ROUTES_SUPPORT_NOTIFICATIONS_HOST: edgex-support-notifications
+      ROUTES_SUPPORT_SCHEDULER_HOST: edgex-support-scheduler
+      ROUTES_SYS_MGMT_AGENT_HOST: edgex-sys-mgmt-agent
+      SECRETSTORE_HOST: edgex-vault
+      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
+      STAGEGATE_DATABASE_HOST: edgex-redis
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
+      STAGEGATE_READY_TORUNPORT: "54329"
+      STAGEGATE_REGISTRY_HOST: edgex-core-consul
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
+      STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
+      STAGEGATE_WAITFOR_TIMEOUT: 60s
+    hostname: edgex-security-proxy-setup
+    image: nexus3.edgexfoundry.org:10004/security-proxy-setup-arm64:latest
+    networks:
+      edgex-network: null
+    read_only: true
+    security_opt:
+    - no-new-privileges:true
+    user: root:root
+    volumes:
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      volume: {}
+    - type: volume
+      source: vault-config
+      target: /vault/config
+      volume: {}
+    - type: volume
+      source: nginx-templates
+      target: /etc/nginx/templates
+      volume: {}
+    - type: volume
+      source: nginx-tls
+      target: /etc/ssl/nginx
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/security-proxy-setup
+      target: /tmp/edgex/secrets/security-proxy-setup
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
+    - type: volume
+      source: consul-acl-token
+      target: /tmp/edgex/secrets/consul-acl-token
+      read_only: true
+      volume: {}
+  security-secretstore-setup:
     container_name: edgex-security-secretstore-setup
     depends_on:
       security-bootstrapper:
@@ -1064,12 +970,28 @@ services:
       source: vault-config
       target: /vault/config
       volume: {}
-  security-bootstrapper:
-    container_name: edgex-security-bootstrapper
+  support-notifications:
+    command:
+    - /support-notifications
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
+    container_name: edgex-support-notifications
+    depends_on:
+      consul:
+        condition: service_started
+      database:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
+      security-secretstore-setup:
+        condition: service_started
+    entrypoint:
+    - /edgex-init/ready_to_run_wait_install.sh
     environment:
-      EDGEX_GROUP: "2001"
-      EDGEX_USER: "2002"
+      EDGEX_SECURITY_SECRET_STORE: "true"
       PROXY_SETUP_HOST: edgex-security-proxy-setup
+      SECRETSTORE_HOST: edgex-vault
+      SERVICE_HOST: edgex-support-notifications
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
       STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
@@ -1082,20 +1004,98 @@ services:
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
       STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
-    hostname: edgex-security-bootstrapper
-    image: nexus3.edgexfoundry.org:10004/security-bootstrapper-arm64:latest
+    hostname: edgex-support-notifications
+    image: nexus3.edgexfoundry.org:10004/support-notifications-arm64:latest
     networks:
       edgex-network: null
+    ports:
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59860
+      published: "59860"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
-    user: root:root
+    user: 2002:2001
     volumes:
     - type: volume
       source: edgex-init
       target: /edgex-init
+      read_only: true
       volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/support-notifications
+      target: /tmp/edgex/secrets/support-notifications
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
+  support-scheduler:
+    command:
+    - /support-scheduler
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
+    container_name: edgex-support-scheduler
+    depends_on:
+      consul:
+        condition: service_started
+      database:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
+      security-secretstore-setup:
+        condition: service_started
+    entrypoint:
+    - /edgex-init/ready_to_run_wait_install.sh
+    environment:
+      EDGEX_SECURITY_SECRET_STORE: "true"
+      INTERVALACTIONS_SCRUBAGED_HOST: edgex-core-data
+      INTERVALACTIONS_SCRUBPUSHED_HOST: edgex-core-data
+      PROXY_SETUP_HOST: edgex-security-proxy-setup
+      SECRETSTORE_HOST: edgex-vault
+      SERVICE_HOST: edgex-support-scheduler
+      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
+      STAGEGATE_DATABASE_HOST: edgex-redis
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
+      STAGEGATE_READY_TORUNPORT: "54329"
+      STAGEGATE_REGISTRY_HOST: edgex-core-consul
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
+      STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
+      STAGEGATE_WAITFOR_TIMEOUT: 60s
+    hostname: edgex-support-scheduler
+    image: nexus3.edgexfoundry.org:10004/support-scheduler-arm64:latest
+    networks:
+      edgex-network: null
+    ports:
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59861
+      published: "59861"
+      protocol: tcp
+    read_only: true
+    restart: always
+    security_opt:
+    - no-new-privileges:true
+    user: 2002:2001
+    volumes:
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/support-scheduler
+      target: /tmp/edgex/secrets/support-scheduler
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   ui:
     container_name: edgex-ui-go
     environment:

--- a/docker-compose-no-secty-arm64.yml
+++ b/docker-compose-no-secty-arm64.yml
@@ -26,12 +26,12 @@
 #
 name: edgex
 services:
-  app-service-rules:
+  app-rules-engine:
     container_name: edgex-app-rules-engine
     depends_on:
       consul:
         condition: service_started
-      data:
+      core-data:
         condition: service_started
     environment:
       EDGEX_PROFILE: rules-engine
@@ -49,54 +49,6 @@ services:
       protocol: tcp
     read_only: true
     restart: always
-    security_opt:
-    - no-new-privileges:true
-    user: 2002:2001
-  command:
-    container_name: edgex-core-command
-    depends_on:
-      consul:
-        condition: service_started
-      database:
-        condition: service_started
-      metadata:
-        condition: service_started
-    environment:
-      EDGEX_SECURITY_SECRET_STORE: "false"
-      EXTERNALMQTT_URL: tcp://edgex-mqtt-broker:1883
-      SERVICE_HOST: edgex-core-command
-    hostname: edgex-core-command
-    image: nexus3.edgexfoundry.org:10004/core-command-arm64:latest
-    networks:
-      edgex-network: null
-    ports:
-    - mode: ingress
-      host_ip: 127.0.0.1
-      target: 59882
-      published: "59882"
-      protocol: tcp
-    read_only: true
-    restart: always
-    security_opt:
-    - no-new-privileges:true
-    user: 2002:2001
-  common-config:
-    container_name: edgex-core-common-config-bootstrapper
-    depends_on:
-      consul:
-        condition: service_started
-    environment:
-      ALL_SERVICES_DATABASE_HOST: edgex-redis
-      ALL_SERVICES_MESSAGEBUS_HOST: edgex-redis
-      ALL_SERVICES_REGISTRY_HOST: edgex-core-consul
-      APP_SERVICES_CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
-      DEVICE_SERVICES_CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
-      EDGEX_SECURITY_SECRET_STORE: "false"
-    hostname: edgex-core-common-config-bootstrapper
-    image: nexus3.edgexfoundry.org:10004/core-common-config-bootstrapper-arm64:latest
-    networks:
-      edgex-network: null
-    read_only: true
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -133,14 +85,62 @@ services:
       source: consul-data
       target: /consul/data
       volume: {}
-  data:
+  core-command:
+    container_name: edgex-core-command
+    depends_on:
+      consul:
+        condition: service_started
+      core-metadata:
+        condition: service_started
+      database:
+        condition: service_started
+    environment:
+      EDGEX_SECURITY_SECRET_STORE: "false"
+      EXTERNALMQTT_URL: tcp://edgex-mqtt-broker:1883
+      SERVICE_HOST: edgex-core-command
+    hostname: edgex-core-command
+    image: nexus3.edgexfoundry.org:10004/core-command-arm64:latest
+    networks:
+      edgex-network: null
+    ports:
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59882
+      published: "59882"
+      protocol: tcp
+    read_only: true
+    restart: always
+    security_opt:
+    - no-new-privileges:true
+    user: 2002:2001
+  core-common-config-bootstrapper:
+    container_name: edgex-core-common-config-bootstrapper
+    depends_on:
+      consul:
+        condition: service_started
+    environment:
+      ALL_SERVICES_DATABASE_HOST: edgex-redis
+      ALL_SERVICES_MESSAGEBUS_HOST: edgex-redis
+      ALL_SERVICES_REGISTRY_HOST: edgex-core-consul
+      APP_SERVICES_CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
+      DEVICE_SERVICES_CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
+      EDGEX_SECURITY_SECRET_STORE: "false"
+    hostname: edgex-core-common-config-bootstrapper
+    image: nexus3.edgexfoundry.org:10004/core-common-config-bootstrapper-arm64:latest
+    networks:
+      edgex-network: null
+    read_only: true
+    security_opt:
+    - no-new-privileges:true
+    user: 2002:2001
+  core-data:
     container_name: edgex-core-data
     depends_on:
       consul:
         condition: service_started
-      database:
+      core-metadata:
         condition: service_started
-      metadata:
+      database:
         condition: service_started
     environment:
       EDGEX_SECURITY_SECRET_STORE: "false"
@@ -154,6 +154,31 @@ services:
       host_ip: 127.0.0.1
       target: 59880
       published: "59880"
+      protocol: tcp
+    read_only: true
+    restart: always
+    security_opt:
+    - no-new-privileges:true
+    user: 2002:2001
+  core-metadata:
+    container_name: edgex-core-metadata
+    depends_on:
+      consul:
+        condition: service_started
+      database:
+        condition: service_started
+    environment:
+      EDGEX_SECURITY_SECRET_STORE: "false"
+      SERVICE_HOST: edgex-core-metadata
+    hostname: edgex-core-metadata
+    image: nexus3.edgexfoundry.org:10004/core-metadata-arm64:latest
+    networks:
+      edgex-network: null
+    ports:
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59881
+      published: "59881"
       protocol: tcp
     read_only: true
     restart: always
@@ -187,9 +212,9 @@ services:
     depends_on:
       consul:
         condition: service_started
-      data:
+      core-data:
         condition: service_started
-      metadata:
+      core-metadata:
         condition: service_started
     environment:
       EDGEX_SECURITY_SECRET_STORE: "false"
@@ -214,9 +239,9 @@ services:
     depends_on:
       consul:
         condition: service_started
-      data:
+      core-data:
         condition: service_started
-      metadata:
+      core-metadata:
         condition: service_started
     environment:
       EDGEX_SECURITY_SECRET_STORE: "false"
@@ -236,57 +261,7 @@ services:
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
-  metadata:
-    container_name: edgex-core-metadata
-    depends_on:
-      consul:
-        condition: service_started
-      database:
-        condition: service_started
-    environment:
-      EDGEX_SECURITY_SECRET_STORE: "false"
-      SERVICE_HOST: edgex-core-metadata
-    hostname: edgex-core-metadata
-    image: nexus3.edgexfoundry.org:10004/core-metadata-arm64:latest
-    networks:
-      edgex-network: null
-    ports:
-    - mode: ingress
-      host_ip: 127.0.0.1
-      target: 59881
-      published: "59881"
-      protocol: tcp
-    read_only: true
-    restart: always
-    security_opt:
-    - no-new-privileges:true
-    user: 2002:2001
-  notifications:
-    container_name: edgex-support-notifications
-    depends_on:
-      consul:
-        condition: service_started
-      database:
-        condition: service_started
-    environment:
-      EDGEX_SECURITY_SECRET_STORE: "false"
-      SERVICE_HOST: edgex-support-notifications
-    hostname: edgex-support-notifications
-    image: nexus3.edgexfoundry.org:10004/support-notifications-arm64:latest
-    networks:
-      edgex-network: null
-    ports:
-    - mode: ingress
-      host_ip: 127.0.0.1
-      target: 59860
-      published: "59860"
-      protocol: tcp
-    read_only: true
-    restart: always
-    security_opt:
-    - no-new-privileges:true
-    user: 2002:2001
-  rulesengine:
+  rules-engine:
     container_name: edgex-kuiper
     depends_on:
       database:
@@ -335,7 +310,32 @@ services:
       source: kuiper-plugins
       target: /kuiper/plugins
       volume: {}
-  scheduler:
+  support-notifications:
+    container_name: edgex-support-notifications
+    depends_on:
+      consul:
+        condition: service_started
+      database:
+        condition: service_started
+    environment:
+      EDGEX_SECURITY_SECRET_STORE: "false"
+      SERVICE_HOST: edgex-support-notifications
+    hostname: edgex-support-notifications
+    image: nexus3.edgexfoundry.org:10004/support-notifications-arm64:latest
+    networks:
+      edgex-network: null
+    ports:
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59860
+      published: "59860"
+      protocol: tcp
+    read_only: true
+    restart: always
+    security_opt:
+    - no-new-privileges:true
+    user: 2002:2001
+  support-scheduler:
     container_name: edgex-support-scheduler
     depends_on:
       consul:

--- a/docker-compose-no-secty-with-app-sample-arm64.yml
+++ b/docker-compose-no-secty-with-app-sample-arm64.yml
@@ -26,12 +26,12 @@
 #
 name: edgex
 services:
-  app-service-rules:
+  app-rules-engine:
     container_name: edgex-app-rules-engine
     depends_on:
       consul:
         condition: service_started
-      data:
+      core-data:
         condition: service_started
     environment:
       EDGEX_PROFILE: rules-engine
@@ -52,12 +52,12 @@ services:
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
-  app-service-sample:
+  app-sample:
     container_name: edgex-app-sample
     depends_on:
       consul:
         condition: service_started
-      data:
+      core-data:
         condition: service_started
     environment:
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
@@ -78,54 +78,6 @@ services:
       protocol: tcp
     read_only: true
     restart: always
-    security_opt:
-    - no-new-privileges:true
-    user: 2002:2001
-  command:
-    container_name: edgex-core-command
-    depends_on:
-      consul:
-        condition: service_started
-      database:
-        condition: service_started
-      metadata:
-        condition: service_started
-    environment:
-      EDGEX_SECURITY_SECRET_STORE: "false"
-      EXTERNALMQTT_URL: tcp://edgex-mqtt-broker:1883
-      SERVICE_HOST: edgex-core-command
-    hostname: edgex-core-command
-    image: nexus3.edgexfoundry.org:10004/core-command-arm64:latest
-    networks:
-      edgex-network: null
-    ports:
-    - mode: ingress
-      host_ip: 127.0.0.1
-      target: 59882
-      published: "59882"
-      protocol: tcp
-    read_only: true
-    restart: always
-    security_opt:
-    - no-new-privileges:true
-    user: 2002:2001
-  common-config:
-    container_name: edgex-core-common-config-bootstrapper
-    depends_on:
-      consul:
-        condition: service_started
-    environment:
-      ALL_SERVICES_DATABASE_HOST: edgex-redis
-      ALL_SERVICES_MESSAGEBUS_HOST: edgex-redis
-      ALL_SERVICES_REGISTRY_HOST: edgex-core-consul
-      APP_SERVICES_CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
-      DEVICE_SERVICES_CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
-      EDGEX_SECURITY_SECRET_STORE: "false"
-    hostname: edgex-core-common-config-bootstrapper
-    image: nexus3.edgexfoundry.org:10004/core-common-config-bootstrapper-arm64:latest
-    networks:
-      edgex-network: null
-    read_only: true
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -162,14 +114,62 @@ services:
       source: consul-data
       target: /consul/data
       volume: {}
-  data:
+  core-command:
+    container_name: edgex-core-command
+    depends_on:
+      consul:
+        condition: service_started
+      core-metadata:
+        condition: service_started
+      database:
+        condition: service_started
+    environment:
+      EDGEX_SECURITY_SECRET_STORE: "false"
+      EXTERNALMQTT_URL: tcp://edgex-mqtt-broker:1883
+      SERVICE_HOST: edgex-core-command
+    hostname: edgex-core-command
+    image: nexus3.edgexfoundry.org:10004/core-command-arm64:latest
+    networks:
+      edgex-network: null
+    ports:
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59882
+      published: "59882"
+      protocol: tcp
+    read_only: true
+    restart: always
+    security_opt:
+    - no-new-privileges:true
+    user: 2002:2001
+  core-common-config-bootstrapper:
+    container_name: edgex-core-common-config-bootstrapper
+    depends_on:
+      consul:
+        condition: service_started
+    environment:
+      ALL_SERVICES_DATABASE_HOST: edgex-redis
+      ALL_SERVICES_MESSAGEBUS_HOST: edgex-redis
+      ALL_SERVICES_REGISTRY_HOST: edgex-core-consul
+      APP_SERVICES_CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
+      DEVICE_SERVICES_CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
+      EDGEX_SECURITY_SECRET_STORE: "false"
+    hostname: edgex-core-common-config-bootstrapper
+    image: nexus3.edgexfoundry.org:10004/core-common-config-bootstrapper-arm64:latest
+    networks:
+      edgex-network: null
+    read_only: true
+    security_opt:
+    - no-new-privileges:true
+    user: 2002:2001
+  core-data:
     container_name: edgex-core-data
     depends_on:
       consul:
         condition: service_started
-      database:
+      core-metadata:
         condition: service_started
-      metadata:
+      database:
         condition: service_started
     environment:
       EDGEX_SECURITY_SECRET_STORE: "false"
@@ -183,6 +183,31 @@ services:
       host_ip: 127.0.0.1
       target: 59880
       published: "59880"
+      protocol: tcp
+    read_only: true
+    restart: always
+    security_opt:
+    - no-new-privileges:true
+    user: 2002:2001
+  core-metadata:
+    container_name: edgex-core-metadata
+    depends_on:
+      consul:
+        condition: service_started
+      database:
+        condition: service_started
+    environment:
+      EDGEX_SECURITY_SECRET_STORE: "false"
+      SERVICE_HOST: edgex-core-metadata
+    hostname: edgex-core-metadata
+    image: nexus3.edgexfoundry.org:10004/core-metadata-arm64:latest
+    networks:
+      edgex-network: null
+    ports:
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59881
+      published: "59881"
       protocol: tcp
     read_only: true
     restart: always
@@ -216,9 +241,9 @@ services:
     depends_on:
       consul:
         condition: service_started
-      data:
+      core-data:
         condition: service_started
-      metadata:
+      core-metadata:
         condition: service_started
     environment:
       EDGEX_SECURITY_SECRET_STORE: "false"
@@ -243,9 +268,9 @@ services:
     depends_on:
       consul:
         condition: service_started
-      data:
+      core-data:
         condition: service_started
-      metadata:
+      core-metadata:
         condition: service_started
     environment:
       EDGEX_SECURITY_SECRET_STORE: "false"
@@ -265,57 +290,7 @@ services:
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
-  metadata:
-    container_name: edgex-core-metadata
-    depends_on:
-      consul:
-        condition: service_started
-      database:
-        condition: service_started
-    environment:
-      EDGEX_SECURITY_SECRET_STORE: "false"
-      SERVICE_HOST: edgex-core-metadata
-    hostname: edgex-core-metadata
-    image: nexus3.edgexfoundry.org:10004/core-metadata-arm64:latest
-    networks:
-      edgex-network: null
-    ports:
-    - mode: ingress
-      host_ip: 127.0.0.1
-      target: 59881
-      published: "59881"
-      protocol: tcp
-    read_only: true
-    restart: always
-    security_opt:
-    - no-new-privileges:true
-    user: 2002:2001
-  notifications:
-    container_name: edgex-support-notifications
-    depends_on:
-      consul:
-        condition: service_started
-      database:
-        condition: service_started
-    environment:
-      EDGEX_SECURITY_SECRET_STORE: "false"
-      SERVICE_HOST: edgex-support-notifications
-    hostname: edgex-support-notifications
-    image: nexus3.edgexfoundry.org:10004/support-notifications-arm64:latest
-    networks:
-      edgex-network: null
-    ports:
-    - mode: ingress
-      host_ip: 127.0.0.1
-      target: 59860
-      published: "59860"
-      protocol: tcp
-    read_only: true
-    restart: always
-    security_opt:
-    - no-new-privileges:true
-    user: 2002:2001
-  rulesengine:
+  rules-engine:
     container_name: edgex-kuiper
     depends_on:
       database:
@@ -364,7 +339,32 @@ services:
       source: kuiper-plugins
       target: /kuiper/plugins
       volume: {}
-  scheduler:
+  support-notifications:
+    container_name: edgex-support-notifications
+    depends_on:
+      consul:
+        condition: service_started
+      database:
+        condition: service_started
+    environment:
+      EDGEX_SECURITY_SECRET_STORE: "false"
+      SERVICE_HOST: edgex-support-notifications
+    hostname: edgex-support-notifications
+    image: nexus3.edgexfoundry.org:10004/support-notifications-arm64:latest
+    networks:
+      edgex-network: null
+    ports:
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59860
+      published: "59860"
+      protocol: tcp
+    read_only: true
+    restart: always
+    security_opt:
+    - no-new-privileges:true
+    user: 2002:2001
+  support-scheduler:
     container_name: edgex-support-scheduler
     depends_on:
       consul:

--- a/docker-compose-no-secty-with-app-sample.yml
+++ b/docker-compose-no-secty-with-app-sample.yml
@@ -26,12 +26,12 @@
 #
 name: edgex
 services:
-  app-service-rules:
+  app-rules-engine:
     container_name: edgex-app-rules-engine
     depends_on:
       consul:
         condition: service_started
-      data:
+      core-data:
         condition: service_started
     environment:
       EDGEX_PROFILE: rules-engine
@@ -52,12 +52,12 @@ services:
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
-  app-service-sample:
+  app-sample:
     container_name: edgex-app-sample
     depends_on:
       consul:
         condition: service_started
-      data:
+      core-data:
         condition: service_started
     environment:
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
@@ -78,54 +78,6 @@ services:
       protocol: tcp
     read_only: true
     restart: always
-    security_opt:
-    - no-new-privileges:true
-    user: 2002:2001
-  command:
-    container_name: edgex-core-command
-    depends_on:
-      consul:
-        condition: service_started
-      database:
-        condition: service_started
-      metadata:
-        condition: service_started
-    environment:
-      EDGEX_SECURITY_SECRET_STORE: "false"
-      EXTERNALMQTT_URL: tcp://edgex-mqtt-broker:1883
-      SERVICE_HOST: edgex-core-command
-    hostname: edgex-core-command
-    image: nexus3.edgexfoundry.org:10004/core-command:latest
-    networks:
-      edgex-network: null
-    ports:
-    - mode: ingress
-      host_ip: 127.0.0.1
-      target: 59882
-      published: "59882"
-      protocol: tcp
-    read_only: true
-    restart: always
-    security_opt:
-    - no-new-privileges:true
-    user: 2002:2001
-  common-config:
-    container_name: edgex-core-common-config-bootstrapper
-    depends_on:
-      consul:
-        condition: service_started
-    environment:
-      ALL_SERVICES_DATABASE_HOST: edgex-redis
-      ALL_SERVICES_MESSAGEBUS_HOST: edgex-redis
-      ALL_SERVICES_REGISTRY_HOST: edgex-core-consul
-      APP_SERVICES_CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
-      DEVICE_SERVICES_CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
-      EDGEX_SECURITY_SECRET_STORE: "false"
-    hostname: edgex-core-common-config-bootstrapper
-    image: nexus3.edgexfoundry.org:10004/core-common-config-bootstrapper:latest
-    networks:
-      edgex-network: null
-    read_only: true
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -162,14 +114,62 @@ services:
       source: consul-data
       target: /consul/data
       volume: {}
-  data:
+  core-command:
+    container_name: edgex-core-command
+    depends_on:
+      consul:
+        condition: service_started
+      core-metadata:
+        condition: service_started
+      database:
+        condition: service_started
+    environment:
+      EDGEX_SECURITY_SECRET_STORE: "false"
+      EXTERNALMQTT_URL: tcp://edgex-mqtt-broker:1883
+      SERVICE_HOST: edgex-core-command
+    hostname: edgex-core-command
+    image: nexus3.edgexfoundry.org:10004/core-command:latest
+    networks:
+      edgex-network: null
+    ports:
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59882
+      published: "59882"
+      protocol: tcp
+    read_only: true
+    restart: always
+    security_opt:
+    - no-new-privileges:true
+    user: 2002:2001
+  core-common-config-bootstrapper:
+    container_name: edgex-core-common-config-bootstrapper
+    depends_on:
+      consul:
+        condition: service_started
+    environment:
+      ALL_SERVICES_DATABASE_HOST: edgex-redis
+      ALL_SERVICES_MESSAGEBUS_HOST: edgex-redis
+      ALL_SERVICES_REGISTRY_HOST: edgex-core-consul
+      APP_SERVICES_CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
+      DEVICE_SERVICES_CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
+      EDGEX_SECURITY_SECRET_STORE: "false"
+    hostname: edgex-core-common-config-bootstrapper
+    image: nexus3.edgexfoundry.org:10004/core-common-config-bootstrapper:latest
+    networks:
+      edgex-network: null
+    read_only: true
+    security_opt:
+    - no-new-privileges:true
+    user: 2002:2001
+  core-data:
     container_name: edgex-core-data
     depends_on:
       consul:
         condition: service_started
-      database:
+      core-metadata:
         condition: service_started
-      metadata:
+      database:
         condition: service_started
     environment:
       EDGEX_SECURITY_SECRET_STORE: "false"
@@ -183,6 +183,31 @@ services:
       host_ip: 127.0.0.1
       target: 59880
       published: "59880"
+      protocol: tcp
+    read_only: true
+    restart: always
+    security_opt:
+    - no-new-privileges:true
+    user: 2002:2001
+  core-metadata:
+    container_name: edgex-core-metadata
+    depends_on:
+      consul:
+        condition: service_started
+      database:
+        condition: service_started
+    environment:
+      EDGEX_SECURITY_SECRET_STORE: "false"
+      SERVICE_HOST: edgex-core-metadata
+    hostname: edgex-core-metadata
+    image: nexus3.edgexfoundry.org:10004/core-metadata:latest
+    networks:
+      edgex-network: null
+    ports:
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59881
+      published: "59881"
       protocol: tcp
     read_only: true
     restart: always
@@ -216,9 +241,9 @@ services:
     depends_on:
       consul:
         condition: service_started
-      data:
+      core-data:
         condition: service_started
-      metadata:
+      core-metadata:
         condition: service_started
     environment:
       EDGEX_SECURITY_SECRET_STORE: "false"
@@ -243,9 +268,9 @@ services:
     depends_on:
       consul:
         condition: service_started
-      data:
+      core-data:
         condition: service_started
-      metadata:
+      core-metadata:
         condition: service_started
     environment:
       EDGEX_SECURITY_SECRET_STORE: "false"
@@ -265,57 +290,7 @@ services:
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
-  metadata:
-    container_name: edgex-core-metadata
-    depends_on:
-      consul:
-        condition: service_started
-      database:
-        condition: service_started
-    environment:
-      EDGEX_SECURITY_SECRET_STORE: "false"
-      SERVICE_HOST: edgex-core-metadata
-    hostname: edgex-core-metadata
-    image: nexus3.edgexfoundry.org:10004/core-metadata:latest
-    networks:
-      edgex-network: null
-    ports:
-    - mode: ingress
-      host_ip: 127.0.0.1
-      target: 59881
-      published: "59881"
-      protocol: tcp
-    read_only: true
-    restart: always
-    security_opt:
-    - no-new-privileges:true
-    user: 2002:2001
-  notifications:
-    container_name: edgex-support-notifications
-    depends_on:
-      consul:
-        condition: service_started
-      database:
-        condition: service_started
-    environment:
-      EDGEX_SECURITY_SECRET_STORE: "false"
-      SERVICE_HOST: edgex-support-notifications
-    hostname: edgex-support-notifications
-    image: nexus3.edgexfoundry.org:10004/support-notifications:latest
-    networks:
-      edgex-network: null
-    ports:
-    - mode: ingress
-      host_ip: 127.0.0.1
-      target: 59860
-      published: "59860"
-      protocol: tcp
-    read_only: true
-    restart: always
-    security_opt:
-    - no-new-privileges:true
-    user: 2002:2001
-  rulesengine:
+  rules-engine:
     container_name: edgex-kuiper
     depends_on:
       database:
@@ -364,7 +339,32 @@ services:
       source: kuiper-plugins
       target: /kuiper/plugins
       volume: {}
-  scheduler:
+  support-notifications:
+    container_name: edgex-support-notifications
+    depends_on:
+      consul:
+        condition: service_started
+      database:
+        condition: service_started
+    environment:
+      EDGEX_SECURITY_SECRET_STORE: "false"
+      SERVICE_HOST: edgex-support-notifications
+    hostname: edgex-support-notifications
+    image: nexus3.edgexfoundry.org:10004/support-notifications:latest
+    networks:
+      edgex-network: null
+    ports:
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59860
+      published: "59860"
+      protocol: tcp
+    read_only: true
+    restart: always
+    security_opt:
+    - no-new-privileges:true
+    user: 2002:2001
+  support-scheduler:
     container_name: edgex-support-scheduler
     depends_on:
       consul:

--- a/docker-compose-no-secty.yml
+++ b/docker-compose-no-secty.yml
@@ -26,12 +26,12 @@
 #
 name: edgex
 services:
-  app-service-rules:
+  app-rules-engine:
     container_name: edgex-app-rules-engine
     depends_on:
       consul:
         condition: service_started
-      data:
+      core-data:
         condition: service_started
     environment:
       EDGEX_PROFILE: rules-engine
@@ -49,54 +49,6 @@ services:
       protocol: tcp
     read_only: true
     restart: always
-    security_opt:
-    - no-new-privileges:true
-    user: 2002:2001
-  command:
-    container_name: edgex-core-command
-    depends_on:
-      consul:
-        condition: service_started
-      database:
-        condition: service_started
-      metadata:
-        condition: service_started
-    environment:
-      EDGEX_SECURITY_SECRET_STORE: "false"
-      EXTERNALMQTT_URL: tcp://edgex-mqtt-broker:1883
-      SERVICE_HOST: edgex-core-command
-    hostname: edgex-core-command
-    image: nexus3.edgexfoundry.org:10004/core-command:latest
-    networks:
-      edgex-network: null
-    ports:
-    - mode: ingress
-      host_ip: 127.0.0.1
-      target: 59882
-      published: "59882"
-      protocol: tcp
-    read_only: true
-    restart: always
-    security_opt:
-    - no-new-privileges:true
-    user: 2002:2001
-  common-config:
-    container_name: edgex-core-common-config-bootstrapper
-    depends_on:
-      consul:
-        condition: service_started
-    environment:
-      ALL_SERVICES_DATABASE_HOST: edgex-redis
-      ALL_SERVICES_MESSAGEBUS_HOST: edgex-redis
-      ALL_SERVICES_REGISTRY_HOST: edgex-core-consul
-      APP_SERVICES_CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
-      DEVICE_SERVICES_CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
-      EDGEX_SECURITY_SECRET_STORE: "false"
-    hostname: edgex-core-common-config-bootstrapper
-    image: nexus3.edgexfoundry.org:10004/core-common-config-bootstrapper:latest
-    networks:
-      edgex-network: null
-    read_only: true
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -133,14 +85,62 @@ services:
       source: consul-data
       target: /consul/data
       volume: {}
-  data:
+  core-command:
+    container_name: edgex-core-command
+    depends_on:
+      consul:
+        condition: service_started
+      core-metadata:
+        condition: service_started
+      database:
+        condition: service_started
+    environment:
+      EDGEX_SECURITY_SECRET_STORE: "false"
+      EXTERNALMQTT_URL: tcp://edgex-mqtt-broker:1883
+      SERVICE_HOST: edgex-core-command
+    hostname: edgex-core-command
+    image: nexus3.edgexfoundry.org:10004/core-command:latest
+    networks:
+      edgex-network: null
+    ports:
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59882
+      published: "59882"
+      protocol: tcp
+    read_only: true
+    restart: always
+    security_opt:
+    - no-new-privileges:true
+    user: 2002:2001
+  core-common-config-bootstrapper:
+    container_name: edgex-core-common-config-bootstrapper
+    depends_on:
+      consul:
+        condition: service_started
+    environment:
+      ALL_SERVICES_DATABASE_HOST: edgex-redis
+      ALL_SERVICES_MESSAGEBUS_HOST: edgex-redis
+      ALL_SERVICES_REGISTRY_HOST: edgex-core-consul
+      APP_SERVICES_CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
+      DEVICE_SERVICES_CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
+      EDGEX_SECURITY_SECRET_STORE: "false"
+    hostname: edgex-core-common-config-bootstrapper
+    image: nexus3.edgexfoundry.org:10004/core-common-config-bootstrapper:latest
+    networks:
+      edgex-network: null
+    read_only: true
+    security_opt:
+    - no-new-privileges:true
+    user: 2002:2001
+  core-data:
     container_name: edgex-core-data
     depends_on:
       consul:
         condition: service_started
-      database:
+      core-metadata:
         condition: service_started
-      metadata:
+      database:
         condition: service_started
     environment:
       EDGEX_SECURITY_SECRET_STORE: "false"
@@ -154,6 +154,31 @@ services:
       host_ip: 127.0.0.1
       target: 59880
       published: "59880"
+      protocol: tcp
+    read_only: true
+    restart: always
+    security_opt:
+    - no-new-privileges:true
+    user: 2002:2001
+  core-metadata:
+    container_name: edgex-core-metadata
+    depends_on:
+      consul:
+        condition: service_started
+      database:
+        condition: service_started
+    environment:
+      EDGEX_SECURITY_SECRET_STORE: "false"
+      SERVICE_HOST: edgex-core-metadata
+    hostname: edgex-core-metadata
+    image: nexus3.edgexfoundry.org:10004/core-metadata:latest
+    networks:
+      edgex-network: null
+    ports:
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59881
+      published: "59881"
       protocol: tcp
     read_only: true
     restart: always
@@ -187,9 +212,9 @@ services:
     depends_on:
       consul:
         condition: service_started
-      data:
+      core-data:
         condition: service_started
-      metadata:
+      core-metadata:
         condition: service_started
     environment:
       EDGEX_SECURITY_SECRET_STORE: "false"
@@ -214,9 +239,9 @@ services:
     depends_on:
       consul:
         condition: service_started
-      data:
+      core-data:
         condition: service_started
-      metadata:
+      core-metadata:
         condition: service_started
     environment:
       EDGEX_SECURITY_SECRET_STORE: "false"
@@ -236,57 +261,7 @@ services:
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
-  metadata:
-    container_name: edgex-core-metadata
-    depends_on:
-      consul:
-        condition: service_started
-      database:
-        condition: service_started
-    environment:
-      EDGEX_SECURITY_SECRET_STORE: "false"
-      SERVICE_HOST: edgex-core-metadata
-    hostname: edgex-core-metadata
-    image: nexus3.edgexfoundry.org:10004/core-metadata:latest
-    networks:
-      edgex-network: null
-    ports:
-    - mode: ingress
-      host_ip: 127.0.0.1
-      target: 59881
-      published: "59881"
-      protocol: tcp
-    read_only: true
-    restart: always
-    security_opt:
-    - no-new-privileges:true
-    user: 2002:2001
-  notifications:
-    container_name: edgex-support-notifications
-    depends_on:
-      consul:
-        condition: service_started
-      database:
-        condition: service_started
-    environment:
-      EDGEX_SECURITY_SECRET_STORE: "false"
-      SERVICE_HOST: edgex-support-notifications
-    hostname: edgex-support-notifications
-    image: nexus3.edgexfoundry.org:10004/support-notifications:latest
-    networks:
-      edgex-network: null
-    ports:
-    - mode: ingress
-      host_ip: 127.0.0.1
-      target: 59860
-      published: "59860"
-      protocol: tcp
-    read_only: true
-    restart: always
-    security_opt:
-    - no-new-privileges:true
-    user: 2002:2001
-  rulesengine:
+  rules-engine:
     container_name: edgex-kuiper
     depends_on:
       database:
@@ -335,7 +310,32 @@ services:
       source: kuiper-plugins
       target: /kuiper/plugins
       volume: {}
-  scheduler:
+  support-notifications:
+    container_name: edgex-support-notifications
+    depends_on:
+      consul:
+        condition: service_started
+      database:
+        condition: service_started
+    environment:
+      EDGEX_SECURITY_SECRET_STORE: "false"
+      SERVICE_HOST: edgex-support-notifications
+    hostname: edgex-support-notifications
+    image: nexus3.edgexfoundry.org:10004/support-notifications:latest
+    networks:
+      edgex-network: null
+    ports:
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59860
+      published: "59860"
+      protocol: tcp
+    read_only: true
+    restart: always
+    security_opt:
+    - no-new-privileges:true
+    user: 2002:2001
+  support-scheduler:
     container_name: edgex-support-scheduler
     depends_on:
       consul:

--- a/docker-compose-with-app-sample-arm64.yml
+++ b/docker-compose-with-app-sample-arm64.yml
@@ -26,7 +26,7 @@
 #
 name: edgex
 services:
-  app-service-rules:
+  app-rules-engine:
     command:
     - /app-service-configurable
     - -cp=consul.http://edgex-core-consul:8500
@@ -35,7 +35,7 @@ services:
     depends_on:
       consul:
         condition: service_started
-      data:
+      core-data:
         condition: service_started
       security-bootstrapper:
         condition: service_started
@@ -87,7 +87,7 @@ services:
       bind:
         selinux: z
         create_host_path: true
-  app-service-sample:
+  app-sample:
     command:
     - /app-service-configurable
     - -cp=consul.http://edgex-core-consul:8500
@@ -96,7 +96,7 @@ services:
     depends_on:
       consul:
         condition: service_started
-      data:
+      core-data:
         condition: service_started
       security-bootstrapper:
         condition: service_started
@@ -147,128 +147,6 @@ services:
     - type: bind
       source: /tmp/edgex/secrets/app-sample
       target: /tmp/edgex/secrets/app-sample
-      read_only: true
-      bind:
-        selinux: z
-        create_host_path: true
-  command:
-    command:
-    - /core-command
-    - -cp=consul.http://edgex-core-consul:8500
-    - --registry
-    container_name: edgex-core-command
-    depends_on:
-      consul:
-        condition: service_started
-      database:
-        condition: service_started
-      metadata:
-        condition: service_started
-      secretstore-setup:
-        condition: service_started
-      security-bootstrapper:
-        condition: service_started
-    entrypoint:
-    - /edgex-init/ready_to_run_wait_install.sh
-    environment:
-      EDGEX_SECURITY_SECRET_STORE: "true"
-      EXTERNALMQTT_URL: tcp://edgex-mqtt-broker:1883
-      PROXY_SETUP_HOST: edgex-security-proxy-setup
-      SECRETSTORE_HOST: edgex-vault
-      SERVICE_HOST: edgex-core-command
-      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
-      STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: "6379"
-      STAGEGATE_DATABASE_READYPORT: "6379"
-      STAGEGATE_READY_TORUNPORT: "54329"
-      STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: "8500"
-      STAGEGATE_REGISTRY_READYPORT: "54324"
-      STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
-      STAGEGATE_WAITFOR_TIMEOUT: 60s
-    hostname: edgex-core-command
-    image: nexus3.edgexfoundry.org:10004/core-command-arm64:latest
-    networks:
-      edgex-network: null
-    ports:
-    - mode: ingress
-      host_ip: 127.0.0.1
-      target: 59882
-      published: "59882"
-      protocol: tcp
-    read_only: true
-    restart: always
-    security_opt:
-    - no-new-privileges:true
-    user: 2002:2001
-    volumes:
-    - type: volume
-      source: edgex-init
-      target: /edgex-init
-      read_only: true
-      volume: {}
-    - type: bind
-      source: /tmp/edgex/secrets/core-command
-      target: /tmp/edgex/secrets/core-command
-      read_only: true
-      bind:
-        selinux: z
-        create_host_path: true
-  common-config:
-    command:
-    - /entrypoint.sh
-    - /core-common-config-bootstrapper
-    - -cp=consul.http://edgex-core-consul:8500
-    container_name: edgex-core-common-config-bootstrapper
-    depends_on:
-      consul:
-        condition: service_started
-      secretstore-setup:
-        condition: service_started
-      security-bootstrapper:
-        condition: service_started
-    entrypoint:
-    - /edgex-init/ready_to_run_wait_install.sh
-    environment:
-      ALL_SERVICES_DATABASE_HOST: edgex-redis
-      ALL_SERVICES_MESSAGEBUS_HOST: edgex-redis
-      ALL_SERVICES_REGISTRY_HOST: edgex-core-consul
-      APP_SERVICES_CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
-      DEVICE_SERVICES_CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
-      EDGEX_SECURITY_SECRET_STORE: "true"
-      PROXY_SETUP_HOST: edgex-security-proxy-setup
-      SECRETSTORE_HOST: edgex-vault
-      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
-      STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: "6379"
-      STAGEGATE_DATABASE_READYPORT: "6379"
-      STAGEGATE_READY_TORUNPORT: "54329"
-      STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: "8500"
-      STAGEGATE_REGISTRY_READYPORT: "54324"
-      STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
-      STAGEGATE_WAITFOR_TIMEOUT: 60s
-    hostname: edgex-core-common-config-bootstrapper
-    image: nexus3.edgexfoundry.org:10004/core-common-config-bootstrapper-arm64:latest
-    networks:
-      edgex-network: null
-    read_only: true
-    security_opt:
-    - no-new-privileges:true
-    user: 2002:2001
-    volumes:
-    - type: volume
-      source: edgex-init
-      target: /edgex-init
-      read_only: true
-      volume: {}
-    - type: bind
-      source: /tmp/edgex/secrets/core-common-config-bootstrapper
-      target: /tmp/edgex/secrets/core-common-config-bootstrapper
       read_only: true
       bind:
         selinux: z
@@ -351,7 +229,129 @@ services:
       bind:
         selinux: z
         create_host_path: true
-  data:
+  core-command:
+    command:
+    - /core-command
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
+    container_name: edgex-core-command
+    depends_on:
+      consul:
+        condition: service_started
+      core-metadata:
+        condition: service_started
+      database:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
+      security-secretstore-setup:
+        condition: service_started
+    entrypoint:
+    - /edgex-init/ready_to_run_wait_install.sh
+    environment:
+      EDGEX_SECURITY_SECRET_STORE: "true"
+      EXTERNALMQTT_URL: tcp://edgex-mqtt-broker:1883
+      PROXY_SETUP_HOST: edgex-security-proxy-setup
+      SECRETSTORE_HOST: edgex-vault
+      SERVICE_HOST: edgex-core-command
+      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
+      STAGEGATE_DATABASE_HOST: edgex-redis
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
+      STAGEGATE_READY_TORUNPORT: "54329"
+      STAGEGATE_REGISTRY_HOST: edgex-core-consul
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
+      STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
+      STAGEGATE_WAITFOR_TIMEOUT: 60s
+    hostname: edgex-core-command
+    image: nexus3.edgexfoundry.org:10004/core-command-arm64:latest
+    networks:
+      edgex-network: null
+    ports:
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59882
+      published: "59882"
+      protocol: tcp
+    read_only: true
+    restart: always
+    security_opt:
+    - no-new-privileges:true
+    user: 2002:2001
+    volumes:
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/core-command
+      target: /tmp/edgex/secrets/core-command
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
+  core-common-config-bootstrapper:
+    command:
+    - /entrypoint.sh
+    - /core-common-config-bootstrapper
+    - -cp=consul.http://edgex-core-consul:8500
+    container_name: edgex-core-common-config-bootstrapper
+    depends_on:
+      consul:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
+      security-secretstore-setup:
+        condition: service_started
+    entrypoint:
+    - /edgex-init/ready_to_run_wait_install.sh
+    environment:
+      ALL_SERVICES_DATABASE_HOST: edgex-redis
+      ALL_SERVICES_MESSAGEBUS_HOST: edgex-redis
+      ALL_SERVICES_REGISTRY_HOST: edgex-core-consul
+      APP_SERVICES_CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
+      DEVICE_SERVICES_CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
+      EDGEX_SECURITY_SECRET_STORE: "true"
+      PROXY_SETUP_HOST: edgex-security-proxy-setup
+      SECRETSTORE_HOST: edgex-vault
+      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
+      STAGEGATE_DATABASE_HOST: edgex-redis
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
+      STAGEGATE_READY_TORUNPORT: "54329"
+      STAGEGATE_REGISTRY_HOST: edgex-core-consul
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
+      STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
+      STAGEGATE_WAITFOR_TIMEOUT: 60s
+    hostname: edgex-core-common-config-bootstrapper
+    image: nexus3.edgexfoundry.org:10004/core-common-config-bootstrapper-arm64:latest
+    networks:
+      edgex-network: null
+    read_only: true
+    security_opt:
+    - no-new-privileges:true
+    user: 2002:2001
+    volumes:
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/core-common-config-bootstrapper
+      target: /tmp/edgex/secrets/core-common-config-bootstrapper
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
+  core-data:
     command:
     - /core-data
     - -cp=consul.http://edgex-core-consul:8500
@@ -360,13 +360,13 @@ services:
     depends_on:
       consul:
         condition: service_started
+      core-metadata:
+        condition: service_started
       database:
         condition: service_started
-      metadata:
-        condition: service_started
-      secretstore-setup:
-        condition: service_started
       security-bootstrapper:
+        condition: service_started
+      security-secretstore-setup:
         condition: service_started
     entrypoint:
     - /edgex-init/ready_to_run_wait_install.sh
@@ -415,12 +415,74 @@ services:
       bind:
         selinux: z
         create_host_path: true
+  core-metadata:
+    command:
+    - /core-metadata
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
+    container_name: edgex-core-metadata
+    depends_on:
+      consul:
+        condition: service_started
+      database:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
+      security-secretstore-setup:
+        condition: service_started
+    entrypoint:
+    - /edgex-init/ready_to_run_wait_install.sh
+    environment:
+      EDGEX_SECURITY_SECRET_STORE: "true"
+      PROXY_SETUP_HOST: edgex-security-proxy-setup
+      SECRETSTORE_HOST: edgex-vault
+      SERVICE_HOST: edgex-core-metadata
+      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
+      STAGEGATE_DATABASE_HOST: edgex-redis
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
+      STAGEGATE_READY_TORUNPORT: "54329"
+      STAGEGATE_REGISTRY_HOST: edgex-core-consul
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
+      STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
+      STAGEGATE_WAITFOR_TIMEOUT: 60s
+    hostname: edgex-core-metadata
+    image: nexus3.edgexfoundry.org:10004/core-metadata-arm64:latest
+    networks:
+      edgex-network: null
+    ports:
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59881
+      published: "59881"
+      protocol: tcp
+    read_only: true
+    restart: always
+    security_opt:
+    - no-new-privileges:true
+    user: 2002:2001
+    volumes:
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/core-metadata
+      target: /tmp/edgex/secrets/core-metadata
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   database:
     container_name: edgex-redis
     depends_on:
-      secretstore-setup:
-        condition: service_started
       security-bootstrapper:
+        condition: service_started
+      security-secretstore-setup:
         condition: service_started
     entrypoint:
     - /edgex-init/redis_wait_install.sh
@@ -489,9 +551,9 @@ services:
     depends_on:
       consul:
         condition: service_started
-      data:
+      core-data:
         condition: service_started
-      metadata:
+      core-metadata:
         condition: service_started
       security-bootstrapper:
         condition: service_started
@@ -551,9 +613,9 @@ services:
     depends_on:
       consul:
         condition: service_started
-      data:
+      core-data:
         condition: service_started
-      metadata:
+      core-metadata:
         condition: service_started
       security-bootstrapper:
         condition: service_started
@@ -604,68 +666,6 @@ services:
       bind:
         selinux: z
         create_host_path: true
-  metadata:
-    command:
-    - /core-metadata
-    - -cp=consul.http://edgex-core-consul:8500
-    - --registry
-    container_name: edgex-core-metadata
-    depends_on:
-      consul:
-        condition: service_started
-      database:
-        condition: service_started
-      secretstore-setup:
-        condition: service_started
-      security-bootstrapper:
-        condition: service_started
-    entrypoint:
-    - /edgex-init/ready_to_run_wait_install.sh
-    environment:
-      EDGEX_SECURITY_SECRET_STORE: "true"
-      PROXY_SETUP_HOST: edgex-security-proxy-setup
-      SECRETSTORE_HOST: edgex-vault
-      SERVICE_HOST: edgex-core-metadata
-      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
-      STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: "6379"
-      STAGEGATE_DATABASE_READYPORT: "6379"
-      STAGEGATE_READY_TORUNPORT: "54329"
-      STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: "8500"
-      STAGEGATE_REGISTRY_READYPORT: "54324"
-      STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
-      STAGEGATE_WAITFOR_TIMEOUT: 60s
-    hostname: edgex-core-metadata
-    image: nexus3.edgexfoundry.org:10004/core-metadata-arm64:latest
-    networks:
-      edgex-network: null
-    ports:
-    - mode: ingress
-      host_ip: 127.0.0.1
-      target: 59881
-      published: "59881"
-      protocol: tcp
-    read_only: true
-    restart: always
-    security_opt:
-    - no-new-privileges:true
-    user: 2002:2001
-    volumes:
-    - type: volume
-      source: edgex-init
-      target: /edgex-init
-      read_only: true
-      volume: {}
-    - type: bind
-      source: /tmp/edgex/secrets/core-metadata
-      target: /tmp/edgex/secrets/core-metadata
-      read_only: true
-      bind:
-        selinux: z
-        create_host_path: true
   nginx:
     command:
     - /docker-entrypoint.sh
@@ -674,7 +674,7 @@ services:
     - daemon off;
     container_name: edgex-nginx
     depends_on:
-      secretstore-setup:
+      security-secretstore-setup:
         condition: service_started
     entrypoint:
     - /bin/sh
@@ -727,206 +727,14 @@ services:
       source: nginx-tls
       target: /etc/ssl/nginx
       volume: {}
-  notifications:
-    command:
-    - /support-notifications
-    - -cp=consul.http://edgex-core-consul:8500
-    - --registry
-    container_name: edgex-support-notifications
-    depends_on:
-      consul:
-        condition: service_started
-      database:
-        condition: service_started
-      secretstore-setup:
-        condition: service_started
-      security-bootstrapper:
-        condition: service_started
-    entrypoint:
-    - /edgex-init/ready_to_run_wait_install.sh
-    environment:
-      EDGEX_SECURITY_SECRET_STORE: "true"
-      PROXY_SETUP_HOST: edgex-security-proxy-setup
-      SECRETSTORE_HOST: edgex-vault
-      SERVICE_HOST: edgex-support-notifications
-      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
-      STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: "6379"
-      STAGEGATE_DATABASE_READYPORT: "6379"
-      STAGEGATE_READY_TORUNPORT: "54329"
-      STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: "8500"
-      STAGEGATE_REGISTRY_READYPORT: "54324"
-      STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
-      STAGEGATE_WAITFOR_TIMEOUT: 60s
-    hostname: edgex-support-notifications
-    image: nexus3.edgexfoundry.org:10004/support-notifications-arm64:latest
-    networks:
-      edgex-network: null
-    ports:
-    - mode: ingress
-      host_ip: 127.0.0.1
-      target: 59860
-      published: "59860"
-      protocol: tcp
-    read_only: true
-    restart: always
-    security_opt:
-    - no-new-privileges:true
-    user: 2002:2001
-    volumes:
-    - type: volume
-      source: edgex-init
-      target: /edgex-init
-      read_only: true
-      volume: {}
-    - type: bind
-      source: /tmp/edgex/secrets/support-notifications
-      target: /tmp/edgex/secrets/support-notifications
-      read_only: true
-      bind:
-        selinux: z
-        create_host_path: true
-  proxy-auth:
-    command:
-    - entrypoint.sh
-    - /security-proxy-auth
-    - -cp=consul.http://edgex-core-consul:8500
-    - --registry
-    container_name: edgex-proxy-auth
-    depends_on:
-      secretstore-setup:
-        condition: service_started
-    entrypoint:
-    - /bin/sh
-    - /edgex-init/ready_to_run_wait_install.sh
-    environment:
-      EDGEX_SECURITY_SECRET_STORE: "true"
-      PROXY_SETUP_HOST: edgex-security-proxy-setup
-      SECRETSTORE_HOST: edgex-vault
-      SERVICE_HOST: edgex-proxy-auth
-      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
-      STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: "6379"
-      STAGEGATE_DATABASE_READYPORT: "6379"
-      STAGEGATE_READY_TORUNPORT: "54329"
-      STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: "8500"
-      STAGEGATE_REGISTRY_READYPORT: "54324"
-      STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
-      STAGEGATE_WAITFOR_TIMEOUT: 60s
-    hostname: edgex-proxy-auth
-    image: nexus3.edgexfoundry.org:10004/security-proxy-auth-arm64:latest
-    networks:
-      edgex-network: null
-    ports:
-    - mode: ingress
-      host_ip: 127.0.0.1
-      target: 59842
-      published: "59842"
-      protocol: tcp
-    read_only: true
-    restart: always
-    security_opt:
-    - no-new-privileges:true
-    volumes:
-    - type: volume
-      source: edgex-init
-      target: /edgex-init
-      read_only: true
-      volume: {}
-    - type: bind
-      source: /tmp/edgex/secrets/security-proxy-auth
-      target: /tmp/edgex/secrets/security-proxy-auth
-      read_only: true
-      bind:
-        selinux: z
-        create_host_path: true
-  proxy-setup:
-    container_name: edgex-security-proxy-setup
-    depends_on:
-      secretstore-setup:
-        condition: service_started
-      security-bootstrapper:
-        condition: service_started
-    entrypoint:
-    - /edgex-init/proxy_setup_wait_install.sh
-    environment:
-      ADD_PROXY_ROUTE: ""
-      EDGEX_SECURITY_SECRET_STORE: "true"
-      PROXY_SETUP_HOST: edgex-security-proxy-setup
-      ROUTES_CORE_COMMAND_HOST: edgex-core-command
-      ROUTES_CORE_CONSUL_HOST: edgex-core-consul
-      ROUTES_CORE_DATA_HOST: edgex-core-data
-      ROUTES_CORE_METADATA_HOST: edgex-core-metadata
-      ROUTES_DEVICE_VIRTUAL_HOST: device-virtual
-      ROUTES_RULES_ENGINE_HOST: edgex-kuiper
-      ROUTES_SUPPORT_NOTIFICATIONS_HOST: edgex-support-notifications
-      ROUTES_SUPPORT_SCHEDULER_HOST: edgex-support-scheduler
-      ROUTES_SYS_MGMT_AGENT_HOST: edgex-sys-mgmt-agent
-      SECRETSTORE_HOST: edgex-vault
-      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
-      STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: "6379"
-      STAGEGATE_DATABASE_READYPORT: "6379"
-      STAGEGATE_READY_TORUNPORT: "54329"
-      STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: "8500"
-      STAGEGATE_REGISTRY_READYPORT: "54324"
-      STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
-      STAGEGATE_WAITFOR_TIMEOUT: 60s
-    hostname: edgex-security-proxy-setup
-    image: nexus3.edgexfoundry.org:10004/security-proxy-setup-arm64:latest
-    networks:
-      edgex-network: null
-    read_only: true
-    security_opt:
-    - no-new-privileges:true
-    user: root:root
-    volumes:
-    - type: volume
-      source: edgex-init
-      target: /edgex-init
-      read_only: true
-      volume: {}
-    - type: volume
-      source: vault-config
-      target: /vault/config
-      volume: {}
-    - type: volume
-      source: nginx-templates
-      target: /etc/nginx/templates
-      volume: {}
-    - type: volume
-      source: nginx-tls
-      target: /etc/ssl/nginx
-      volume: {}
-    - type: bind
-      source: /tmp/edgex/secrets/security-proxy-setup
-      target: /tmp/edgex/secrets/security-proxy-setup
-      read_only: true
-      bind:
-        selinux: z
-        create_host_path: true
-    - type: volume
-      source: consul-acl-token
-      target: /tmp/edgex/secrets/consul-acl-token
-      read_only: true
-      volume: {}
-  rulesengine:
+  rules-engine:
     container_name: edgex-kuiper
     depends_on:
       database:
         condition: service_started
-      secretstore-setup:
-        condition: service_started
       security-bootstrapper:
+        condition: service_started
+      security-secretstore-setup:
         condition: service_started
     entrypoint:
     - /edgex-init/kuiper_wait_install.sh
@@ -1000,30 +808,12 @@ services:
       source: kuiper-plugins
       target: /kuiper/plugins
       volume: {}
-  scheduler:
-    command:
-    - /support-scheduler
-    - -cp=consul.http://edgex-core-consul:8500
-    - --registry
-    container_name: edgex-support-scheduler
-    depends_on:
-      consul:
-        condition: service_started
-      database:
-        condition: service_started
-      secretstore-setup:
-        condition: service_started
-      security-bootstrapper:
-        condition: service_started
-    entrypoint:
-    - /edgex-init/ready_to_run_wait_install.sh
+  security-bootstrapper:
+    container_name: edgex-security-bootstrapper
     environment:
-      EDGEX_SECURITY_SECRET_STORE: "true"
-      INTERVALACTIONS_SCRUBAGED_HOST: edgex-core-data
-      INTERVALACTIONS_SCRUBPUSHED_HOST: edgex-core-data
+      EDGEX_GROUP: "2001"
+      EDGEX_USER: "2002"
       PROXY_SETUP_HOST: edgex-security-proxy-setup
-      SECRETSTORE_HOST: edgex-vault
-      SERVICE_HOST: edgex-support-scheduler
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
       STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
@@ -1036,21 +826,64 @@ services:
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
       STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
-    hostname: edgex-support-scheduler
-    image: nexus3.edgexfoundry.org:10004/support-scheduler-arm64:latest
+    hostname: edgex-security-bootstrapper
+    image: nexus3.edgexfoundry.org:10004/security-bootstrapper-arm64:latest
+    networks:
+      edgex-network: null
+    read_only: true
+    restart: always
+    security_opt:
+    - no-new-privileges:true
+    user: root:root
+    volumes:
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      volume: {}
+  security-proxy-auth:
+    command:
+    - entrypoint.sh
+    - /security-proxy-auth
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
+    container_name: edgex-proxy-auth
+    depends_on:
+      security-secretstore-setup:
+        condition: service_started
+    entrypoint:
+    - /bin/sh
+    - /edgex-init/ready_to_run_wait_install.sh
+    environment:
+      EDGEX_SECURITY_SECRET_STORE: "true"
+      PROXY_SETUP_HOST: edgex-security-proxy-setup
+      SECRETSTORE_HOST: edgex-vault
+      SERVICE_HOST: edgex-proxy-auth
+      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
+      STAGEGATE_DATABASE_HOST: edgex-redis
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
+      STAGEGATE_READY_TORUNPORT: "54329"
+      STAGEGATE_REGISTRY_HOST: edgex-core-consul
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
+      STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
+      STAGEGATE_WAITFOR_TIMEOUT: 60s
+    hostname: edgex-proxy-auth
+    image: nexus3.edgexfoundry.org:10004/security-proxy-auth-arm64:latest
     networks:
       edgex-network: null
     ports:
     - mode: ingress
       host_ip: 127.0.0.1
-      target: 59861
-      published: "59861"
+      target: 59842
+      published: "59842"
       protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
-    user: 2002:2001
     volumes:
     - type: volume
       source: edgex-init
@@ -1058,13 +891,86 @@ services:
       read_only: true
       volume: {}
     - type: bind
-      source: /tmp/edgex/secrets/support-scheduler
-      target: /tmp/edgex/secrets/support-scheduler
+      source: /tmp/edgex/secrets/security-proxy-auth
+      target: /tmp/edgex/secrets/security-proxy-auth
       read_only: true
       bind:
         selinux: z
         create_host_path: true
-  secretstore-setup:
+  security-proxy-setup:
+    container_name: edgex-security-proxy-setup
+    depends_on:
+      security-bootstrapper:
+        condition: service_started
+      security-secretstore-setup:
+        condition: service_started
+    entrypoint:
+    - /edgex-init/proxy_setup_wait_install.sh
+    environment:
+      ADD_PROXY_ROUTE: ""
+      EDGEX_SECURITY_SECRET_STORE: "true"
+      PROXY_SETUP_HOST: edgex-security-proxy-setup
+      ROUTES_CORE_COMMAND_HOST: edgex-core-command
+      ROUTES_CORE_CONSUL_HOST: edgex-core-consul
+      ROUTES_CORE_DATA_HOST: edgex-core-data
+      ROUTES_CORE_METADATA_HOST: edgex-core-metadata
+      ROUTES_DEVICE_VIRTUAL_HOST: device-virtual
+      ROUTES_RULES_ENGINE_HOST: edgex-kuiper
+      ROUTES_SUPPORT_NOTIFICATIONS_HOST: edgex-support-notifications
+      ROUTES_SUPPORT_SCHEDULER_HOST: edgex-support-scheduler
+      ROUTES_SYS_MGMT_AGENT_HOST: edgex-sys-mgmt-agent
+      SECRETSTORE_HOST: edgex-vault
+      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
+      STAGEGATE_DATABASE_HOST: edgex-redis
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
+      STAGEGATE_READY_TORUNPORT: "54329"
+      STAGEGATE_REGISTRY_HOST: edgex-core-consul
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
+      STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
+      STAGEGATE_WAITFOR_TIMEOUT: 60s
+    hostname: edgex-security-proxy-setup
+    image: nexus3.edgexfoundry.org:10004/security-proxy-setup-arm64:latest
+    networks:
+      edgex-network: null
+    read_only: true
+    security_opt:
+    - no-new-privileges:true
+    user: root:root
+    volumes:
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      volume: {}
+    - type: volume
+      source: vault-config
+      target: /vault/config
+      volume: {}
+    - type: volume
+      source: nginx-templates
+      target: /etc/nginx/templates
+      volume: {}
+    - type: volume
+      source: nginx-tls
+      target: /etc/ssl/nginx
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/security-proxy-setup
+      target: /tmp/edgex/secrets/security-proxy-setup
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
+    - type: volume
+      source: consul-acl-token
+      target: /tmp/edgex/secrets/consul-acl-token
+      read_only: true
+      volume: {}
+  security-secretstore-setup:
     container_name: edgex-security-secretstore-setup
     depends_on:
       security-bootstrapper:
@@ -1128,12 +1034,28 @@ services:
       source: vault-config
       target: /vault/config
       volume: {}
-  security-bootstrapper:
-    container_name: edgex-security-bootstrapper
+  support-notifications:
+    command:
+    - /support-notifications
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
+    container_name: edgex-support-notifications
+    depends_on:
+      consul:
+        condition: service_started
+      database:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
+      security-secretstore-setup:
+        condition: service_started
+    entrypoint:
+    - /edgex-init/ready_to_run_wait_install.sh
     environment:
-      EDGEX_GROUP: "2001"
-      EDGEX_USER: "2002"
+      EDGEX_SECURITY_SECRET_STORE: "true"
       PROXY_SETUP_HOST: edgex-security-proxy-setup
+      SECRETSTORE_HOST: edgex-vault
+      SERVICE_HOST: edgex-support-notifications
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
       STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
@@ -1146,20 +1068,98 @@ services:
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
       STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
-    hostname: edgex-security-bootstrapper
-    image: nexus3.edgexfoundry.org:10004/security-bootstrapper-arm64:latest
+    hostname: edgex-support-notifications
+    image: nexus3.edgexfoundry.org:10004/support-notifications-arm64:latest
     networks:
       edgex-network: null
+    ports:
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59860
+      published: "59860"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
-    user: root:root
+    user: 2002:2001
     volumes:
     - type: volume
       source: edgex-init
       target: /edgex-init
+      read_only: true
       volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/support-notifications
+      target: /tmp/edgex/secrets/support-notifications
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
+  support-scheduler:
+    command:
+    - /support-scheduler
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
+    container_name: edgex-support-scheduler
+    depends_on:
+      consul:
+        condition: service_started
+      database:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
+      security-secretstore-setup:
+        condition: service_started
+    entrypoint:
+    - /edgex-init/ready_to_run_wait_install.sh
+    environment:
+      EDGEX_SECURITY_SECRET_STORE: "true"
+      INTERVALACTIONS_SCRUBAGED_HOST: edgex-core-data
+      INTERVALACTIONS_SCRUBPUSHED_HOST: edgex-core-data
+      PROXY_SETUP_HOST: edgex-security-proxy-setup
+      SECRETSTORE_HOST: edgex-vault
+      SERVICE_HOST: edgex-support-scheduler
+      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
+      STAGEGATE_DATABASE_HOST: edgex-redis
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
+      STAGEGATE_READY_TORUNPORT: "54329"
+      STAGEGATE_REGISTRY_HOST: edgex-core-consul
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
+      STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
+      STAGEGATE_WAITFOR_TIMEOUT: 60s
+    hostname: edgex-support-scheduler
+    image: nexus3.edgexfoundry.org:10004/support-scheduler-arm64:latest
+    networks:
+      edgex-network: null
+    ports:
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59861
+      published: "59861"
+      protocol: tcp
+    read_only: true
+    restart: always
+    security_opt:
+    - no-new-privileges:true
+    user: 2002:2001
+    volumes:
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/support-scheduler
+      target: /tmp/edgex/secrets/support-scheduler
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   ui:
     container_name: edgex-ui-go
     environment:

--- a/docker-compose-with-app-sample.yml
+++ b/docker-compose-with-app-sample.yml
@@ -26,7 +26,7 @@
 #
 name: edgex
 services:
-  app-service-rules:
+  app-rules-engine:
     command:
     - /app-service-configurable
     - -cp=consul.http://edgex-core-consul:8500
@@ -35,7 +35,7 @@ services:
     depends_on:
       consul:
         condition: service_started
-      data:
+      core-data:
         condition: service_started
       security-bootstrapper:
         condition: service_started
@@ -87,7 +87,7 @@ services:
       bind:
         selinux: z
         create_host_path: true
-  app-service-sample:
+  app-sample:
     command:
     - /app-service-configurable
     - -cp=consul.http://edgex-core-consul:8500
@@ -96,7 +96,7 @@ services:
     depends_on:
       consul:
         condition: service_started
-      data:
+      core-data:
         condition: service_started
       security-bootstrapper:
         condition: service_started
@@ -147,128 +147,6 @@ services:
     - type: bind
       source: /tmp/edgex/secrets/app-sample
       target: /tmp/edgex/secrets/app-sample
-      read_only: true
-      bind:
-        selinux: z
-        create_host_path: true
-  command:
-    command:
-    - /core-command
-    - -cp=consul.http://edgex-core-consul:8500
-    - --registry
-    container_name: edgex-core-command
-    depends_on:
-      consul:
-        condition: service_started
-      database:
-        condition: service_started
-      metadata:
-        condition: service_started
-      secretstore-setup:
-        condition: service_started
-      security-bootstrapper:
-        condition: service_started
-    entrypoint:
-    - /edgex-init/ready_to_run_wait_install.sh
-    environment:
-      EDGEX_SECURITY_SECRET_STORE: "true"
-      EXTERNALMQTT_URL: tcp://edgex-mqtt-broker:1883
-      PROXY_SETUP_HOST: edgex-security-proxy-setup
-      SECRETSTORE_HOST: edgex-vault
-      SERVICE_HOST: edgex-core-command
-      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
-      STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: "6379"
-      STAGEGATE_DATABASE_READYPORT: "6379"
-      STAGEGATE_READY_TORUNPORT: "54329"
-      STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: "8500"
-      STAGEGATE_REGISTRY_READYPORT: "54324"
-      STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
-      STAGEGATE_WAITFOR_TIMEOUT: 60s
-    hostname: edgex-core-command
-    image: nexus3.edgexfoundry.org:10004/core-command:latest
-    networks:
-      edgex-network: null
-    ports:
-    - mode: ingress
-      host_ip: 127.0.0.1
-      target: 59882
-      published: "59882"
-      protocol: tcp
-    read_only: true
-    restart: always
-    security_opt:
-    - no-new-privileges:true
-    user: 2002:2001
-    volumes:
-    - type: volume
-      source: edgex-init
-      target: /edgex-init
-      read_only: true
-      volume: {}
-    - type: bind
-      source: /tmp/edgex/secrets/core-command
-      target: /tmp/edgex/secrets/core-command
-      read_only: true
-      bind:
-        selinux: z
-        create_host_path: true
-  common-config:
-    command:
-    - /entrypoint.sh
-    - /core-common-config-bootstrapper
-    - -cp=consul.http://edgex-core-consul:8500
-    container_name: edgex-core-common-config-bootstrapper
-    depends_on:
-      consul:
-        condition: service_started
-      secretstore-setup:
-        condition: service_started
-      security-bootstrapper:
-        condition: service_started
-    entrypoint:
-    - /edgex-init/ready_to_run_wait_install.sh
-    environment:
-      ALL_SERVICES_DATABASE_HOST: edgex-redis
-      ALL_SERVICES_MESSAGEBUS_HOST: edgex-redis
-      ALL_SERVICES_REGISTRY_HOST: edgex-core-consul
-      APP_SERVICES_CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
-      DEVICE_SERVICES_CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
-      EDGEX_SECURITY_SECRET_STORE: "true"
-      PROXY_SETUP_HOST: edgex-security-proxy-setup
-      SECRETSTORE_HOST: edgex-vault
-      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
-      STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: "6379"
-      STAGEGATE_DATABASE_READYPORT: "6379"
-      STAGEGATE_READY_TORUNPORT: "54329"
-      STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: "8500"
-      STAGEGATE_REGISTRY_READYPORT: "54324"
-      STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
-      STAGEGATE_WAITFOR_TIMEOUT: 60s
-    hostname: edgex-core-common-config-bootstrapper
-    image: nexus3.edgexfoundry.org:10004/core-common-config-bootstrapper:latest
-    networks:
-      edgex-network: null
-    read_only: true
-    security_opt:
-    - no-new-privileges:true
-    user: 2002:2001
-    volumes:
-    - type: volume
-      source: edgex-init
-      target: /edgex-init
-      read_only: true
-      volume: {}
-    - type: bind
-      source: /tmp/edgex/secrets/core-common-config-bootstrapper
-      target: /tmp/edgex/secrets/core-common-config-bootstrapper
       read_only: true
       bind:
         selinux: z
@@ -351,7 +229,129 @@ services:
       bind:
         selinux: z
         create_host_path: true
-  data:
+  core-command:
+    command:
+    - /core-command
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
+    container_name: edgex-core-command
+    depends_on:
+      consul:
+        condition: service_started
+      core-metadata:
+        condition: service_started
+      database:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
+      security-secretstore-setup:
+        condition: service_started
+    entrypoint:
+    - /edgex-init/ready_to_run_wait_install.sh
+    environment:
+      EDGEX_SECURITY_SECRET_STORE: "true"
+      EXTERNALMQTT_URL: tcp://edgex-mqtt-broker:1883
+      PROXY_SETUP_HOST: edgex-security-proxy-setup
+      SECRETSTORE_HOST: edgex-vault
+      SERVICE_HOST: edgex-core-command
+      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
+      STAGEGATE_DATABASE_HOST: edgex-redis
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
+      STAGEGATE_READY_TORUNPORT: "54329"
+      STAGEGATE_REGISTRY_HOST: edgex-core-consul
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
+      STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
+      STAGEGATE_WAITFOR_TIMEOUT: 60s
+    hostname: edgex-core-command
+    image: nexus3.edgexfoundry.org:10004/core-command:latest
+    networks:
+      edgex-network: null
+    ports:
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59882
+      published: "59882"
+      protocol: tcp
+    read_only: true
+    restart: always
+    security_opt:
+    - no-new-privileges:true
+    user: 2002:2001
+    volumes:
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/core-command
+      target: /tmp/edgex/secrets/core-command
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
+  core-common-config-bootstrapper:
+    command:
+    - /entrypoint.sh
+    - /core-common-config-bootstrapper
+    - -cp=consul.http://edgex-core-consul:8500
+    container_name: edgex-core-common-config-bootstrapper
+    depends_on:
+      consul:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
+      security-secretstore-setup:
+        condition: service_started
+    entrypoint:
+    - /edgex-init/ready_to_run_wait_install.sh
+    environment:
+      ALL_SERVICES_DATABASE_HOST: edgex-redis
+      ALL_SERVICES_MESSAGEBUS_HOST: edgex-redis
+      ALL_SERVICES_REGISTRY_HOST: edgex-core-consul
+      APP_SERVICES_CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
+      DEVICE_SERVICES_CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
+      EDGEX_SECURITY_SECRET_STORE: "true"
+      PROXY_SETUP_HOST: edgex-security-proxy-setup
+      SECRETSTORE_HOST: edgex-vault
+      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
+      STAGEGATE_DATABASE_HOST: edgex-redis
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
+      STAGEGATE_READY_TORUNPORT: "54329"
+      STAGEGATE_REGISTRY_HOST: edgex-core-consul
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
+      STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
+      STAGEGATE_WAITFOR_TIMEOUT: 60s
+    hostname: edgex-core-common-config-bootstrapper
+    image: nexus3.edgexfoundry.org:10004/core-common-config-bootstrapper:latest
+    networks:
+      edgex-network: null
+    read_only: true
+    security_opt:
+    - no-new-privileges:true
+    user: 2002:2001
+    volumes:
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/core-common-config-bootstrapper
+      target: /tmp/edgex/secrets/core-common-config-bootstrapper
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
+  core-data:
     command:
     - /core-data
     - -cp=consul.http://edgex-core-consul:8500
@@ -360,13 +360,13 @@ services:
     depends_on:
       consul:
         condition: service_started
+      core-metadata:
+        condition: service_started
       database:
         condition: service_started
-      metadata:
-        condition: service_started
-      secretstore-setup:
-        condition: service_started
       security-bootstrapper:
+        condition: service_started
+      security-secretstore-setup:
         condition: service_started
     entrypoint:
     - /edgex-init/ready_to_run_wait_install.sh
@@ -415,12 +415,74 @@ services:
       bind:
         selinux: z
         create_host_path: true
+  core-metadata:
+    command:
+    - /core-metadata
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
+    container_name: edgex-core-metadata
+    depends_on:
+      consul:
+        condition: service_started
+      database:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
+      security-secretstore-setup:
+        condition: service_started
+    entrypoint:
+    - /edgex-init/ready_to_run_wait_install.sh
+    environment:
+      EDGEX_SECURITY_SECRET_STORE: "true"
+      PROXY_SETUP_HOST: edgex-security-proxy-setup
+      SECRETSTORE_HOST: edgex-vault
+      SERVICE_HOST: edgex-core-metadata
+      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
+      STAGEGATE_DATABASE_HOST: edgex-redis
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
+      STAGEGATE_READY_TORUNPORT: "54329"
+      STAGEGATE_REGISTRY_HOST: edgex-core-consul
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
+      STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
+      STAGEGATE_WAITFOR_TIMEOUT: 60s
+    hostname: edgex-core-metadata
+    image: nexus3.edgexfoundry.org:10004/core-metadata:latest
+    networks:
+      edgex-network: null
+    ports:
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59881
+      published: "59881"
+      protocol: tcp
+    read_only: true
+    restart: always
+    security_opt:
+    - no-new-privileges:true
+    user: 2002:2001
+    volumes:
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/core-metadata
+      target: /tmp/edgex/secrets/core-metadata
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   database:
     container_name: edgex-redis
     depends_on:
-      secretstore-setup:
-        condition: service_started
       security-bootstrapper:
+        condition: service_started
+      security-secretstore-setup:
         condition: service_started
     entrypoint:
     - /edgex-init/redis_wait_install.sh
@@ -489,9 +551,9 @@ services:
     depends_on:
       consul:
         condition: service_started
-      data:
+      core-data:
         condition: service_started
-      metadata:
+      core-metadata:
         condition: service_started
       security-bootstrapper:
         condition: service_started
@@ -551,9 +613,9 @@ services:
     depends_on:
       consul:
         condition: service_started
-      data:
+      core-data:
         condition: service_started
-      metadata:
+      core-metadata:
         condition: service_started
       security-bootstrapper:
         condition: service_started
@@ -604,68 +666,6 @@ services:
       bind:
         selinux: z
         create_host_path: true
-  metadata:
-    command:
-    - /core-metadata
-    - -cp=consul.http://edgex-core-consul:8500
-    - --registry
-    container_name: edgex-core-metadata
-    depends_on:
-      consul:
-        condition: service_started
-      database:
-        condition: service_started
-      secretstore-setup:
-        condition: service_started
-      security-bootstrapper:
-        condition: service_started
-    entrypoint:
-    - /edgex-init/ready_to_run_wait_install.sh
-    environment:
-      EDGEX_SECURITY_SECRET_STORE: "true"
-      PROXY_SETUP_HOST: edgex-security-proxy-setup
-      SECRETSTORE_HOST: edgex-vault
-      SERVICE_HOST: edgex-core-metadata
-      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
-      STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: "6379"
-      STAGEGATE_DATABASE_READYPORT: "6379"
-      STAGEGATE_READY_TORUNPORT: "54329"
-      STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: "8500"
-      STAGEGATE_REGISTRY_READYPORT: "54324"
-      STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
-      STAGEGATE_WAITFOR_TIMEOUT: 60s
-    hostname: edgex-core-metadata
-    image: nexus3.edgexfoundry.org:10004/core-metadata:latest
-    networks:
-      edgex-network: null
-    ports:
-    - mode: ingress
-      host_ip: 127.0.0.1
-      target: 59881
-      published: "59881"
-      protocol: tcp
-    read_only: true
-    restart: always
-    security_opt:
-    - no-new-privileges:true
-    user: 2002:2001
-    volumes:
-    - type: volume
-      source: edgex-init
-      target: /edgex-init
-      read_only: true
-      volume: {}
-    - type: bind
-      source: /tmp/edgex/secrets/core-metadata
-      target: /tmp/edgex/secrets/core-metadata
-      read_only: true
-      bind:
-        selinux: z
-        create_host_path: true
   nginx:
     command:
     - /docker-entrypoint.sh
@@ -674,7 +674,7 @@ services:
     - daemon off;
     container_name: edgex-nginx
     depends_on:
-      secretstore-setup:
+      security-secretstore-setup:
         condition: service_started
     entrypoint:
     - /bin/sh
@@ -727,206 +727,14 @@ services:
       source: nginx-tls
       target: /etc/ssl/nginx
       volume: {}
-  notifications:
-    command:
-    - /support-notifications
-    - -cp=consul.http://edgex-core-consul:8500
-    - --registry
-    container_name: edgex-support-notifications
-    depends_on:
-      consul:
-        condition: service_started
-      database:
-        condition: service_started
-      secretstore-setup:
-        condition: service_started
-      security-bootstrapper:
-        condition: service_started
-    entrypoint:
-    - /edgex-init/ready_to_run_wait_install.sh
-    environment:
-      EDGEX_SECURITY_SECRET_STORE: "true"
-      PROXY_SETUP_HOST: edgex-security-proxy-setup
-      SECRETSTORE_HOST: edgex-vault
-      SERVICE_HOST: edgex-support-notifications
-      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
-      STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: "6379"
-      STAGEGATE_DATABASE_READYPORT: "6379"
-      STAGEGATE_READY_TORUNPORT: "54329"
-      STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: "8500"
-      STAGEGATE_REGISTRY_READYPORT: "54324"
-      STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
-      STAGEGATE_WAITFOR_TIMEOUT: 60s
-    hostname: edgex-support-notifications
-    image: nexus3.edgexfoundry.org:10004/support-notifications:latest
-    networks:
-      edgex-network: null
-    ports:
-    - mode: ingress
-      host_ip: 127.0.0.1
-      target: 59860
-      published: "59860"
-      protocol: tcp
-    read_only: true
-    restart: always
-    security_opt:
-    - no-new-privileges:true
-    user: 2002:2001
-    volumes:
-    - type: volume
-      source: edgex-init
-      target: /edgex-init
-      read_only: true
-      volume: {}
-    - type: bind
-      source: /tmp/edgex/secrets/support-notifications
-      target: /tmp/edgex/secrets/support-notifications
-      read_only: true
-      bind:
-        selinux: z
-        create_host_path: true
-  proxy-auth:
-    command:
-    - entrypoint.sh
-    - /security-proxy-auth
-    - -cp=consul.http://edgex-core-consul:8500
-    - --registry
-    container_name: edgex-proxy-auth
-    depends_on:
-      secretstore-setup:
-        condition: service_started
-    entrypoint:
-    - /bin/sh
-    - /edgex-init/ready_to_run_wait_install.sh
-    environment:
-      EDGEX_SECURITY_SECRET_STORE: "true"
-      PROXY_SETUP_HOST: edgex-security-proxy-setup
-      SECRETSTORE_HOST: edgex-vault
-      SERVICE_HOST: edgex-proxy-auth
-      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
-      STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: "6379"
-      STAGEGATE_DATABASE_READYPORT: "6379"
-      STAGEGATE_READY_TORUNPORT: "54329"
-      STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: "8500"
-      STAGEGATE_REGISTRY_READYPORT: "54324"
-      STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
-      STAGEGATE_WAITFOR_TIMEOUT: 60s
-    hostname: edgex-proxy-auth
-    image: nexus3.edgexfoundry.org:10004/security-proxy-auth:latest
-    networks:
-      edgex-network: null
-    ports:
-    - mode: ingress
-      host_ip: 127.0.0.1
-      target: 59842
-      published: "59842"
-      protocol: tcp
-    read_only: true
-    restart: always
-    security_opt:
-    - no-new-privileges:true
-    volumes:
-    - type: volume
-      source: edgex-init
-      target: /edgex-init
-      read_only: true
-      volume: {}
-    - type: bind
-      source: /tmp/edgex/secrets/security-proxy-auth
-      target: /tmp/edgex/secrets/security-proxy-auth
-      read_only: true
-      bind:
-        selinux: z
-        create_host_path: true
-  proxy-setup:
-    container_name: edgex-security-proxy-setup
-    depends_on:
-      secretstore-setup:
-        condition: service_started
-      security-bootstrapper:
-        condition: service_started
-    entrypoint:
-    - /edgex-init/proxy_setup_wait_install.sh
-    environment:
-      ADD_PROXY_ROUTE: ""
-      EDGEX_SECURITY_SECRET_STORE: "true"
-      PROXY_SETUP_HOST: edgex-security-proxy-setup
-      ROUTES_CORE_COMMAND_HOST: edgex-core-command
-      ROUTES_CORE_CONSUL_HOST: edgex-core-consul
-      ROUTES_CORE_DATA_HOST: edgex-core-data
-      ROUTES_CORE_METADATA_HOST: edgex-core-metadata
-      ROUTES_DEVICE_VIRTUAL_HOST: device-virtual
-      ROUTES_RULES_ENGINE_HOST: edgex-kuiper
-      ROUTES_SUPPORT_NOTIFICATIONS_HOST: edgex-support-notifications
-      ROUTES_SUPPORT_SCHEDULER_HOST: edgex-support-scheduler
-      ROUTES_SYS_MGMT_AGENT_HOST: edgex-sys-mgmt-agent
-      SECRETSTORE_HOST: edgex-vault
-      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
-      STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: "6379"
-      STAGEGATE_DATABASE_READYPORT: "6379"
-      STAGEGATE_READY_TORUNPORT: "54329"
-      STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: "8500"
-      STAGEGATE_REGISTRY_READYPORT: "54324"
-      STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
-      STAGEGATE_WAITFOR_TIMEOUT: 60s
-    hostname: edgex-security-proxy-setup
-    image: nexus3.edgexfoundry.org:10004/security-proxy-setup:latest
-    networks:
-      edgex-network: null
-    read_only: true
-    security_opt:
-    - no-new-privileges:true
-    user: root:root
-    volumes:
-    - type: volume
-      source: edgex-init
-      target: /edgex-init
-      read_only: true
-      volume: {}
-    - type: volume
-      source: vault-config
-      target: /vault/config
-      volume: {}
-    - type: volume
-      source: nginx-templates
-      target: /etc/nginx/templates
-      volume: {}
-    - type: volume
-      source: nginx-tls
-      target: /etc/ssl/nginx
-      volume: {}
-    - type: bind
-      source: /tmp/edgex/secrets/security-proxy-setup
-      target: /tmp/edgex/secrets/security-proxy-setup
-      read_only: true
-      bind:
-        selinux: z
-        create_host_path: true
-    - type: volume
-      source: consul-acl-token
-      target: /tmp/edgex/secrets/consul-acl-token
-      read_only: true
-      volume: {}
-  rulesengine:
+  rules-engine:
     container_name: edgex-kuiper
     depends_on:
       database:
         condition: service_started
-      secretstore-setup:
-        condition: service_started
       security-bootstrapper:
+        condition: service_started
+      security-secretstore-setup:
         condition: service_started
     entrypoint:
     - /edgex-init/kuiper_wait_install.sh
@@ -1000,30 +808,12 @@ services:
       source: kuiper-plugins
       target: /kuiper/plugins
       volume: {}
-  scheduler:
-    command:
-    - /support-scheduler
-    - -cp=consul.http://edgex-core-consul:8500
-    - --registry
-    container_name: edgex-support-scheduler
-    depends_on:
-      consul:
-        condition: service_started
-      database:
-        condition: service_started
-      secretstore-setup:
-        condition: service_started
-      security-bootstrapper:
-        condition: service_started
-    entrypoint:
-    - /edgex-init/ready_to_run_wait_install.sh
+  security-bootstrapper:
+    container_name: edgex-security-bootstrapper
     environment:
-      EDGEX_SECURITY_SECRET_STORE: "true"
-      INTERVALACTIONS_SCRUBAGED_HOST: edgex-core-data
-      INTERVALACTIONS_SCRUBPUSHED_HOST: edgex-core-data
+      EDGEX_GROUP: "2001"
+      EDGEX_USER: "2002"
       PROXY_SETUP_HOST: edgex-security-proxy-setup
-      SECRETSTORE_HOST: edgex-vault
-      SERVICE_HOST: edgex-support-scheduler
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
       STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
@@ -1036,21 +826,64 @@ services:
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
       STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
-    hostname: edgex-support-scheduler
-    image: nexus3.edgexfoundry.org:10004/support-scheduler:latest
+    hostname: edgex-security-bootstrapper
+    image: nexus3.edgexfoundry.org:10004/security-bootstrapper:latest
+    networks:
+      edgex-network: null
+    read_only: true
+    restart: always
+    security_opt:
+    - no-new-privileges:true
+    user: root:root
+    volumes:
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      volume: {}
+  security-proxy-auth:
+    command:
+    - entrypoint.sh
+    - /security-proxy-auth
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
+    container_name: edgex-proxy-auth
+    depends_on:
+      security-secretstore-setup:
+        condition: service_started
+    entrypoint:
+    - /bin/sh
+    - /edgex-init/ready_to_run_wait_install.sh
+    environment:
+      EDGEX_SECURITY_SECRET_STORE: "true"
+      PROXY_SETUP_HOST: edgex-security-proxy-setup
+      SECRETSTORE_HOST: edgex-vault
+      SERVICE_HOST: edgex-proxy-auth
+      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
+      STAGEGATE_DATABASE_HOST: edgex-redis
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
+      STAGEGATE_READY_TORUNPORT: "54329"
+      STAGEGATE_REGISTRY_HOST: edgex-core-consul
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
+      STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
+      STAGEGATE_WAITFOR_TIMEOUT: 60s
+    hostname: edgex-proxy-auth
+    image: nexus3.edgexfoundry.org:10004/security-proxy-auth:latest
     networks:
       edgex-network: null
     ports:
     - mode: ingress
       host_ip: 127.0.0.1
-      target: 59861
-      published: "59861"
+      target: 59842
+      published: "59842"
       protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
-    user: 2002:2001
     volumes:
     - type: volume
       source: edgex-init
@@ -1058,13 +891,86 @@ services:
       read_only: true
       volume: {}
     - type: bind
-      source: /tmp/edgex/secrets/support-scheduler
-      target: /tmp/edgex/secrets/support-scheduler
+      source: /tmp/edgex/secrets/security-proxy-auth
+      target: /tmp/edgex/secrets/security-proxy-auth
       read_only: true
       bind:
         selinux: z
         create_host_path: true
-  secretstore-setup:
+  security-proxy-setup:
+    container_name: edgex-security-proxy-setup
+    depends_on:
+      security-bootstrapper:
+        condition: service_started
+      security-secretstore-setup:
+        condition: service_started
+    entrypoint:
+    - /edgex-init/proxy_setup_wait_install.sh
+    environment:
+      ADD_PROXY_ROUTE: ""
+      EDGEX_SECURITY_SECRET_STORE: "true"
+      PROXY_SETUP_HOST: edgex-security-proxy-setup
+      ROUTES_CORE_COMMAND_HOST: edgex-core-command
+      ROUTES_CORE_CONSUL_HOST: edgex-core-consul
+      ROUTES_CORE_DATA_HOST: edgex-core-data
+      ROUTES_CORE_METADATA_HOST: edgex-core-metadata
+      ROUTES_DEVICE_VIRTUAL_HOST: device-virtual
+      ROUTES_RULES_ENGINE_HOST: edgex-kuiper
+      ROUTES_SUPPORT_NOTIFICATIONS_HOST: edgex-support-notifications
+      ROUTES_SUPPORT_SCHEDULER_HOST: edgex-support-scheduler
+      ROUTES_SYS_MGMT_AGENT_HOST: edgex-sys-mgmt-agent
+      SECRETSTORE_HOST: edgex-vault
+      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
+      STAGEGATE_DATABASE_HOST: edgex-redis
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
+      STAGEGATE_READY_TORUNPORT: "54329"
+      STAGEGATE_REGISTRY_HOST: edgex-core-consul
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
+      STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
+      STAGEGATE_WAITFOR_TIMEOUT: 60s
+    hostname: edgex-security-proxy-setup
+    image: nexus3.edgexfoundry.org:10004/security-proxy-setup:latest
+    networks:
+      edgex-network: null
+    read_only: true
+    security_opt:
+    - no-new-privileges:true
+    user: root:root
+    volumes:
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      volume: {}
+    - type: volume
+      source: vault-config
+      target: /vault/config
+      volume: {}
+    - type: volume
+      source: nginx-templates
+      target: /etc/nginx/templates
+      volume: {}
+    - type: volume
+      source: nginx-tls
+      target: /etc/ssl/nginx
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/security-proxy-setup
+      target: /tmp/edgex/secrets/security-proxy-setup
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
+    - type: volume
+      source: consul-acl-token
+      target: /tmp/edgex/secrets/consul-acl-token
+      read_only: true
+      volume: {}
+  security-secretstore-setup:
     container_name: edgex-security-secretstore-setup
     depends_on:
       security-bootstrapper:
@@ -1128,12 +1034,28 @@ services:
       source: vault-config
       target: /vault/config
       volume: {}
-  security-bootstrapper:
-    container_name: edgex-security-bootstrapper
+  support-notifications:
+    command:
+    - /support-notifications
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
+    container_name: edgex-support-notifications
+    depends_on:
+      consul:
+        condition: service_started
+      database:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
+      security-secretstore-setup:
+        condition: service_started
+    entrypoint:
+    - /edgex-init/ready_to_run_wait_install.sh
     environment:
-      EDGEX_GROUP: "2001"
-      EDGEX_USER: "2002"
+      EDGEX_SECURITY_SECRET_STORE: "true"
       PROXY_SETUP_HOST: edgex-security-proxy-setup
+      SECRETSTORE_HOST: edgex-vault
+      SERVICE_HOST: edgex-support-notifications
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
       STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
@@ -1146,20 +1068,98 @@ services:
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
       STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
-    hostname: edgex-security-bootstrapper
-    image: nexus3.edgexfoundry.org:10004/security-bootstrapper:latest
+    hostname: edgex-support-notifications
+    image: nexus3.edgexfoundry.org:10004/support-notifications:latest
     networks:
       edgex-network: null
+    ports:
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59860
+      published: "59860"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
-    user: root:root
+    user: 2002:2001
     volumes:
     - type: volume
       source: edgex-init
       target: /edgex-init
+      read_only: true
       volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/support-notifications
+      target: /tmp/edgex/secrets/support-notifications
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
+  support-scheduler:
+    command:
+    - /support-scheduler
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
+    container_name: edgex-support-scheduler
+    depends_on:
+      consul:
+        condition: service_started
+      database:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
+      security-secretstore-setup:
+        condition: service_started
+    entrypoint:
+    - /edgex-init/ready_to_run_wait_install.sh
+    environment:
+      EDGEX_SECURITY_SECRET_STORE: "true"
+      INTERVALACTIONS_SCRUBAGED_HOST: edgex-core-data
+      INTERVALACTIONS_SCRUBPUSHED_HOST: edgex-core-data
+      PROXY_SETUP_HOST: edgex-security-proxy-setup
+      SECRETSTORE_HOST: edgex-vault
+      SERVICE_HOST: edgex-support-scheduler
+      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
+      STAGEGATE_DATABASE_HOST: edgex-redis
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
+      STAGEGATE_READY_TORUNPORT: "54329"
+      STAGEGATE_REGISTRY_HOST: edgex-core-consul
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
+      STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
+      STAGEGATE_WAITFOR_TIMEOUT: 60s
+    hostname: edgex-support-scheduler
+    image: nexus3.edgexfoundry.org:10004/support-scheduler:latest
+    networks:
+      edgex-network: null
+    ports:
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59861
+      published: "59861"
+      protocol: tcp
+    read_only: true
+    restart: always
+    security_opt:
+    - no-new-privileges:true
+    user: 2002:2001
+    volumes:
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/support-scheduler
+      target: /tmp/edgex/secrets/support-scheduler
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   ui:
     container_name: edgex-ui-go
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,7 @@
 #
 name: edgex
 services:
-  app-service-rules:
+  app-rules-engine:
     command:
     - /app-service-configurable
     - -cp=consul.http://edgex-core-consul:8500
@@ -35,7 +35,7 @@ services:
     depends_on:
       consul:
         condition: service_started
-      data:
+      core-data:
         condition: service_started
       security-bootstrapper:
         condition: service_started
@@ -83,128 +83,6 @@ services:
     - type: bind
       source: /tmp/edgex/secrets/app-rules-engine
       target: /tmp/edgex/secrets/app-rules-engine
-      read_only: true
-      bind:
-        selinux: z
-        create_host_path: true
-  command:
-    command:
-    - /core-command
-    - -cp=consul.http://edgex-core-consul:8500
-    - --registry
-    container_name: edgex-core-command
-    depends_on:
-      consul:
-        condition: service_started
-      database:
-        condition: service_started
-      metadata:
-        condition: service_started
-      secretstore-setup:
-        condition: service_started
-      security-bootstrapper:
-        condition: service_started
-    entrypoint:
-    - /edgex-init/ready_to_run_wait_install.sh
-    environment:
-      EDGEX_SECURITY_SECRET_STORE: "true"
-      EXTERNALMQTT_URL: tcp://edgex-mqtt-broker:1883
-      PROXY_SETUP_HOST: edgex-security-proxy-setup
-      SECRETSTORE_HOST: edgex-vault
-      SERVICE_HOST: edgex-core-command
-      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
-      STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: "6379"
-      STAGEGATE_DATABASE_READYPORT: "6379"
-      STAGEGATE_READY_TORUNPORT: "54329"
-      STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: "8500"
-      STAGEGATE_REGISTRY_READYPORT: "54324"
-      STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
-      STAGEGATE_WAITFOR_TIMEOUT: 60s
-    hostname: edgex-core-command
-    image: nexus3.edgexfoundry.org:10004/core-command:latest
-    networks:
-      edgex-network: null
-    ports:
-    - mode: ingress
-      host_ip: 127.0.0.1
-      target: 59882
-      published: "59882"
-      protocol: tcp
-    read_only: true
-    restart: always
-    security_opt:
-    - no-new-privileges:true
-    user: 2002:2001
-    volumes:
-    - type: volume
-      source: edgex-init
-      target: /edgex-init
-      read_only: true
-      volume: {}
-    - type: bind
-      source: /tmp/edgex/secrets/core-command
-      target: /tmp/edgex/secrets/core-command
-      read_only: true
-      bind:
-        selinux: z
-        create_host_path: true
-  common-config:
-    command:
-    - /entrypoint.sh
-    - /core-common-config-bootstrapper
-    - -cp=consul.http://edgex-core-consul:8500
-    container_name: edgex-core-common-config-bootstrapper
-    depends_on:
-      consul:
-        condition: service_started
-      secretstore-setup:
-        condition: service_started
-      security-bootstrapper:
-        condition: service_started
-    entrypoint:
-    - /edgex-init/ready_to_run_wait_install.sh
-    environment:
-      ALL_SERVICES_DATABASE_HOST: edgex-redis
-      ALL_SERVICES_MESSAGEBUS_HOST: edgex-redis
-      ALL_SERVICES_REGISTRY_HOST: edgex-core-consul
-      APP_SERVICES_CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
-      DEVICE_SERVICES_CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
-      EDGEX_SECURITY_SECRET_STORE: "true"
-      PROXY_SETUP_HOST: edgex-security-proxy-setup
-      SECRETSTORE_HOST: edgex-vault
-      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
-      STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: "6379"
-      STAGEGATE_DATABASE_READYPORT: "6379"
-      STAGEGATE_READY_TORUNPORT: "54329"
-      STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: "8500"
-      STAGEGATE_REGISTRY_READYPORT: "54324"
-      STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
-      STAGEGATE_WAITFOR_TIMEOUT: 60s
-    hostname: edgex-core-common-config-bootstrapper
-    image: nexus3.edgexfoundry.org:10004/core-common-config-bootstrapper:latest
-    networks:
-      edgex-network: null
-    read_only: true
-    security_opt:
-    - no-new-privileges:true
-    user: 2002:2001
-    volumes:
-    - type: volume
-      source: edgex-init
-      target: /edgex-init
-      read_only: true
-      volume: {}
-    - type: bind
-      source: /tmp/edgex/secrets/core-common-config-bootstrapper
-      target: /tmp/edgex/secrets/core-common-config-bootstrapper
       read_only: true
       bind:
         selinux: z
@@ -287,7 +165,129 @@ services:
       bind:
         selinux: z
         create_host_path: true
-  data:
+  core-command:
+    command:
+    - /core-command
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
+    container_name: edgex-core-command
+    depends_on:
+      consul:
+        condition: service_started
+      core-metadata:
+        condition: service_started
+      database:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
+      security-secretstore-setup:
+        condition: service_started
+    entrypoint:
+    - /edgex-init/ready_to_run_wait_install.sh
+    environment:
+      EDGEX_SECURITY_SECRET_STORE: "true"
+      EXTERNALMQTT_URL: tcp://edgex-mqtt-broker:1883
+      PROXY_SETUP_HOST: edgex-security-proxy-setup
+      SECRETSTORE_HOST: edgex-vault
+      SERVICE_HOST: edgex-core-command
+      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
+      STAGEGATE_DATABASE_HOST: edgex-redis
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
+      STAGEGATE_READY_TORUNPORT: "54329"
+      STAGEGATE_REGISTRY_HOST: edgex-core-consul
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
+      STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
+      STAGEGATE_WAITFOR_TIMEOUT: 60s
+    hostname: edgex-core-command
+    image: nexus3.edgexfoundry.org:10004/core-command:latest
+    networks:
+      edgex-network: null
+    ports:
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59882
+      published: "59882"
+      protocol: tcp
+    read_only: true
+    restart: always
+    security_opt:
+    - no-new-privileges:true
+    user: 2002:2001
+    volumes:
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/core-command
+      target: /tmp/edgex/secrets/core-command
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
+  core-common-config-bootstrapper:
+    command:
+    - /entrypoint.sh
+    - /core-common-config-bootstrapper
+    - -cp=consul.http://edgex-core-consul:8500
+    container_name: edgex-core-common-config-bootstrapper
+    depends_on:
+      consul:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
+      security-secretstore-setup:
+        condition: service_started
+    entrypoint:
+    - /edgex-init/ready_to_run_wait_install.sh
+    environment:
+      ALL_SERVICES_DATABASE_HOST: edgex-redis
+      ALL_SERVICES_MESSAGEBUS_HOST: edgex-redis
+      ALL_SERVICES_REGISTRY_HOST: edgex-core-consul
+      APP_SERVICES_CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
+      DEVICE_SERVICES_CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
+      EDGEX_SECURITY_SECRET_STORE: "true"
+      PROXY_SETUP_HOST: edgex-security-proxy-setup
+      SECRETSTORE_HOST: edgex-vault
+      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
+      STAGEGATE_DATABASE_HOST: edgex-redis
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
+      STAGEGATE_READY_TORUNPORT: "54329"
+      STAGEGATE_REGISTRY_HOST: edgex-core-consul
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
+      STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
+      STAGEGATE_WAITFOR_TIMEOUT: 60s
+    hostname: edgex-core-common-config-bootstrapper
+    image: nexus3.edgexfoundry.org:10004/core-common-config-bootstrapper:latest
+    networks:
+      edgex-network: null
+    read_only: true
+    security_opt:
+    - no-new-privileges:true
+    user: 2002:2001
+    volumes:
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/core-common-config-bootstrapper
+      target: /tmp/edgex/secrets/core-common-config-bootstrapper
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
+  core-data:
     command:
     - /core-data
     - -cp=consul.http://edgex-core-consul:8500
@@ -296,13 +296,13 @@ services:
     depends_on:
       consul:
         condition: service_started
+      core-metadata:
+        condition: service_started
       database:
         condition: service_started
-      metadata:
-        condition: service_started
-      secretstore-setup:
-        condition: service_started
       security-bootstrapper:
+        condition: service_started
+      security-secretstore-setup:
         condition: service_started
     entrypoint:
     - /edgex-init/ready_to_run_wait_install.sh
@@ -351,12 +351,74 @@ services:
       bind:
         selinux: z
         create_host_path: true
+  core-metadata:
+    command:
+    - /core-metadata
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
+    container_name: edgex-core-metadata
+    depends_on:
+      consul:
+        condition: service_started
+      database:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
+      security-secretstore-setup:
+        condition: service_started
+    entrypoint:
+    - /edgex-init/ready_to_run_wait_install.sh
+    environment:
+      EDGEX_SECURITY_SECRET_STORE: "true"
+      PROXY_SETUP_HOST: edgex-security-proxy-setup
+      SECRETSTORE_HOST: edgex-vault
+      SERVICE_HOST: edgex-core-metadata
+      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
+      STAGEGATE_DATABASE_HOST: edgex-redis
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
+      STAGEGATE_READY_TORUNPORT: "54329"
+      STAGEGATE_REGISTRY_HOST: edgex-core-consul
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
+      STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
+      STAGEGATE_WAITFOR_TIMEOUT: 60s
+    hostname: edgex-core-metadata
+    image: nexus3.edgexfoundry.org:10004/core-metadata:latest
+    networks:
+      edgex-network: null
+    ports:
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59881
+      published: "59881"
+      protocol: tcp
+    read_only: true
+    restart: always
+    security_opt:
+    - no-new-privileges:true
+    user: 2002:2001
+    volumes:
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/core-metadata
+      target: /tmp/edgex/secrets/core-metadata
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   database:
     container_name: edgex-redis
     depends_on:
-      secretstore-setup:
-        condition: service_started
       security-bootstrapper:
+        condition: service_started
+      security-secretstore-setup:
         condition: service_started
     entrypoint:
     - /edgex-init/redis_wait_install.sh
@@ -425,9 +487,9 @@ services:
     depends_on:
       consul:
         condition: service_started
-      data:
+      core-data:
         condition: service_started
-      metadata:
+      core-metadata:
         condition: service_started
       security-bootstrapper:
         condition: service_started
@@ -487,9 +549,9 @@ services:
     depends_on:
       consul:
         condition: service_started
-      data:
+      core-data:
         condition: service_started
-      metadata:
+      core-metadata:
         condition: service_started
       security-bootstrapper:
         condition: service_started
@@ -540,68 +602,6 @@ services:
       bind:
         selinux: z
         create_host_path: true
-  metadata:
-    command:
-    - /core-metadata
-    - -cp=consul.http://edgex-core-consul:8500
-    - --registry
-    container_name: edgex-core-metadata
-    depends_on:
-      consul:
-        condition: service_started
-      database:
-        condition: service_started
-      secretstore-setup:
-        condition: service_started
-      security-bootstrapper:
-        condition: service_started
-    entrypoint:
-    - /edgex-init/ready_to_run_wait_install.sh
-    environment:
-      EDGEX_SECURITY_SECRET_STORE: "true"
-      PROXY_SETUP_HOST: edgex-security-proxy-setup
-      SECRETSTORE_HOST: edgex-vault
-      SERVICE_HOST: edgex-core-metadata
-      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
-      STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: "6379"
-      STAGEGATE_DATABASE_READYPORT: "6379"
-      STAGEGATE_READY_TORUNPORT: "54329"
-      STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: "8500"
-      STAGEGATE_REGISTRY_READYPORT: "54324"
-      STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
-      STAGEGATE_WAITFOR_TIMEOUT: 60s
-    hostname: edgex-core-metadata
-    image: nexus3.edgexfoundry.org:10004/core-metadata:latest
-    networks:
-      edgex-network: null
-    ports:
-    - mode: ingress
-      host_ip: 127.0.0.1
-      target: 59881
-      published: "59881"
-      protocol: tcp
-    read_only: true
-    restart: always
-    security_opt:
-    - no-new-privileges:true
-    user: 2002:2001
-    volumes:
-    - type: volume
-      source: edgex-init
-      target: /edgex-init
-      read_only: true
-      volume: {}
-    - type: bind
-      source: /tmp/edgex/secrets/core-metadata
-      target: /tmp/edgex/secrets/core-metadata
-      read_only: true
-      bind:
-        selinux: z
-        create_host_path: true
   nginx:
     command:
     - /docker-entrypoint.sh
@@ -610,7 +610,7 @@ services:
     - daemon off;
     container_name: edgex-nginx
     depends_on:
-      secretstore-setup:
+      security-secretstore-setup:
         condition: service_started
     entrypoint:
     - /bin/sh
@@ -663,206 +663,14 @@ services:
       source: nginx-tls
       target: /etc/ssl/nginx
       volume: {}
-  notifications:
-    command:
-    - /support-notifications
-    - -cp=consul.http://edgex-core-consul:8500
-    - --registry
-    container_name: edgex-support-notifications
-    depends_on:
-      consul:
-        condition: service_started
-      database:
-        condition: service_started
-      secretstore-setup:
-        condition: service_started
-      security-bootstrapper:
-        condition: service_started
-    entrypoint:
-    - /edgex-init/ready_to_run_wait_install.sh
-    environment:
-      EDGEX_SECURITY_SECRET_STORE: "true"
-      PROXY_SETUP_HOST: edgex-security-proxy-setup
-      SECRETSTORE_HOST: edgex-vault
-      SERVICE_HOST: edgex-support-notifications
-      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
-      STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: "6379"
-      STAGEGATE_DATABASE_READYPORT: "6379"
-      STAGEGATE_READY_TORUNPORT: "54329"
-      STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: "8500"
-      STAGEGATE_REGISTRY_READYPORT: "54324"
-      STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
-      STAGEGATE_WAITFOR_TIMEOUT: 60s
-    hostname: edgex-support-notifications
-    image: nexus3.edgexfoundry.org:10004/support-notifications:latest
-    networks:
-      edgex-network: null
-    ports:
-    - mode: ingress
-      host_ip: 127.0.0.1
-      target: 59860
-      published: "59860"
-      protocol: tcp
-    read_only: true
-    restart: always
-    security_opt:
-    - no-new-privileges:true
-    user: 2002:2001
-    volumes:
-    - type: volume
-      source: edgex-init
-      target: /edgex-init
-      read_only: true
-      volume: {}
-    - type: bind
-      source: /tmp/edgex/secrets/support-notifications
-      target: /tmp/edgex/secrets/support-notifications
-      read_only: true
-      bind:
-        selinux: z
-        create_host_path: true
-  proxy-auth:
-    command:
-    - entrypoint.sh
-    - /security-proxy-auth
-    - -cp=consul.http://edgex-core-consul:8500
-    - --registry
-    container_name: edgex-proxy-auth
-    depends_on:
-      secretstore-setup:
-        condition: service_started
-    entrypoint:
-    - /bin/sh
-    - /edgex-init/ready_to_run_wait_install.sh
-    environment:
-      EDGEX_SECURITY_SECRET_STORE: "true"
-      PROXY_SETUP_HOST: edgex-security-proxy-setup
-      SECRETSTORE_HOST: edgex-vault
-      SERVICE_HOST: edgex-proxy-auth
-      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
-      STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: "6379"
-      STAGEGATE_DATABASE_READYPORT: "6379"
-      STAGEGATE_READY_TORUNPORT: "54329"
-      STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: "8500"
-      STAGEGATE_REGISTRY_READYPORT: "54324"
-      STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
-      STAGEGATE_WAITFOR_TIMEOUT: 60s
-    hostname: edgex-proxy-auth
-    image: nexus3.edgexfoundry.org:10004/security-proxy-auth:latest
-    networks:
-      edgex-network: null
-    ports:
-    - mode: ingress
-      host_ip: 127.0.0.1
-      target: 59842
-      published: "59842"
-      protocol: tcp
-    read_only: true
-    restart: always
-    security_opt:
-    - no-new-privileges:true
-    volumes:
-    - type: volume
-      source: edgex-init
-      target: /edgex-init
-      read_only: true
-      volume: {}
-    - type: bind
-      source: /tmp/edgex/secrets/security-proxy-auth
-      target: /tmp/edgex/secrets/security-proxy-auth
-      read_only: true
-      bind:
-        selinux: z
-        create_host_path: true
-  proxy-setup:
-    container_name: edgex-security-proxy-setup
-    depends_on:
-      secretstore-setup:
-        condition: service_started
-      security-bootstrapper:
-        condition: service_started
-    entrypoint:
-    - /edgex-init/proxy_setup_wait_install.sh
-    environment:
-      ADD_PROXY_ROUTE: ""
-      EDGEX_SECURITY_SECRET_STORE: "true"
-      PROXY_SETUP_HOST: edgex-security-proxy-setup
-      ROUTES_CORE_COMMAND_HOST: edgex-core-command
-      ROUTES_CORE_CONSUL_HOST: edgex-core-consul
-      ROUTES_CORE_DATA_HOST: edgex-core-data
-      ROUTES_CORE_METADATA_HOST: edgex-core-metadata
-      ROUTES_DEVICE_VIRTUAL_HOST: device-virtual
-      ROUTES_RULES_ENGINE_HOST: edgex-kuiper
-      ROUTES_SUPPORT_NOTIFICATIONS_HOST: edgex-support-notifications
-      ROUTES_SUPPORT_SCHEDULER_HOST: edgex-support-scheduler
-      ROUTES_SYS_MGMT_AGENT_HOST: edgex-sys-mgmt-agent
-      SECRETSTORE_HOST: edgex-vault
-      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
-      STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: "6379"
-      STAGEGATE_DATABASE_READYPORT: "6379"
-      STAGEGATE_READY_TORUNPORT: "54329"
-      STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: "8500"
-      STAGEGATE_REGISTRY_READYPORT: "54324"
-      STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
-      STAGEGATE_WAITFOR_TIMEOUT: 60s
-    hostname: edgex-security-proxy-setup
-    image: nexus3.edgexfoundry.org:10004/security-proxy-setup:latest
-    networks:
-      edgex-network: null
-    read_only: true
-    security_opt:
-    - no-new-privileges:true
-    user: root:root
-    volumes:
-    - type: volume
-      source: edgex-init
-      target: /edgex-init
-      read_only: true
-      volume: {}
-    - type: volume
-      source: vault-config
-      target: /vault/config
-      volume: {}
-    - type: volume
-      source: nginx-templates
-      target: /etc/nginx/templates
-      volume: {}
-    - type: volume
-      source: nginx-tls
-      target: /etc/ssl/nginx
-      volume: {}
-    - type: bind
-      source: /tmp/edgex/secrets/security-proxy-setup
-      target: /tmp/edgex/secrets/security-proxy-setup
-      read_only: true
-      bind:
-        selinux: z
-        create_host_path: true
-    - type: volume
-      source: consul-acl-token
-      target: /tmp/edgex/secrets/consul-acl-token
-      read_only: true
-      volume: {}
-  rulesengine:
+  rules-engine:
     container_name: edgex-kuiper
     depends_on:
       database:
         condition: service_started
-      secretstore-setup:
-        condition: service_started
       security-bootstrapper:
+        condition: service_started
+      security-secretstore-setup:
         condition: service_started
     entrypoint:
     - /edgex-init/kuiper_wait_install.sh
@@ -936,30 +744,12 @@ services:
       source: kuiper-plugins
       target: /kuiper/plugins
       volume: {}
-  scheduler:
-    command:
-    - /support-scheduler
-    - -cp=consul.http://edgex-core-consul:8500
-    - --registry
-    container_name: edgex-support-scheduler
-    depends_on:
-      consul:
-        condition: service_started
-      database:
-        condition: service_started
-      secretstore-setup:
-        condition: service_started
-      security-bootstrapper:
-        condition: service_started
-    entrypoint:
-    - /edgex-init/ready_to_run_wait_install.sh
+  security-bootstrapper:
+    container_name: edgex-security-bootstrapper
     environment:
-      EDGEX_SECURITY_SECRET_STORE: "true"
-      INTERVALACTIONS_SCRUBAGED_HOST: edgex-core-data
-      INTERVALACTIONS_SCRUBPUSHED_HOST: edgex-core-data
+      EDGEX_GROUP: "2001"
+      EDGEX_USER: "2002"
       PROXY_SETUP_HOST: edgex-security-proxy-setup
-      SECRETSTORE_HOST: edgex-vault
-      SERVICE_HOST: edgex-support-scheduler
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
       STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
@@ -972,21 +762,64 @@ services:
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
       STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
-    hostname: edgex-support-scheduler
-    image: nexus3.edgexfoundry.org:10004/support-scheduler:latest
+    hostname: edgex-security-bootstrapper
+    image: nexus3.edgexfoundry.org:10004/security-bootstrapper:latest
+    networks:
+      edgex-network: null
+    read_only: true
+    restart: always
+    security_opt:
+    - no-new-privileges:true
+    user: root:root
+    volumes:
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      volume: {}
+  security-proxy-auth:
+    command:
+    - entrypoint.sh
+    - /security-proxy-auth
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
+    container_name: edgex-proxy-auth
+    depends_on:
+      security-secretstore-setup:
+        condition: service_started
+    entrypoint:
+    - /bin/sh
+    - /edgex-init/ready_to_run_wait_install.sh
+    environment:
+      EDGEX_SECURITY_SECRET_STORE: "true"
+      PROXY_SETUP_HOST: edgex-security-proxy-setup
+      SECRETSTORE_HOST: edgex-vault
+      SERVICE_HOST: edgex-proxy-auth
+      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
+      STAGEGATE_DATABASE_HOST: edgex-redis
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
+      STAGEGATE_READY_TORUNPORT: "54329"
+      STAGEGATE_REGISTRY_HOST: edgex-core-consul
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
+      STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
+      STAGEGATE_WAITFOR_TIMEOUT: 60s
+    hostname: edgex-proxy-auth
+    image: nexus3.edgexfoundry.org:10004/security-proxy-auth:latest
     networks:
       edgex-network: null
     ports:
     - mode: ingress
       host_ip: 127.0.0.1
-      target: 59861
-      published: "59861"
+      target: 59842
+      published: "59842"
       protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
-    user: 2002:2001
     volumes:
     - type: volume
       source: edgex-init
@@ -994,13 +827,86 @@ services:
       read_only: true
       volume: {}
     - type: bind
-      source: /tmp/edgex/secrets/support-scheduler
-      target: /tmp/edgex/secrets/support-scheduler
+      source: /tmp/edgex/secrets/security-proxy-auth
+      target: /tmp/edgex/secrets/security-proxy-auth
       read_only: true
       bind:
         selinux: z
         create_host_path: true
-  secretstore-setup:
+  security-proxy-setup:
+    container_name: edgex-security-proxy-setup
+    depends_on:
+      security-bootstrapper:
+        condition: service_started
+      security-secretstore-setup:
+        condition: service_started
+    entrypoint:
+    - /edgex-init/proxy_setup_wait_install.sh
+    environment:
+      ADD_PROXY_ROUTE: ""
+      EDGEX_SECURITY_SECRET_STORE: "true"
+      PROXY_SETUP_HOST: edgex-security-proxy-setup
+      ROUTES_CORE_COMMAND_HOST: edgex-core-command
+      ROUTES_CORE_CONSUL_HOST: edgex-core-consul
+      ROUTES_CORE_DATA_HOST: edgex-core-data
+      ROUTES_CORE_METADATA_HOST: edgex-core-metadata
+      ROUTES_DEVICE_VIRTUAL_HOST: device-virtual
+      ROUTES_RULES_ENGINE_HOST: edgex-kuiper
+      ROUTES_SUPPORT_NOTIFICATIONS_HOST: edgex-support-notifications
+      ROUTES_SUPPORT_SCHEDULER_HOST: edgex-support-scheduler
+      ROUTES_SYS_MGMT_AGENT_HOST: edgex-sys-mgmt-agent
+      SECRETSTORE_HOST: edgex-vault
+      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
+      STAGEGATE_DATABASE_HOST: edgex-redis
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
+      STAGEGATE_READY_TORUNPORT: "54329"
+      STAGEGATE_REGISTRY_HOST: edgex-core-consul
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
+      STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
+      STAGEGATE_WAITFOR_TIMEOUT: 60s
+    hostname: edgex-security-proxy-setup
+    image: nexus3.edgexfoundry.org:10004/security-proxy-setup:latest
+    networks:
+      edgex-network: null
+    read_only: true
+    security_opt:
+    - no-new-privileges:true
+    user: root:root
+    volumes:
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      volume: {}
+    - type: volume
+      source: vault-config
+      target: /vault/config
+      volume: {}
+    - type: volume
+      source: nginx-templates
+      target: /etc/nginx/templates
+      volume: {}
+    - type: volume
+      source: nginx-tls
+      target: /etc/ssl/nginx
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/security-proxy-setup
+      target: /tmp/edgex/secrets/security-proxy-setup
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
+    - type: volume
+      source: consul-acl-token
+      target: /tmp/edgex/secrets/consul-acl-token
+      read_only: true
+      volume: {}
+  security-secretstore-setup:
     container_name: edgex-security-secretstore-setup
     depends_on:
       security-bootstrapper:
@@ -1064,12 +970,28 @@ services:
       source: vault-config
       target: /vault/config
       volume: {}
-  security-bootstrapper:
-    container_name: edgex-security-bootstrapper
+  support-notifications:
+    command:
+    - /support-notifications
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
+    container_name: edgex-support-notifications
+    depends_on:
+      consul:
+        condition: service_started
+      database:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
+      security-secretstore-setup:
+        condition: service_started
+    entrypoint:
+    - /edgex-init/ready_to_run_wait_install.sh
     environment:
-      EDGEX_GROUP: "2001"
-      EDGEX_USER: "2002"
+      EDGEX_SECURITY_SECRET_STORE: "true"
       PROXY_SETUP_HOST: edgex-security-proxy-setup
+      SECRETSTORE_HOST: edgex-vault
+      SERVICE_HOST: edgex-support-notifications
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
       STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
@@ -1082,20 +1004,98 @@ services:
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
       STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
-    hostname: edgex-security-bootstrapper
-    image: nexus3.edgexfoundry.org:10004/security-bootstrapper:latest
+    hostname: edgex-support-notifications
+    image: nexus3.edgexfoundry.org:10004/support-notifications:latest
     networks:
       edgex-network: null
+    ports:
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59860
+      published: "59860"
+      protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
-    user: root:root
+    user: 2002:2001
     volumes:
     - type: volume
       source: edgex-init
       target: /edgex-init
+      read_only: true
       volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/support-notifications
+      target: /tmp/edgex/secrets/support-notifications
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
+  support-scheduler:
+    command:
+    - /support-scheduler
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
+    container_name: edgex-support-scheduler
+    depends_on:
+      consul:
+        condition: service_started
+      database:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
+      security-secretstore-setup:
+        condition: service_started
+    entrypoint:
+    - /edgex-init/ready_to_run_wait_install.sh
+    environment:
+      EDGEX_SECURITY_SECRET_STORE: "true"
+      INTERVALACTIONS_SCRUBAGED_HOST: edgex-core-data
+      INTERVALACTIONS_SCRUBPUSHED_HOST: edgex-core-data
+      PROXY_SETUP_HOST: edgex-security-proxy-setup
+      SECRETSTORE_HOST: edgex-vault
+      SERVICE_HOST: edgex-support-scheduler
+      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
+      STAGEGATE_DATABASE_HOST: edgex-redis
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
+      STAGEGATE_READY_TORUNPORT: "54329"
+      STAGEGATE_REGISTRY_HOST: edgex-core-consul
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
+      STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
+      STAGEGATE_WAITFOR_TIMEOUT: 60s
+    hostname: edgex-support-scheduler
+    image: nexus3.edgexfoundry.org:10004/support-scheduler:latest
+    networks:
+      edgex-network: null
+    ports:
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59861
+      published: "59861"
+      protocol: tcp
+    read_only: true
+    restart: always
+    security_opt:
+    - no-new-privileges:true
+    user: 2002:2001
+    volumes:
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/support-scheduler
+      target: /tmp/edgex/secrets/support-scheduler
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   ui:
     container_name: edgex-ui-go
     environment:

--- a/taf/docker-compose-taf-arm64.yml
+++ b/taf/docker-compose-taf-arm64.yml
@@ -26,7 +26,7 @@
 #
 name: edgex
 services:
-  app-service-external-mqtt-trigger:
+  app-external-mqtt-trigger:
     command:
     - /app-service-configurable
     - -cp=consul.http://edgex-core-consul:8500
@@ -35,7 +35,7 @@ services:
     depends_on:
       consul:
         condition: service_started
-      data:
+      core-data:
         condition: service_started
       security-bootstrapper:
         condition: service_started
@@ -91,16 +91,16 @@ services:
       bind:
         selinux: z
         create_host_path: true
-  app-service-functional-tests:
+  app-functional-tests:
     command:
     - /app-service-configurable
     - -cp=consul.http://edgex-core-consul:8500
     - --registry
-    container_name: app-functional-tests
+    container_name: edgex-app-functional-tests
     depends_on:
       consul:
         condition: service_started
-      data:
+      core-data:
         condition: service_started
       security-bootstrapper:
         condition: service_started
@@ -111,7 +111,7 @@ services:
       EDGEX_SECURITY_SECRET_STORE: "true"
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       SECRETSTORE_HOST: edgex-vault
-      SERVICE_HOST: app-functional-tests
+      SERVICE_HOST: edgex-app-functional-tests
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
       STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
@@ -124,7 +124,7 @@ services:
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
       STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
-    hostname: app-functional-tests
+    hostname: edgex-app-functional-tests
     image: nexus3.edgexfoundry.org:10004/app-service-configurable-arm64:latest
     networks:
       edgex-network: null
@@ -150,7 +150,7 @@ services:
       bind:
         selinux: z
         create_host_path: true
-  app-service-http-export:
+  app-http-export:
     command:
     - /app-service-configurable
     - -cp=consul.http://edgex-core-consul:8500
@@ -159,7 +159,7 @@ services:
     depends_on:
       consul:
         condition: service_started
-      data:
+      core-data:
         condition: service_started
       security-bootstrapper:
         condition: service_started
@@ -213,7 +213,7 @@ services:
       bind:
         selinux: z
         create_host_path: true
-  app-service-mqtt-export:
+  app-mqtt-export:
     command:
     - /app-service-configurable
     - -cp=consul.http://edgex-core-consul:8500
@@ -222,7 +222,7 @@ services:
     depends_on:
       consul:
         condition: service_started
-      data:
+      core-data:
         condition: service_started
       security-bootstrapper:
         condition: service_started
@@ -277,7 +277,7 @@ services:
       bind:
         selinux: z
         create_host_path: true
-  app-service-rules:
+  app-rules-engine:
     command:
     - /app-service-configurable
     - -cp=consul.http://edgex-core-consul:8500
@@ -286,7 +286,7 @@ services:
     depends_on:
       consul:
         condition: service_started
-      data:
+      core-data:
         condition: service_started
       security-bootstrapper:
         condition: service_started
@@ -338,7 +338,7 @@ services:
       bind:
         selinux: z
         create_host_path: true
-  app-service-sample:
+  app-sample:
     command:
     - /app-service-configurable
     - -cp=consul.http://edgex-core-consul:8500
@@ -347,7 +347,7 @@ services:
     depends_on:
       consul:
         condition: service_started
-      data:
+      core-data:
         condition: service_started
       security-bootstrapper:
         condition: service_started
@@ -402,31 +402,29 @@ services:
       bind:
         selinux: z
         create_host_path: true
-  command:
+  app-scalability-test-mqtt-export:
     command:
-    - /core-command
+    - /app-service-configurable
     - -cp=consul.http://edgex-core-consul:8500
     - --registry
-    container_name: edgex-core-command
+    container_name: edgex-app-scalability-test-mqtt-export
     depends_on:
       consul:
         condition: service_started
-      database:
-        condition: service_started
-      metadata:
-        condition: service_started
-      secretstore-setup:
+      core-data:
         condition: service_started
       security-bootstrapper:
         condition: service_started
     entrypoint:
     - /edgex-init/ready_to_run_wait_install.sh
     environment:
+      EDGEX_PROFILE: mqtt-export
       EDGEX_SECURITY_SECRET_STORE: "true"
-      EXTERNALMQTT_URL: tcp://edgex-mqtt-broker:1883
+      EDGEX_SERVICE_KEY: app-scalability-test-mqtt-export
+      MESSAGEBUS_OPTIONAL_CLIENTID: app-scalability-test-mqtt-export
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       SECRETSTORE_HOST: edgex-vault
-      SERVICE_HOST: edgex-core-command
+      SERVICE_HOST: edgex-app-scalability-test-mqtt-export
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
       STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
@@ -439,18 +437,20 @@ services:
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
       STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
-    hostname: edgex-core-command
-    image: nexus3.edgexfoundry.org:10004/core-command-arm64:latest
+      WRITABLE_LOGLEVEL: DEBUG
+      WRITABLE_PIPELINE_FUNCTIONS_MQTTEXPORT_PARAMETERS_BROKERADDRESS: MQTT_BROKER_ADDRESS_PLACE_HOLDER
+      WRITABLE_PIPELINE_FUNCTIONS_MQTTEXPORT_PARAMETERS_CLIENTID: app-scalability-test-mqtt-export
+      WRITABLE_PIPELINE_FUNCTIONS_MQTTEXPORT_PARAMETERS_TOPIC: edgex-events
+    hostname: edgex-app-scalability-test-mqtt-export
+    image: nexus3.edgexfoundry.org:10004/app-service-configurable-arm64:latest
     networks:
       edgex-network: null
     ports:
     - mode: ingress
-      host_ip: 127.0.0.1
-      target: 59882
-      published: "59882"
+      target: 59703
+      published: "59710"
       protocol: tcp
     read_only: true
-    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -461,65 +461,8 @@ services:
       read_only: true
       volume: {}
     - type: bind
-      source: /tmp/edgex/secrets/core-command
-      target: /tmp/edgex/secrets/core-command
-      read_only: true
-      bind:
-        selinux: z
-        create_host_path: true
-  common-config:
-    command:
-    - /entrypoint.sh
-    - /core-common-config-bootstrapper
-    - -cp=consul.http://edgex-core-consul:8500
-    container_name: edgex-core-common-config-bootstrapper
-    depends_on:
-      consul:
-        condition: service_started
-      secretstore-setup:
-        condition: service_started
-      security-bootstrapper:
-        condition: service_started
-    entrypoint:
-    - /edgex-init/ready_to_run_wait_install.sh
-    environment:
-      ALL_SERVICES_DATABASE_HOST: edgex-redis
-      ALL_SERVICES_MESSAGEBUS_HOST: edgex-redis
-      ALL_SERVICES_REGISTRY_HOST: edgex-core-consul
-      APP_SERVICES_CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
-      DEVICE_SERVICES_CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
-      EDGEX_SECURITY_SECRET_STORE: "true"
-      PROXY_SETUP_HOST: edgex-security-proxy-setup
-      SECRETSTORE_HOST: edgex-vault
-      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
-      STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: "6379"
-      STAGEGATE_DATABASE_READYPORT: "6379"
-      STAGEGATE_READY_TORUNPORT: "54329"
-      STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: "8500"
-      STAGEGATE_REGISTRY_READYPORT: "54324"
-      STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
-      STAGEGATE_WAITFOR_TIMEOUT: 60s
-    hostname: edgex-core-common-config-bootstrapper
-    image: nexus3.edgexfoundry.org:10004/core-common-config-bootstrapper-arm64:latest
-    networks:
-      edgex-network: null
-    read_only: true
-    security_opt:
-    - no-new-privileges:true
-    user: 2002:2001
-    volumes:
-    - type: volume
-      source: edgex-init
-      target: /edgex-init
-      read_only: true
-      volume: {}
-    - type: bind
-      source: /tmp/edgex/secrets/core-common-config-bootstrapper
-      target: /tmp/edgex/secrets/core-common-config-bootstrapper
+      source: /tmp/edgex/secrets/app-scalability-test-mqtt-export
+      target: /tmp/edgex/secrets/app-scalability-test-mqtt-export
       read_only: true
       bind:
         selinux: z
@@ -602,7 +545,129 @@ services:
       bind:
         selinux: z
         create_host_path: true
-  data:
+  core-command:
+    command:
+    - /core-command
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
+    container_name: edgex-core-command
+    depends_on:
+      consul:
+        condition: service_started
+      core-metadata:
+        condition: service_started
+      database:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
+      security-secretstore-setup:
+        condition: service_started
+    entrypoint:
+    - /edgex-init/ready_to_run_wait_install.sh
+    environment:
+      EDGEX_SECURITY_SECRET_STORE: "true"
+      EXTERNALMQTT_URL: tcp://edgex-mqtt-broker:1883
+      PROXY_SETUP_HOST: edgex-security-proxy-setup
+      SECRETSTORE_HOST: edgex-vault
+      SERVICE_HOST: edgex-core-command
+      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
+      STAGEGATE_DATABASE_HOST: edgex-redis
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
+      STAGEGATE_READY_TORUNPORT: "54329"
+      STAGEGATE_REGISTRY_HOST: edgex-core-consul
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
+      STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
+      STAGEGATE_WAITFOR_TIMEOUT: 60s
+    hostname: edgex-core-command
+    image: nexus3.edgexfoundry.org:10004/core-command-arm64:latest
+    networks:
+      edgex-network: null
+    ports:
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59882
+      published: "59882"
+      protocol: tcp
+    read_only: true
+    restart: always
+    security_opt:
+    - no-new-privileges:true
+    user: 2002:2001
+    volumes:
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/core-command
+      target: /tmp/edgex/secrets/core-command
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
+  core-common-config-bootstrapper:
+    command:
+    - /entrypoint.sh
+    - /core-common-config-bootstrapper
+    - -cp=consul.http://edgex-core-consul:8500
+    container_name: edgex-core-common-config-bootstrapper
+    depends_on:
+      consul:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
+      security-secretstore-setup:
+        condition: service_started
+    entrypoint:
+    - /edgex-init/ready_to_run_wait_install.sh
+    environment:
+      ALL_SERVICES_DATABASE_HOST: edgex-redis
+      ALL_SERVICES_MESSAGEBUS_HOST: edgex-redis
+      ALL_SERVICES_REGISTRY_HOST: edgex-core-consul
+      APP_SERVICES_CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
+      DEVICE_SERVICES_CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
+      EDGEX_SECURITY_SECRET_STORE: "true"
+      PROXY_SETUP_HOST: edgex-security-proxy-setup
+      SECRETSTORE_HOST: edgex-vault
+      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
+      STAGEGATE_DATABASE_HOST: edgex-redis
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
+      STAGEGATE_READY_TORUNPORT: "54329"
+      STAGEGATE_REGISTRY_HOST: edgex-core-consul
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
+      STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
+      STAGEGATE_WAITFOR_TIMEOUT: 60s
+    hostname: edgex-core-common-config-bootstrapper
+    image: nexus3.edgexfoundry.org:10004/core-common-config-bootstrapper-arm64:latest
+    networks:
+      edgex-network: null
+    read_only: true
+    security_opt:
+    - no-new-privileges:true
+    user: 2002:2001
+    volumes:
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/core-common-config-bootstrapper
+      target: /tmp/edgex/secrets/core-common-config-bootstrapper
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
+  core-data:
     command:
     - /core-data
     - -cp=consul.http://edgex-core-consul:8500
@@ -611,13 +676,13 @@ services:
     depends_on:
       consul:
         condition: service_started
+      core-metadata:
+        condition: service_started
       database:
         condition: service_started
-      metadata:
-        condition: service_started
-      secretstore-setup:
-        condition: service_started
       security-bootstrapper:
+        condition: service_started
+      security-secretstore-setup:
         condition: service_started
     entrypoint:
     - /edgex-init/ready_to_run_wait_install.sh
@@ -666,12 +731,74 @@ services:
       bind:
         selinux: z
         create_host_path: true
+  core-metadata:
+    command:
+    - /core-metadata
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
+    container_name: edgex-core-metadata
+    depends_on:
+      consul:
+        condition: service_started
+      database:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
+      security-secretstore-setup:
+        condition: service_started
+    entrypoint:
+    - /edgex-init/ready_to_run_wait_install.sh
+    environment:
+      EDGEX_SECURITY_SECRET_STORE: "true"
+      PROXY_SETUP_HOST: edgex-security-proxy-setup
+      SECRETSTORE_HOST: edgex-vault
+      SERVICE_HOST: edgex-core-metadata
+      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
+      STAGEGATE_DATABASE_HOST: edgex-redis
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
+      STAGEGATE_READY_TORUNPORT: "54329"
+      STAGEGATE_REGISTRY_HOST: edgex-core-consul
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
+      STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
+      STAGEGATE_WAITFOR_TIMEOUT: 60s
+    hostname: edgex-core-metadata
+    image: nexus3.edgexfoundry.org:10004/core-metadata-arm64:latest
+    networks:
+      edgex-network: null
+    ports:
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59881
+      published: "59881"
+      protocol: tcp
+    read_only: true
+    restart: always
+    security_opt:
+    - no-new-privileges:true
+    user: 2002:2001
+    volumes:
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/core-metadata
+      target: /tmp/edgex/secrets/core-metadata
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   database:
     container_name: edgex-redis
     depends_on:
-      secretstore-setup:
-        condition: service_started
       security-bootstrapper:
+        condition: service_started
+      security-secretstore-setup:
         condition: service_started
     entrypoint:
     - /edgex-init/redis_wait_install.sh
@@ -741,9 +868,9 @@ services:
     depends_on:
       consul:
         condition: service_started
-      data:
+      core-data:
         condition: service_started
-      metadata:
+      core-metadata:
         condition: service_started
       modbus-simulator:
         condition: service_started
@@ -811,9 +938,9 @@ services:
     depends_on:
       consul:
         condition: service_started
-      data:
+      core-data:
         condition: service_started
-      metadata:
+      core-metadata:
         condition: service_started
       security-bootstrapper:
         condition: service_started
@@ -873,9 +1000,9 @@ services:
     depends_on:
       consul:
         condition: service_started
-      data:
+      core-data:
         condition: service_started
-      metadata:
+      core-metadata:
         condition: service_started
       security-bootstrapper:
         condition: service_started
@@ -936,9 +1063,9 @@ services:
     depends_on:
       consul:
         condition: service_started
-      data:
+      core-data:
         condition: service_started
-      metadata:
+      core-metadata:
         condition: service_started
       security-bootstrapper:
         condition: service_started
@@ -992,68 +1119,6 @@ services:
     - type: bind
       source: /PROFILE_VOLUME_PLACE_HOLDER
       target: CONFIG_DIR_PLACE_HOLDER
-      bind:
-        selinux: z
-        create_host_path: true
-  metadata:
-    command:
-    - /core-metadata
-    - -cp=consul.http://edgex-core-consul:8500
-    - --registry
-    container_name: edgex-core-metadata
-    depends_on:
-      consul:
-        condition: service_started
-      database:
-        condition: service_started
-      secretstore-setup:
-        condition: service_started
-      security-bootstrapper:
-        condition: service_started
-    entrypoint:
-    - /edgex-init/ready_to_run_wait_install.sh
-    environment:
-      EDGEX_SECURITY_SECRET_STORE: "true"
-      PROXY_SETUP_HOST: edgex-security-proxy-setup
-      SECRETSTORE_HOST: edgex-vault
-      SERVICE_HOST: edgex-core-metadata
-      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
-      STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: "6379"
-      STAGEGATE_DATABASE_READYPORT: "6379"
-      STAGEGATE_READY_TORUNPORT: "54329"
-      STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: "8500"
-      STAGEGATE_REGISTRY_READYPORT: "54324"
-      STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
-      STAGEGATE_WAITFOR_TIMEOUT: 60s
-    hostname: edgex-core-metadata
-    image: nexus3.edgexfoundry.org:10004/core-metadata-arm64:latest
-    networks:
-      edgex-network: null
-    ports:
-    - mode: ingress
-      host_ip: 127.0.0.1
-      target: 59881
-      published: "59881"
-      protocol: tcp
-    read_only: true
-    restart: always
-    security_opt:
-    - no-new-privileges:true
-    user: 2002:2001
-    volumes:
-    - type: volume
-      source: edgex-init
-      target: /edgex-init
-      read_only: true
-      volume: {}
-    - type: bind
-      source: /tmp/edgex/secrets/core-metadata
-      target: /tmp/edgex/secrets/core-metadata
-      read_only: true
       bind:
         selinux: z
         create_host_path: true
@@ -1124,7 +1189,7 @@ services:
     - daemon off;
     container_name: edgex-nginx
     depends_on:
-      secretstore-setup:
+      security-secretstore-setup:
         condition: service_started
     entrypoint:
     - /bin/sh
@@ -1177,206 +1242,14 @@ services:
       source: nginx-tls
       target: /etc/ssl/nginx
       volume: {}
-  notifications:
-    command:
-    - /support-notifications
-    - -cp=consul.http://edgex-core-consul:8500
-    - --registry
-    container_name: edgex-support-notifications
-    depends_on:
-      consul:
-        condition: service_started
-      database:
-        condition: service_started
-      secretstore-setup:
-        condition: service_started
-      security-bootstrapper:
-        condition: service_started
-    entrypoint:
-    - /edgex-init/ready_to_run_wait_install.sh
-    environment:
-      EDGEX_SECURITY_SECRET_STORE: "true"
-      PROXY_SETUP_HOST: edgex-security-proxy-setup
-      SECRETSTORE_HOST: edgex-vault
-      SERVICE_HOST: edgex-support-notifications
-      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
-      STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: "6379"
-      STAGEGATE_DATABASE_READYPORT: "6379"
-      STAGEGATE_READY_TORUNPORT: "54329"
-      STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: "8500"
-      STAGEGATE_REGISTRY_READYPORT: "54324"
-      STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
-      STAGEGATE_WAITFOR_TIMEOUT: 60s
-    hostname: edgex-support-notifications
-    image: nexus3.edgexfoundry.org:10004/support-notifications-arm64:latest
-    networks:
-      edgex-network: null
-    ports:
-    - mode: ingress
-      host_ip: 127.0.0.1
-      target: 59860
-      published: "59860"
-      protocol: tcp
-    read_only: true
-    restart: always
-    security_opt:
-    - no-new-privileges:true
-    user: 2002:2001
-    volumes:
-    - type: volume
-      source: edgex-init
-      target: /edgex-init
-      read_only: true
-      volume: {}
-    - type: bind
-      source: /tmp/edgex/secrets/support-notifications
-      target: /tmp/edgex/secrets/support-notifications
-      read_only: true
-      bind:
-        selinux: z
-        create_host_path: true
-  proxy-auth:
-    command:
-    - entrypoint.sh
-    - /security-proxy-auth
-    - -cp=consul.http://edgex-core-consul:8500
-    - --registry
-    container_name: edgex-proxy-auth
-    depends_on:
-      secretstore-setup:
-        condition: service_started
-    entrypoint:
-    - /bin/sh
-    - /edgex-init/ready_to_run_wait_install.sh
-    environment:
-      EDGEX_SECURITY_SECRET_STORE: "true"
-      PROXY_SETUP_HOST: edgex-security-proxy-setup
-      SECRETSTORE_HOST: edgex-vault
-      SERVICE_HOST: edgex-proxy-auth
-      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
-      STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: "6379"
-      STAGEGATE_DATABASE_READYPORT: "6379"
-      STAGEGATE_READY_TORUNPORT: "54329"
-      STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: "8500"
-      STAGEGATE_REGISTRY_READYPORT: "54324"
-      STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
-      STAGEGATE_WAITFOR_TIMEOUT: 60s
-    hostname: edgex-proxy-auth
-    image: nexus3.edgexfoundry.org:10004/security-proxy-auth-arm64:latest
-    networks:
-      edgex-network: null
-    ports:
-    - mode: ingress
-      host_ip: 127.0.0.1
-      target: 59842
-      published: "59842"
-      protocol: tcp
-    read_only: true
-    restart: always
-    security_opt:
-    - no-new-privileges:true
-    volumes:
-    - type: volume
-      source: edgex-init
-      target: /edgex-init
-      read_only: true
-      volume: {}
-    - type: bind
-      source: /tmp/edgex/secrets/security-proxy-auth
-      target: /tmp/edgex/secrets/security-proxy-auth
-      read_only: true
-      bind:
-        selinux: z
-        create_host_path: true
-  proxy-setup:
-    container_name: edgex-security-proxy-setup
-    depends_on:
-      secretstore-setup:
-        condition: service_started
-      security-bootstrapper:
-        condition: service_started
-    entrypoint:
-    - /edgex-init/proxy_setup_wait_install.sh
-    environment:
-      ADD_PROXY_ROUTE: device-modbus.http://edgex-device-modbus:59901
-      EDGEX_SECURITY_SECRET_STORE: "true"
-      PROXY_SETUP_HOST: edgex-security-proxy-setup
-      ROUTES_CORE_COMMAND_HOST: edgex-core-command
-      ROUTES_CORE_CONSUL_HOST: edgex-core-consul
-      ROUTES_CORE_DATA_HOST: edgex-core-data
-      ROUTES_CORE_METADATA_HOST: edgex-core-metadata
-      ROUTES_DEVICE_VIRTUAL_HOST: device-virtual
-      ROUTES_RULES_ENGINE_HOST: edgex-kuiper
-      ROUTES_SUPPORT_NOTIFICATIONS_HOST: edgex-support-notifications
-      ROUTES_SUPPORT_SCHEDULER_HOST: edgex-support-scheduler
-      ROUTES_SYS_MGMT_AGENT_HOST: edgex-sys-mgmt-agent
-      SECRETSTORE_HOST: edgex-vault
-      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
-      STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: "6379"
-      STAGEGATE_DATABASE_READYPORT: "6379"
-      STAGEGATE_READY_TORUNPORT: "54329"
-      STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: "8500"
-      STAGEGATE_REGISTRY_READYPORT: "54324"
-      STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
-      STAGEGATE_WAITFOR_TIMEOUT: 60s
-    hostname: edgex-security-proxy-setup
-    image: nexus3.edgexfoundry.org:10004/security-proxy-setup-arm64:latest
-    networks:
-      edgex-network: null
-    read_only: true
-    security_opt:
-    - no-new-privileges:true
-    user: root:root
-    volumes:
-    - type: volume
-      source: edgex-init
-      target: /edgex-init
-      read_only: true
-      volume: {}
-    - type: volume
-      source: nginx-templates
-      target: /etc/nginx/templates
-      volume: {}
-    - type: volume
-      source: nginx-tls
-      target: /etc/ssl/nginx
-      volume: {}
-    - type: volume
-      source: consul-acl-token
-      target: /tmp/edgex/secrets/consul-acl-token
-      read_only: true
-      volume: {}
-    - type: bind
-      source: /tmp/edgex/secrets/security-proxy-setup
-      target: /tmp/edgex/secrets/security-proxy-setup
-      read_only: true
-      bind:
-        selinux: z
-        create_host_path: true
-    - type: volume
-      source: vault-config
-      target: /vault/config
-      volume: {}
-  rulesengine:
+  rules-engine:
     container_name: edgex-kuiper
     depends_on:
       database:
         condition: service_started
-      secretstore-setup:
-        condition: service_started
       security-bootstrapper:
+        condition: service_started
+      security-secretstore-setup:
         condition: service_started
     entrypoint:
     - /edgex-init/kuiper_wait_install.sh
@@ -1450,29 +1323,12 @@ services:
       source: kuiper-plugins
       target: /kuiper/plugins
       volume: {}
-  scalability-test-mqtt-export:
-    command:
-    - /app-service-configurable
-    - -cp=consul.http://edgex-core-consul:8500
-    - --registry
-    container_name: edgex-scalability-test-mqtt-export
-    depends_on:
-      consul:
-        condition: service_started
-      data:
-        condition: service_started
-      security-bootstrapper:
-        condition: service_started
-    entrypoint:
-    - /edgex-init/ready_to_run_wait_install.sh
+  security-bootstrapper:
+    container_name: edgex-security-bootstrapper
     environment:
-      EDGEX_PROFILE: mqtt-export
-      EDGEX_SECURITY_SECRET_STORE: "true"
-      EDGEX_SERVICE_KEY: app-scalability-test-mqtt-export
-      MESSAGEBUS_OPTIONAL_CLIENTID: app-scalability-test-mqtt-export
+      EDGEX_GROUP: "2001"
+      EDGEX_USER: "2002"
       PROXY_SETUP_HOST: edgex-security-proxy-setup
-      SECRETSTORE_HOST: edgex-vault
-      SERVICE_HOST: edgex-scalability-test-mqtt-export
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
       STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
@@ -1485,60 +1341,38 @@ services:
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
       STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
-      WRITABLE_LOGLEVEL: DEBUG
-      WRITABLE_PIPELINE_FUNCTIONS_MQTTEXPORT_PARAMETERS_BROKERADDRESS: MQTT_BROKER_ADDRESS_PLACE_HOLDER
-      WRITABLE_PIPELINE_FUNCTIONS_MQTTEXPORT_PARAMETERS_CLIENTID: scalability-test-mqtt-export
-      WRITABLE_PIPELINE_FUNCTIONS_MQTTEXPORT_PARAMETERS_TOPIC: edgex-events
-    hostname: edgex-scalability-test-mqtt-export
-    image: nexus3.edgexfoundry.org:10004/app-service-configurable-arm64:latest
+    hostname: edgex-security-bootstrapper
+    image: nexus3.edgexfoundry.org:10004/security-bootstrapper-arm64:latest
     networks:
       edgex-network: null
-    ports:
-    - mode: ingress
-      target: 59703
-      published: "59710"
-      protocol: tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
-    user: 2002:2001
+    user: root:root
     volumes:
     - type: volume
       source: edgex-init
       target: /edgex-init
-      read_only: true
       volume: {}
-    - type: bind
-      source: /tmp/edgex/secrets/app-scalability-test-mqtt-export
-      target: /tmp/edgex/secrets/app-scalability-test-mqtt-export
-      read_only: true
-      bind:
-        selinux: z
-        create_host_path: true
-  scheduler:
+  security-proxy-auth:
     command:
-    - /support-scheduler
+    - entrypoint.sh
+    - /security-proxy-auth
     - -cp=consul.http://edgex-core-consul:8500
     - --registry
-    container_name: edgex-support-scheduler
+    container_name: edgex-proxy-auth
     depends_on:
-      consul:
-        condition: service_started
-      database:
-        condition: service_started
-      secretstore-setup:
-        condition: service_started
-      security-bootstrapper:
+      security-secretstore-setup:
         condition: service_started
     entrypoint:
+    - /bin/sh
     - /edgex-init/ready_to_run_wait_install.sh
     environment:
       EDGEX_SECURITY_SECRET_STORE: "true"
-      INTERVALACTIONS_SCRUBAGED_HOST: edgex-core-data
-      INTERVALACTIONS_SCRUBPUSHED_HOST: edgex-core-data
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       SECRETSTORE_HOST: edgex-vault
-      SERVICE_HOST: edgex-support-scheduler
+      SERVICE_HOST: edgex-proxy-auth
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
       STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
@@ -1551,21 +1385,20 @@ services:
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
       STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
-    hostname: edgex-support-scheduler
-    image: nexus3.edgexfoundry.org:10004/support-scheduler-arm64:latest
+    hostname: edgex-proxy-auth
+    image: nexus3.edgexfoundry.org:10004/security-proxy-auth-arm64:latest
     networks:
       edgex-network: null
     ports:
     - mode: ingress
       host_ip: 127.0.0.1
-      target: 59861
-      published: "59861"
+      target: 59842
+      published: "59842"
       protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
-    user: 2002:2001
     volumes:
     - type: volume
       source: edgex-init
@@ -1573,13 +1406,86 @@ services:
       read_only: true
       volume: {}
     - type: bind
-      source: /tmp/edgex/secrets/support-scheduler
-      target: /tmp/edgex/secrets/support-scheduler
+      source: /tmp/edgex/secrets/security-proxy-auth
+      target: /tmp/edgex/secrets/security-proxy-auth
       read_only: true
       bind:
         selinux: z
         create_host_path: true
-  secretstore-setup:
+  security-proxy-setup:
+    container_name: edgex-security-proxy-setup
+    depends_on:
+      security-bootstrapper:
+        condition: service_started
+      security-secretstore-setup:
+        condition: service_started
+    entrypoint:
+    - /edgex-init/proxy_setup_wait_install.sh
+    environment:
+      ADD_PROXY_ROUTE: device-modbus.http://edgex-device-modbus:59901
+      EDGEX_SECURITY_SECRET_STORE: "true"
+      PROXY_SETUP_HOST: edgex-security-proxy-setup
+      ROUTES_CORE_COMMAND_HOST: edgex-core-command
+      ROUTES_CORE_CONSUL_HOST: edgex-core-consul
+      ROUTES_CORE_DATA_HOST: edgex-core-data
+      ROUTES_CORE_METADATA_HOST: edgex-core-metadata
+      ROUTES_DEVICE_VIRTUAL_HOST: device-virtual
+      ROUTES_RULES_ENGINE_HOST: edgex-kuiper
+      ROUTES_SUPPORT_NOTIFICATIONS_HOST: edgex-support-notifications
+      ROUTES_SUPPORT_SCHEDULER_HOST: edgex-support-scheduler
+      ROUTES_SYS_MGMT_AGENT_HOST: edgex-sys-mgmt-agent
+      SECRETSTORE_HOST: edgex-vault
+      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
+      STAGEGATE_DATABASE_HOST: edgex-redis
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
+      STAGEGATE_READY_TORUNPORT: "54329"
+      STAGEGATE_REGISTRY_HOST: edgex-core-consul
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
+      STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
+      STAGEGATE_WAITFOR_TIMEOUT: 60s
+    hostname: edgex-security-proxy-setup
+    image: nexus3.edgexfoundry.org:10004/security-proxy-setup-arm64:latest
+    networks:
+      edgex-network: null
+    read_only: true
+    security_opt:
+    - no-new-privileges:true
+    user: root:root
+    volumes:
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      volume: {}
+    - type: volume
+      source: nginx-templates
+      target: /etc/nginx/templates
+      volume: {}
+    - type: volume
+      source: nginx-tls
+      target: /etc/ssl/nginx
+      volume: {}
+    - type: volume
+      source: consul-acl-token
+      target: /tmp/edgex/secrets/consul-acl-token
+      read_only: true
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/security-proxy-setup
+      target: /tmp/edgex/secrets/security-proxy-setup
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
+    - type: volume
+      source: vault-config
+      target: /vault/config
+      volume: {}
+  security-secretstore-setup:
     container_name: edgex-security-secretstore-setup
     depends_on:
       security-bootstrapper:
@@ -1642,38 +1548,6 @@ services:
     - type: volume
       source: vault-config
       target: /vault/config
-      volume: {}
-  security-bootstrapper:
-    container_name: edgex-security-bootstrapper
-    environment:
-      EDGEX_GROUP: "2001"
-      EDGEX_USER: "2002"
-      PROXY_SETUP_HOST: edgex-security-proxy-setup
-      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
-      STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: "6379"
-      STAGEGATE_DATABASE_READYPORT: "6379"
-      STAGEGATE_READY_TORUNPORT: "54329"
-      STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: "8500"
-      STAGEGATE_REGISTRY_READYPORT: "54324"
-      STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
-      STAGEGATE_WAITFOR_TIMEOUT: 60s
-    hostname: edgex-security-bootstrapper
-    image: nexus3.edgexfoundry.org:10004/security-bootstrapper-arm64:latest
-    networks:
-      edgex-network: null
-    read_only: true
-    restart: always
-    security_opt:
-    - no-new-privileges:true
-    user: root:root
-    volumes:
-    - type: volume
-      source: edgex-init
-      target: /edgex-init
       volume: {}
   security-spiffe-token-provider:
     command:
@@ -1909,6 +1783,132 @@ services:
     - type: bind
       source: /tmp/edgex/secrets/spiffe
       target: /tmp/edgex/secrets/spiffe
+      bind:
+        selinux: z
+        create_host_path: true
+  support-notifications:
+    command:
+    - /support-notifications
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
+    container_name: edgex-support-notifications
+    depends_on:
+      consul:
+        condition: service_started
+      database:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
+      security-secretstore-setup:
+        condition: service_started
+    entrypoint:
+    - /edgex-init/ready_to_run_wait_install.sh
+    environment:
+      EDGEX_SECURITY_SECRET_STORE: "true"
+      PROXY_SETUP_HOST: edgex-security-proxy-setup
+      SECRETSTORE_HOST: edgex-vault
+      SERVICE_HOST: edgex-support-notifications
+      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
+      STAGEGATE_DATABASE_HOST: edgex-redis
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
+      STAGEGATE_READY_TORUNPORT: "54329"
+      STAGEGATE_REGISTRY_HOST: edgex-core-consul
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
+      STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
+      STAGEGATE_WAITFOR_TIMEOUT: 60s
+    hostname: edgex-support-notifications
+    image: nexus3.edgexfoundry.org:10004/support-notifications-arm64:latest
+    networks:
+      edgex-network: null
+    ports:
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59860
+      published: "59860"
+      protocol: tcp
+    read_only: true
+    restart: always
+    security_opt:
+    - no-new-privileges:true
+    user: 2002:2001
+    volumes:
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/support-notifications
+      target: /tmp/edgex/secrets/support-notifications
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
+  support-scheduler:
+    command:
+    - /support-scheduler
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
+    container_name: edgex-support-scheduler
+    depends_on:
+      consul:
+        condition: service_started
+      database:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
+      security-secretstore-setup:
+        condition: service_started
+    entrypoint:
+    - /edgex-init/ready_to_run_wait_install.sh
+    environment:
+      EDGEX_SECURITY_SECRET_STORE: "true"
+      INTERVALACTIONS_SCRUBAGED_HOST: edgex-core-data
+      INTERVALACTIONS_SCRUBPUSHED_HOST: edgex-core-data
+      PROXY_SETUP_HOST: edgex-security-proxy-setup
+      SECRETSTORE_HOST: edgex-vault
+      SERVICE_HOST: edgex-support-scheduler
+      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
+      STAGEGATE_DATABASE_HOST: edgex-redis
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
+      STAGEGATE_READY_TORUNPORT: "54329"
+      STAGEGATE_REGISTRY_HOST: edgex-core-consul
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
+      STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
+      STAGEGATE_WAITFOR_TIMEOUT: 60s
+    hostname: edgex-support-scheduler
+    image: nexus3.edgexfoundry.org:10004/support-scheduler-arm64:latest
+    networks:
+      edgex-network: null
+    ports:
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59861
+      published: "59861"
+      protocol: tcp
+    read_only: true
+    restart: always
+    security_opt:
+    - no-new-privileges:true
+    user: 2002:2001
+    volumes:
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/support-scheduler
+      target: /tmp/edgex/secrets/support-scheduler
+      read_only: true
       bind:
         selinux: z
         create_host_path: true

--- a/taf/docker-compose-taf-mqtt-bus-arm64.yml
+++ b/taf/docker-compose-taf-mqtt-bus-arm64.yml
@@ -26,7 +26,7 @@
 #
 name: edgex
 services:
-  app-service-external-mqtt-trigger:
+  app-external-mqtt-trigger:
     command:
     - /app-service-configurable
     - -cp=consul.http://edgex-core-consul:8500
@@ -35,7 +35,7 @@ services:
     depends_on:
       consul:
         condition: service_started
-      data:
+      core-data:
         condition: service_started
       security-bootstrapper:
         condition: service_started
@@ -91,16 +91,16 @@ services:
       bind:
         selinux: z
         create_host_path: true
-  app-service-functional-tests:
+  app-functional-tests:
     command:
     - /app-service-configurable
     - -cp=consul.http://edgex-core-consul:8500
     - --registry
-    container_name: app-functional-tests
+    container_name: edgex-app-functional-tests
     depends_on:
       consul:
         condition: service_started
-      data:
+      core-data:
         condition: service_started
       security-bootstrapper:
         condition: service_started
@@ -111,7 +111,7 @@ services:
       EDGEX_SECURITY_SECRET_STORE: "true"
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       SECRETSTORE_HOST: edgex-vault
-      SERVICE_HOST: app-functional-tests
+      SERVICE_HOST: edgex-app-functional-tests
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
       STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
@@ -124,7 +124,7 @@ services:
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
       STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
-    hostname: app-functional-tests
+    hostname: edgex-app-functional-tests
     image: nexus3.edgexfoundry.org:10004/app-service-configurable-arm64:latest
     networks:
       edgex-network: null
@@ -150,7 +150,7 @@ services:
       bind:
         selinux: z
         create_host_path: true
-  app-service-http-export:
+  app-http-export:
     command:
     - /app-service-configurable
     - -cp=consul.http://edgex-core-consul:8500
@@ -159,7 +159,7 @@ services:
     depends_on:
       consul:
         condition: service_started
-      data:
+      core-data:
         condition: service_started
       security-bootstrapper:
         condition: service_started
@@ -213,7 +213,7 @@ services:
       bind:
         selinux: z
         create_host_path: true
-  app-service-mqtt-export:
+  app-mqtt-export:
     command:
     - /app-service-configurable
     - -cp=consul.http://edgex-core-consul:8500
@@ -222,7 +222,7 @@ services:
     depends_on:
       consul:
         condition: service_started
-      data:
+      core-data:
         condition: service_started
       security-bootstrapper:
         condition: service_started
@@ -246,8 +246,6 @@ services:
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
       STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
-      WRITABLE_INSECURESECRETS_MQTT_SECRETS_PASSWORD: PASSWORD_PLACE_HOLDER
-      WRITABLE_INSECURESECRETS_MQTT_SECRETS_USERNAME: USERNAME_PLACEH_OLDER
       WRITABLE_LOGLEVEL: INFO
       WRITABLE_PIPELINE_FUNCTIONS_MQTTEXPORT_PARAMETERS_BROKERADDRESS: MQTT_BROKER_ADDRESS_PLACE_HOLDER
       WRITABLE_PIPELINE_FUNCTIONS_MQTTEXPORT_PARAMETERS_TOPIC: edgex-events
@@ -279,7 +277,7 @@ services:
       bind:
         selinux: z
         create_host_path: true
-  app-service-rules:
+  app-rules-engine:
     command:
     - /app-service-configurable
     - -cp=consul.http://edgex-core-consul:8500
@@ -288,7 +286,7 @@ services:
     depends_on:
       consul:
         condition: service_started
-      data:
+      core-data:
         condition: service_started
       security-bootstrapper:
         condition: service_started
@@ -340,7 +338,7 @@ services:
       bind:
         selinux: z
         create_host_path: true
-  app-service-sample:
+  app-sample:
     command:
     - /app-service-configurable
     - -cp=consul.http://edgex-core-consul:8500
@@ -349,7 +347,7 @@ services:
     depends_on:
       consul:
         condition: service_started
-      data:
+      core-data:
         condition: service_started
       security-bootstrapper:
         condition: service_started
@@ -404,31 +402,29 @@ services:
       bind:
         selinux: z
         create_host_path: true
-  command:
+  app-scalability-test-mqtt-export:
     command:
-    - /core-command
+    - /app-service-configurable
     - -cp=consul.http://edgex-core-consul:8500
     - --registry
-    container_name: edgex-core-command
+    container_name: edgex-app-scalability-test-mqtt-export
     depends_on:
       consul:
         condition: service_started
-      database:
-        condition: service_started
-      metadata:
-        condition: service_started
-      secretstore-setup:
+      core-data:
         condition: service_started
       security-bootstrapper:
         condition: service_started
     entrypoint:
     - /edgex-init/ready_to_run_wait_install.sh
     environment:
+      EDGEX_PROFILE: mqtt-export
       EDGEX_SECURITY_SECRET_STORE: "true"
-      EXTERNALMQTT_URL: tcp://edgex-mqtt-broker:1883
+      EDGEX_SERVICE_KEY: app-scalability-test-mqtt-export
+      MESSAGEBUS_OPTIONAL_CLIENTID: app-scalability-test-mqtt-export
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       SECRETSTORE_HOST: edgex-vault
-      SERVICE_HOST: edgex-core-command
+      SERVICE_HOST: edgex-app-scalability-test-mqtt-export
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
       STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
@@ -441,18 +437,22 @@ services:
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
       STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
-    hostname: edgex-core-command
-    image: nexus3.edgexfoundry.org:10004/core-command-arm64:latest
+      WRITABLE_INSECURESECRETS_MQTT_SECRETS_PASSWORD: PASSWORD_PLACE_HOLDER
+      WRITABLE_INSECURESECRETS_MQTT_SECRETS_USERNAME: USERNAME_PLACEH_OLDER
+      WRITABLE_LOGLEVEL: DEBUG
+      WRITABLE_PIPELINE_FUNCTIONS_MQTTEXPORT_PARAMETERS_BROKERADDRESS: MQTT_BROKER_ADDRESS_PLACE_HOLDER
+      WRITABLE_PIPELINE_FUNCTIONS_MQTTEXPORT_PARAMETERS_CLIENTID: app-scalability-test-mqtt-export
+      WRITABLE_PIPELINE_FUNCTIONS_MQTTEXPORT_PARAMETERS_TOPIC: edgex-events
+    hostname: edgex-app-scalability-test-mqtt-export
+    image: nexus3.edgexfoundry.org:10004/app-service-configurable-arm64:latest
     networks:
       edgex-network: null
     ports:
     - mode: ingress
-      host_ip: 127.0.0.1
-      target: 59882
-      published: "59882"
+      target: 59703
+      published: "59710"
       protocol: tcp
     read_only: true
-    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -463,70 +463,8 @@ services:
       read_only: true
       volume: {}
     - type: bind
-      source: /tmp/edgex/secrets/core-command
-      target: /tmp/edgex/secrets/core-command
-      read_only: true
-      bind:
-        selinux: z
-        create_host_path: true
-  common-config:
-    command:
-    - /entrypoint.sh
-    - /core-common-config-bootstrapper
-    - -cp=consul.http://edgex-core-consul:8500
-    container_name: edgex-core-common-config-bootstrapper
-    depends_on:
-      consul:
-        condition: service_started
-      secretstore-setup:
-        condition: service_started
-      security-bootstrapper:
-        condition: service_started
-    entrypoint:
-    - /edgex-init/ready_to_run_wait_install.sh
-    environment:
-      ALL_SERVICES_DATABASE_HOST: edgex-redis
-      ALL_SERVICES_MESSAGEBUS_AUTHMODE: usernamepassword
-      ALL_SERVICES_MESSAGEBUS_HOST: edgex-mqtt-broker
-      ALL_SERVICES_MESSAGEBUS_PORT: "1883"
-      ALL_SERVICES_MESSAGEBUS_PROTOCOL: tcp
-      ALL_SERVICES_MESSAGEBUS_SECRETNAME: message-bus
-      ALL_SERVICES_MESSAGEBUS_TYPE: mqtt
-      ALL_SERVICES_REGISTRY_HOST: edgex-core-consul
-      APP_SERVICES_CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
-      DEVICE_SERVICES_CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
-      EDGEX_SECURITY_SECRET_STORE: "true"
-      PROXY_SETUP_HOST: edgex-security-proxy-setup
-      SECRETSTORE_HOST: edgex-vault
-      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
-      STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: "6379"
-      STAGEGATE_DATABASE_READYPORT: "6379"
-      STAGEGATE_READY_TORUNPORT: "54329"
-      STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: "8500"
-      STAGEGATE_REGISTRY_READYPORT: "54324"
-      STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
-      STAGEGATE_WAITFOR_TIMEOUT: 60s
-    hostname: edgex-core-common-config-bootstrapper
-    image: nexus3.edgexfoundry.org:10004/core-common-config-bootstrapper-arm64:latest
-    networks:
-      edgex-network: null
-    read_only: true
-    security_opt:
-    - no-new-privileges:true
-    user: 2002:2001
-    volumes:
-    - type: volume
-      source: edgex-init
-      target: /edgex-init
-      read_only: true
-      volume: {}
-    - type: bind
-      source: /tmp/edgex/secrets/core-common-config-bootstrapper
-      target: /tmp/edgex/secrets/core-common-config-bootstrapper
+      source: /tmp/edgex/secrets/app-scalability-test-mqtt-export
+      target: /tmp/edgex/secrets/app-scalability-test-mqtt-export
       read_only: true
       bind:
         selinux: z
@@ -609,7 +547,134 @@ services:
       bind:
         selinux: z
         create_host_path: true
-  data:
+  core-command:
+    command:
+    - /core-command
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
+    container_name: edgex-core-command
+    depends_on:
+      consul:
+        condition: service_started
+      core-metadata:
+        condition: service_started
+      database:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
+      security-secretstore-setup:
+        condition: service_started
+    entrypoint:
+    - /edgex-init/ready_to_run_wait_install.sh
+    environment:
+      EDGEX_SECURITY_SECRET_STORE: "true"
+      EXTERNALMQTT_URL: tcp://edgex-mqtt-broker:1883
+      PROXY_SETUP_HOST: edgex-security-proxy-setup
+      SECRETSTORE_HOST: edgex-vault
+      SERVICE_HOST: edgex-core-command
+      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
+      STAGEGATE_DATABASE_HOST: edgex-redis
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
+      STAGEGATE_READY_TORUNPORT: "54329"
+      STAGEGATE_REGISTRY_HOST: edgex-core-consul
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
+      STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
+      STAGEGATE_WAITFOR_TIMEOUT: 60s
+    hostname: edgex-core-command
+    image: nexus3.edgexfoundry.org:10004/core-command-arm64:latest
+    networks:
+      edgex-network: null
+    ports:
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59882
+      published: "59882"
+      protocol: tcp
+    read_only: true
+    restart: always
+    security_opt:
+    - no-new-privileges:true
+    user: 2002:2001
+    volumes:
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/core-command
+      target: /tmp/edgex/secrets/core-command
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
+  core-common-config-bootstrapper:
+    command:
+    - /entrypoint.sh
+    - /core-common-config-bootstrapper
+    - -cp=consul.http://edgex-core-consul:8500
+    container_name: edgex-core-common-config-bootstrapper
+    depends_on:
+      consul:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
+      security-secretstore-setup:
+        condition: service_started
+    entrypoint:
+    - /edgex-init/ready_to_run_wait_install.sh
+    environment:
+      ALL_SERVICES_DATABASE_HOST: edgex-redis
+      ALL_SERVICES_MESSAGEBUS_AUTHMODE: usernamepassword
+      ALL_SERVICES_MESSAGEBUS_HOST: edgex-mqtt-broker
+      ALL_SERVICES_MESSAGEBUS_PORT: "1883"
+      ALL_SERVICES_MESSAGEBUS_PROTOCOL: tcp
+      ALL_SERVICES_MESSAGEBUS_SECRETNAME: message-bus
+      ALL_SERVICES_MESSAGEBUS_TYPE: mqtt
+      ALL_SERVICES_REGISTRY_HOST: edgex-core-consul
+      APP_SERVICES_CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
+      DEVICE_SERVICES_CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
+      EDGEX_SECURITY_SECRET_STORE: "true"
+      PROXY_SETUP_HOST: edgex-security-proxy-setup
+      SECRETSTORE_HOST: edgex-vault
+      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
+      STAGEGATE_DATABASE_HOST: edgex-redis
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
+      STAGEGATE_READY_TORUNPORT: "54329"
+      STAGEGATE_REGISTRY_HOST: edgex-core-consul
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
+      STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
+      STAGEGATE_WAITFOR_TIMEOUT: 60s
+    hostname: edgex-core-common-config-bootstrapper
+    image: nexus3.edgexfoundry.org:10004/core-common-config-bootstrapper-arm64:latest
+    networks:
+      edgex-network: null
+    read_only: true
+    security_opt:
+    - no-new-privileges:true
+    user: 2002:2001
+    volumes:
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/core-common-config-bootstrapper
+      target: /tmp/edgex/secrets/core-common-config-bootstrapper
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
+  core-data:
     command:
     - /core-data
     - -cp=consul.http://edgex-core-consul:8500
@@ -618,13 +683,13 @@ services:
     depends_on:
       consul:
         condition: service_started
+      core-metadata:
+        condition: service_started
       database:
         condition: service_started
-      metadata:
-        condition: service_started
-      secretstore-setup:
-        condition: service_started
       security-bootstrapper:
+        condition: service_started
+      security-secretstore-setup:
         condition: service_started
     entrypoint:
     - /edgex-init/ready_to_run_wait_install.sh
@@ -673,12 +738,74 @@ services:
       bind:
         selinux: z
         create_host_path: true
+  core-metadata:
+    command:
+    - /core-metadata
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
+    container_name: edgex-core-metadata
+    depends_on:
+      consul:
+        condition: service_started
+      database:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
+      security-secretstore-setup:
+        condition: service_started
+    entrypoint:
+    - /edgex-init/ready_to_run_wait_install.sh
+    environment:
+      EDGEX_SECURITY_SECRET_STORE: "true"
+      PROXY_SETUP_HOST: edgex-security-proxy-setup
+      SECRETSTORE_HOST: edgex-vault
+      SERVICE_HOST: edgex-core-metadata
+      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
+      STAGEGATE_DATABASE_HOST: edgex-redis
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
+      STAGEGATE_READY_TORUNPORT: "54329"
+      STAGEGATE_REGISTRY_HOST: edgex-core-consul
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
+      STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
+      STAGEGATE_WAITFOR_TIMEOUT: 60s
+    hostname: edgex-core-metadata
+    image: nexus3.edgexfoundry.org:10004/core-metadata-arm64:latest
+    networks:
+      edgex-network: null
+    ports:
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59881
+      published: "59881"
+      protocol: tcp
+    read_only: true
+    restart: always
+    security_opt:
+    - no-new-privileges:true
+    user: 2002:2001
+    volumes:
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/core-metadata
+      target: /tmp/edgex/secrets/core-metadata
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   database:
     container_name: edgex-redis
     depends_on:
-      secretstore-setup:
-        condition: service_started
       security-bootstrapper:
+        condition: service_started
+      security-secretstore-setup:
         condition: service_started
     entrypoint:
     - /edgex-init/redis_wait_install.sh
@@ -748,9 +875,9 @@ services:
     depends_on:
       consul:
         condition: service_started
-      data:
+      core-data:
         condition: service_started
-      metadata:
+      core-metadata:
         condition: service_started
       modbus-simulator:
         condition: service_started
@@ -818,9 +945,9 @@ services:
     depends_on:
       consul:
         condition: service_started
-      data:
+      core-data:
         condition: service_started
-      metadata:
+      core-metadata:
         condition: service_started
       security-bootstrapper:
         condition: service_started
@@ -880,9 +1007,9 @@ services:
     depends_on:
       consul:
         condition: service_started
-      data:
+      core-data:
         condition: service_started
-      metadata:
+      core-metadata:
         condition: service_started
       security-bootstrapper:
         condition: service_started
@@ -943,9 +1070,9 @@ services:
     depends_on:
       consul:
         condition: service_started
-      data:
+      core-data:
         condition: service_started
-      metadata:
+      core-metadata:
         condition: service_started
       security-bootstrapper:
         condition: service_started
@@ -1002,68 +1129,6 @@ services:
       bind:
         selinux: z
         create_host_path: true
-  metadata:
-    command:
-    - /core-metadata
-    - -cp=consul.http://edgex-core-consul:8500
-    - --registry
-    container_name: edgex-core-metadata
-    depends_on:
-      consul:
-        condition: service_started
-      database:
-        condition: service_started
-      secretstore-setup:
-        condition: service_started
-      security-bootstrapper:
-        condition: service_started
-    entrypoint:
-    - /edgex-init/ready_to_run_wait_install.sh
-    environment:
-      EDGEX_SECURITY_SECRET_STORE: "true"
-      PROXY_SETUP_HOST: edgex-security-proxy-setup
-      SECRETSTORE_HOST: edgex-vault
-      SERVICE_HOST: edgex-core-metadata
-      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
-      STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: "6379"
-      STAGEGATE_DATABASE_READYPORT: "6379"
-      STAGEGATE_READY_TORUNPORT: "54329"
-      STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: "8500"
-      STAGEGATE_REGISTRY_READYPORT: "54324"
-      STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
-      STAGEGATE_WAITFOR_TIMEOUT: 60s
-    hostname: edgex-core-metadata
-    image: nexus3.edgexfoundry.org:10004/core-metadata-arm64:latest
-    networks:
-      edgex-network: null
-    ports:
-    - mode: ingress
-      host_ip: 127.0.0.1
-      target: 59881
-      published: "59881"
-      protocol: tcp
-    read_only: true
-    restart: always
-    security_opt:
-    - no-new-privileges:true
-    user: 2002:2001
-    volumes:
-    - type: volume
-      source: edgex-init
-      target: /edgex-init
-      read_only: true
-      volume: {}
-    - type: bind
-      source: /tmp/edgex/secrets/core-metadata
-      target: /tmp/edgex/secrets/core-metadata
-      read_only: true
-      bind:
-        selinux: z
-        create_host_path: true
   modbus-simulator:
     container_name: edgex-modbus-simulator
     hostname: edgex-modbus-simulator
@@ -1089,9 +1154,9 @@ services:
     - /mosquitto/config/mosquitto.conf
     container_name: edgex-mqtt-broker
     depends_on:
-      secretstore-setup:
-        condition: service_started
       security-bootstrapper:
+        condition: service_started
+      security-secretstore-setup:
         condition: service_started
     entrypoint:
     - /edgex-init/messagebus_wait_install.sh
@@ -1175,7 +1240,7 @@ services:
     - daemon off;
     container_name: edgex-nginx
     depends_on:
-      secretstore-setup:
+      security-secretstore-setup:
         condition: service_started
     entrypoint:
     - /bin/sh
@@ -1228,208 +1293,16 @@ services:
       source: nginx-tls
       target: /etc/ssl/nginx
       volume: {}
-  notifications:
-    command:
-    - /support-notifications
-    - -cp=consul.http://edgex-core-consul:8500
-    - --registry
-    container_name: edgex-support-notifications
-    depends_on:
-      consul:
-        condition: service_started
-      database:
-        condition: service_started
-      secretstore-setup:
-        condition: service_started
-      security-bootstrapper:
-        condition: service_started
-    entrypoint:
-    - /edgex-init/ready_to_run_wait_install.sh
-    environment:
-      EDGEX_SECURITY_SECRET_STORE: "true"
-      PROXY_SETUP_HOST: edgex-security-proxy-setup
-      SECRETSTORE_HOST: edgex-vault
-      SERVICE_HOST: edgex-support-notifications
-      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
-      STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: "6379"
-      STAGEGATE_DATABASE_READYPORT: "6379"
-      STAGEGATE_READY_TORUNPORT: "54329"
-      STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: "8500"
-      STAGEGATE_REGISTRY_READYPORT: "54324"
-      STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
-      STAGEGATE_WAITFOR_TIMEOUT: 60s
-    hostname: edgex-support-notifications
-    image: nexus3.edgexfoundry.org:10004/support-notifications-arm64:latest
-    networks:
-      edgex-network: null
-    ports:
-    - mode: ingress
-      host_ip: 127.0.0.1
-      target: 59860
-      published: "59860"
-      protocol: tcp
-    read_only: true
-    restart: always
-    security_opt:
-    - no-new-privileges:true
-    user: 2002:2001
-    volumes:
-    - type: volume
-      source: edgex-init
-      target: /edgex-init
-      read_only: true
-      volume: {}
-    - type: bind
-      source: /tmp/edgex/secrets/support-notifications
-      target: /tmp/edgex/secrets/support-notifications
-      read_only: true
-      bind:
-        selinux: z
-        create_host_path: true
-  proxy-auth:
-    command:
-    - entrypoint.sh
-    - /security-proxy-auth
-    - -cp=consul.http://edgex-core-consul:8500
-    - --registry
-    container_name: edgex-proxy-auth
-    depends_on:
-      secretstore-setup:
-        condition: service_started
-    entrypoint:
-    - /bin/sh
-    - /edgex-init/ready_to_run_wait_install.sh
-    environment:
-      EDGEX_SECURITY_SECRET_STORE: "true"
-      PROXY_SETUP_HOST: edgex-security-proxy-setup
-      SECRETSTORE_HOST: edgex-vault
-      SERVICE_HOST: edgex-proxy-auth
-      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
-      STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: "6379"
-      STAGEGATE_DATABASE_READYPORT: "6379"
-      STAGEGATE_READY_TORUNPORT: "54329"
-      STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: "8500"
-      STAGEGATE_REGISTRY_READYPORT: "54324"
-      STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
-      STAGEGATE_WAITFOR_TIMEOUT: 60s
-    hostname: edgex-proxy-auth
-    image: nexus3.edgexfoundry.org:10004/security-proxy-auth-arm64:latest
-    networks:
-      edgex-network: null
-    ports:
-    - mode: ingress
-      host_ip: 127.0.0.1
-      target: 59842
-      published: "59842"
-      protocol: tcp
-    read_only: true
-    restart: always
-    security_opt:
-    - no-new-privileges:true
-    volumes:
-    - type: volume
-      source: edgex-init
-      target: /edgex-init
-      read_only: true
-      volume: {}
-    - type: bind
-      source: /tmp/edgex/secrets/security-proxy-auth
-      target: /tmp/edgex/secrets/security-proxy-auth
-      read_only: true
-      bind:
-        selinux: z
-        create_host_path: true
-  proxy-setup:
-    container_name: edgex-security-proxy-setup
-    depends_on:
-      secretstore-setup:
-        condition: service_started
-      security-bootstrapper:
-        condition: service_started
-    entrypoint:
-    - /edgex-init/proxy_setup_wait_install.sh
-    environment:
-      ADD_PROXY_ROUTE: device-modbus.http://edgex-device-modbus:59901
-      EDGEX_SECURITY_SECRET_STORE: "true"
-      PROXY_SETUP_HOST: edgex-security-proxy-setup
-      ROUTES_CORE_COMMAND_HOST: edgex-core-command
-      ROUTES_CORE_CONSUL_HOST: edgex-core-consul
-      ROUTES_CORE_DATA_HOST: edgex-core-data
-      ROUTES_CORE_METADATA_HOST: edgex-core-metadata
-      ROUTES_DEVICE_VIRTUAL_HOST: device-virtual
-      ROUTES_RULES_ENGINE_HOST: edgex-kuiper
-      ROUTES_SUPPORT_NOTIFICATIONS_HOST: edgex-support-notifications
-      ROUTES_SUPPORT_SCHEDULER_HOST: edgex-support-scheduler
-      ROUTES_SYS_MGMT_AGENT_HOST: edgex-sys-mgmt-agent
-      SECRETSTORE_HOST: edgex-vault
-      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
-      STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: "6379"
-      STAGEGATE_DATABASE_READYPORT: "6379"
-      STAGEGATE_READY_TORUNPORT: "54329"
-      STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: "8500"
-      STAGEGATE_REGISTRY_READYPORT: "54324"
-      STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
-      STAGEGATE_WAITFOR_TIMEOUT: 60s
-    hostname: edgex-security-proxy-setup
-    image: nexus3.edgexfoundry.org:10004/security-proxy-setup-arm64:latest
-    networks:
-      edgex-network: null
-    read_only: true
-    security_opt:
-    - no-new-privileges:true
-    user: root:root
-    volumes:
-    - type: volume
-      source: edgex-init
-      target: /edgex-init
-      read_only: true
-      volume: {}
-    - type: volume
-      source: nginx-templates
-      target: /etc/nginx/templates
-      volume: {}
-    - type: volume
-      source: nginx-tls
-      target: /etc/ssl/nginx
-      volume: {}
-    - type: volume
-      source: consul-acl-token
-      target: /tmp/edgex/secrets/consul-acl-token
-      read_only: true
-      volume: {}
-    - type: bind
-      source: /tmp/edgex/secrets/security-proxy-setup
-      target: /tmp/edgex/secrets/security-proxy-setup
-      read_only: true
-      bind:
-        selinux: z
-        create_host_path: true
-    - type: volume
-      source: vault-config
-      target: /vault/config
-      volume: {}
-  rulesengine:
+  rules-engine:
     container_name: edgex-kuiper
     depends_on:
       database:
         condition: service_started
       mqtt-broker:
         condition: service_started
-      secretstore-setup:
-        condition: service_started
       security-bootstrapper:
+        condition: service_started
+      security-secretstore-setup:
         condition: service_started
     entrypoint:
     - /edgex-init/kuiper_wait_install.sh
@@ -1511,29 +1384,12 @@ services:
       source: kuiper-plugins
       target: /kuiper/plugins
       volume: {}
-  scalability-test-mqtt-export:
-    command:
-    - /app-service-configurable
-    - -cp=consul.http://edgex-core-consul:8500
-    - --registry
-    container_name: edgex-scalability-test-mqtt-export
-    depends_on:
-      consul:
-        condition: service_started
-      data:
-        condition: service_started
-      security-bootstrapper:
-        condition: service_started
-    entrypoint:
-    - /edgex-init/ready_to_run_wait_install.sh
+  security-bootstrapper:
+    container_name: edgex-security-bootstrapper
     environment:
-      EDGEX_PROFILE: mqtt-export
-      EDGEX_SECURITY_SECRET_STORE: "true"
-      EDGEX_SERVICE_KEY: app-scalability-test-mqtt-export
-      MESSAGEBUS_OPTIONAL_CLIENTID: app-scalability-test-mqtt-export
+      EDGEX_GROUP: "2001"
+      EDGEX_USER: "2002"
       PROXY_SETUP_HOST: edgex-security-proxy-setup
-      SECRETSTORE_HOST: edgex-vault
-      SERVICE_HOST: edgex-scalability-test-mqtt-export
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
       STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
@@ -1546,62 +1402,38 @@ services:
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
       STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
-      WRITABLE_INSECURESECRETS_MQTT_SECRETS_PASSWORD: PASSWORD_PLACE_HOLDER
-      WRITABLE_INSECURESECRETS_MQTT_SECRETS_USERNAME: USERNAME_PLACEH_OLDER
-      WRITABLE_LOGLEVEL: DEBUG
-      WRITABLE_PIPELINE_FUNCTIONS_MQTTEXPORT_PARAMETERS_BROKERADDRESS: MQTT_BROKER_ADDRESS_PLACE_HOLDER
-      WRITABLE_PIPELINE_FUNCTIONS_MQTTEXPORT_PARAMETERS_CLIENTID: scalability-test-mqtt-export
-      WRITABLE_PIPELINE_FUNCTIONS_MQTTEXPORT_PARAMETERS_TOPIC: edgex-events
-    hostname: edgex-scalability-test-mqtt-export
-    image: nexus3.edgexfoundry.org:10004/app-service-configurable-arm64:latest
+    hostname: edgex-security-bootstrapper
+    image: nexus3.edgexfoundry.org:10004/security-bootstrapper-arm64:latest
     networks:
       edgex-network: null
-    ports:
-    - mode: ingress
-      target: 59703
-      published: "59710"
-      protocol: tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
-    user: 2002:2001
+    user: root:root
     volumes:
     - type: volume
       source: edgex-init
       target: /edgex-init
-      read_only: true
       volume: {}
-    - type: bind
-      source: /tmp/edgex/secrets/app-scalability-test-mqtt-export
-      target: /tmp/edgex/secrets/app-scalability-test-mqtt-export
-      read_only: true
-      bind:
-        selinux: z
-        create_host_path: true
-  scheduler:
+  security-proxy-auth:
     command:
-    - /support-scheduler
+    - entrypoint.sh
+    - /security-proxy-auth
     - -cp=consul.http://edgex-core-consul:8500
     - --registry
-    container_name: edgex-support-scheduler
+    container_name: edgex-proxy-auth
     depends_on:
-      consul:
-        condition: service_started
-      database:
-        condition: service_started
-      secretstore-setup:
-        condition: service_started
-      security-bootstrapper:
+      security-secretstore-setup:
         condition: service_started
     entrypoint:
+    - /bin/sh
     - /edgex-init/ready_to_run_wait_install.sh
     environment:
       EDGEX_SECURITY_SECRET_STORE: "true"
-      INTERVALACTIONS_SCRUBAGED_HOST: edgex-core-data
-      INTERVALACTIONS_SCRUBPUSHED_HOST: edgex-core-data
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       SECRETSTORE_HOST: edgex-vault
-      SERVICE_HOST: edgex-support-scheduler
+      SERVICE_HOST: edgex-proxy-auth
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
       STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
@@ -1614,21 +1446,20 @@ services:
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
       STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
-    hostname: edgex-support-scheduler
-    image: nexus3.edgexfoundry.org:10004/support-scheduler-arm64:latest
+    hostname: edgex-proxy-auth
+    image: nexus3.edgexfoundry.org:10004/security-proxy-auth-arm64:latest
     networks:
       edgex-network: null
     ports:
     - mode: ingress
       host_ip: 127.0.0.1
-      target: 59861
-      published: "59861"
+      target: 59842
+      published: "59842"
       protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
-    user: 2002:2001
     volumes:
     - type: volume
       source: edgex-init
@@ -1636,13 +1467,86 @@ services:
       read_only: true
       volume: {}
     - type: bind
-      source: /tmp/edgex/secrets/support-scheduler
-      target: /tmp/edgex/secrets/support-scheduler
+      source: /tmp/edgex/secrets/security-proxy-auth
+      target: /tmp/edgex/secrets/security-proxy-auth
       read_only: true
       bind:
         selinux: z
         create_host_path: true
-  secretstore-setup:
+  security-proxy-setup:
+    container_name: edgex-security-proxy-setup
+    depends_on:
+      security-bootstrapper:
+        condition: service_started
+      security-secretstore-setup:
+        condition: service_started
+    entrypoint:
+    - /edgex-init/proxy_setup_wait_install.sh
+    environment:
+      ADD_PROXY_ROUTE: device-modbus.http://edgex-device-modbus:59901
+      EDGEX_SECURITY_SECRET_STORE: "true"
+      PROXY_SETUP_HOST: edgex-security-proxy-setup
+      ROUTES_CORE_COMMAND_HOST: edgex-core-command
+      ROUTES_CORE_CONSUL_HOST: edgex-core-consul
+      ROUTES_CORE_DATA_HOST: edgex-core-data
+      ROUTES_CORE_METADATA_HOST: edgex-core-metadata
+      ROUTES_DEVICE_VIRTUAL_HOST: device-virtual
+      ROUTES_RULES_ENGINE_HOST: edgex-kuiper
+      ROUTES_SUPPORT_NOTIFICATIONS_HOST: edgex-support-notifications
+      ROUTES_SUPPORT_SCHEDULER_HOST: edgex-support-scheduler
+      ROUTES_SYS_MGMT_AGENT_HOST: edgex-sys-mgmt-agent
+      SECRETSTORE_HOST: edgex-vault
+      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
+      STAGEGATE_DATABASE_HOST: edgex-redis
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
+      STAGEGATE_READY_TORUNPORT: "54329"
+      STAGEGATE_REGISTRY_HOST: edgex-core-consul
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
+      STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
+      STAGEGATE_WAITFOR_TIMEOUT: 60s
+    hostname: edgex-security-proxy-setup
+    image: nexus3.edgexfoundry.org:10004/security-proxy-setup-arm64:latest
+    networks:
+      edgex-network: null
+    read_only: true
+    security_opt:
+    - no-new-privileges:true
+    user: root:root
+    volumes:
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      volume: {}
+    - type: volume
+      source: nginx-templates
+      target: /etc/nginx/templates
+      volume: {}
+    - type: volume
+      source: nginx-tls
+      target: /etc/ssl/nginx
+      volume: {}
+    - type: volume
+      source: consul-acl-token
+      target: /tmp/edgex/secrets/consul-acl-token
+      read_only: true
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/security-proxy-setup
+      target: /tmp/edgex/secrets/security-proxy-setup
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
+    - type: volume
+      source: vault-config
+      target: /vault/config
+      volume: {}
+  security-secretstore-setup:
     container_name: edgex-security-secretstore-setup
     depends_on:
       security-bootstrapper:
@@ -1705,38 +1609,6 @@ services:
     - type: volume
       source: vault-config
       target: /vault/config
-      volume: {}
-  security-bootstrapper:
-    container_name: edgex-security-bootstrapper
-    environment:
-      EDGEX_GROUP: "2001"
-      EDGEX_USER: "2002"
-      PROXY_SETUP_HOST: edgex-security-proxy-setup
-      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
-      STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: "6379"
-      STAGEGATE_DATABASE_READYPORT: "6379"
-      STAGEGATE_READY_TORUNPORT: "54329"
-      STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: "8500"
-      STAGEGATE_REGISTRY_READYPORT: "54324"
-      STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
-      STAGEGATE_WAITFOR_TIMEOUT: 60s
-    hostname: edgex-security-bootstrapper
-    image: nexus3.edgexfoundry.org:10004/security-bootstrapper-arm64:latest
-    networks:
-      edgex-network: null
-    read_only: true
-    restart: always
-    security_opt:
-    - no-new-privileges:true
-    user: root:root
-    volumes:
-    - type: volume
-      source: edgex-init
-      target: /edgex-init
       volume: {}
   security-spiffe-token-provider:
     command:
@@ -1972,6 +1844,132 @@ services:
     - type: bind
       source: /tmp/edgex/secrets/spiffe
       target: /tmp/edgex/secrets/spiffe
+      bind:
+        selinux: z
+        create_host_path: true
+  support-notifications:
+    command:
+    - /support-notifications
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
+    container_name: edgex-support-notifications
+    depends_on:
+      consul:
+        condition: service_started
+      database:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
+      security-secretstore-setup:
+        condition: service_started
+    entrypoint:
+    - /edgex-init/ready_to_run_wait_install.sh
+    environment:
+      EDGEX_SECURITY_SECRET_STORE: "true"
+      PROXY_SETUP_HOST: edgex-security-proxy-setup
+      SECRETSTORE_HOST: edgex-vault
+      SERVICE_HOST: edgex-support-notifications
+      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
+      STAGEGATE_DATABASE_HOST: edgex-redis
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
+      STAGEGATE_READY_TORUNPORT: "54329"
+      STAGEGATE_REGISTRY_HOST: edgex-core-consul
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
+      STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
+      STAGEGATE_WAITFOR_TIMEOUT: 60s
+    hostname: edgex-support-notifications
+    image: nexus3.edgexfoundry.org:10004/support-notifications-arm64:latest
+    networks:
+      edgex-network: null
+    ports:
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59860
+      published: "59860"
+      protocol: tcp
+    read_only: true
+    restart: always
+    security_opt:
+    - no-new-privileges:true
+    user: 2002:2001
+    volumes:
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/support-notifications
+      target: /tmp/edgex/secrets/support-notifications
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
+  support-scheduler:
+    command:
+    - /support-scheduler
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
+    container_name: edgex-support-scheduler
+    depends_on:
+      consul:
+        condition: service_started
+      database:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
+      security-secretstore-setup:
+        condition: service_started
+    entrypoint:
+    - /edgex-init/ready_to_run_wait_install.sh
+    environment:
+      EDGEX_SECURITY_SECRET_STORE: "true"
+      INTERVALACTIONS_SCRUBAGED_HOST: edgex-core-data
+      INTERVALACTIONS_SCRUBPUSHED_HOST: edgex-core-data
+      PROXY_SETUP_HOST: edgex-security-proxy-setup
+      SECRETSTORE_HOST: edgex-vault
+      SERVICE_HOST: edgex-support-scheduler
+      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
+      STAGEGATE_DATABASE_HOST: edgex-redis
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
+      STAGEGATE_READY_TORUNPORT: "54329"
+      STAGEGATE_REGISTRY_HOST: edgex-core-consul
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
+      STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
+      STAGEGATE_WAITFOR_TIMEOUT: 60s
+    hostname: edgex-support-scheduler
+    image: nexus3.edgexfoundry.org:10004/support-scheduler-arm64:latest
+    networks:
+      edgex-network: null
+    ports:
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59861
+      published: "59861"
+      protocol: tcp
+    read_only: true
+    restart: always
+    security_opt:
+    - no-new-privileges:true
+    user: 2002:2001
+    volumes:
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/support-scheduler
+      target: /tmp/edgex/secrets/support-scheduler
+      read_only: true
       bind:
         selinux: z
         create_host_path: true

--- a/taf/docker-compose-taf-mqtt-bus.yml
+++ b/taf/docker-compose-taf-mqtt-bus.yml
@@ -26,7 +26,7 @@
 #
 name: edgex
 services:
-  app-service-external-mqtt-trigger:
+  app-external-mqtt-trigger:
     command:
     - /app-service-configurable
     - -cp=consul.http://edgex-core-consul:8500
@@ -35,7 +35,7 @@ services:
     depends_on:
       consul:
         condition: service_started
-      data:
+      core-data:
         condition: service_started
       security-bootstrapper:
         condition: service_started
@@ -91,16 +91,16 @@ services:
       bind:
         selinux: z
         create_host_path: true
-  app-service-functional-tests:
+  app-functional-tests:
     command:
     - /app-service-configurable
     - -cp=consul.http://edgex-core-consul:8500
     - --registry
-    container_name: app-functional-tests
+    container_name: edgex-app-functional-tests
     depends_on:
       consul:
         condition: service_started
-      data:
+      core-data:
         condition: service_started
       security-bootstrapper:
         condition: service_started
@@ -111,7 +111,7 @@ services:
       EDGEX_SECURITY_SECRET_STORE: "true"
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       SECRETSTORE_HOST: edgex-vault
-      SERVICE_HOST: app-functional-tests
+      SERVICE_HOST: edgex-app-functional-tests
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
       STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
@@ -124,7 +124,7 @@ services:
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
       STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
-    hostname: app-functional-tests
+    hostname: edgex-app-functional-tests
     image: nexus3.edgexfoundry.org:10004/app-service-configurable:latest
     networks:
       edgex-network: null
@@ -150,7 +150,7 @@ services:
       bind:
         selinux: z
         create_host_path: true
-  app-service-http-export:
+  app-http-export:
     command:
     - /app-service-configurable
     - -cp=consul.http://edgex-core-consul:8500
@@ -159,7 +159,7 @@ services:
     depends_on:
       consul:
         condition: service_started
-      data:
+      core-data:
         condition: service_started
       security-bootstrapper:
         condition: service_started
@@ -213,7 +213,7 @@ services:
       bind:
         selinux: z
         create_host_path: true
-  app-service-mqtt-export:
+  app-mqtt-export:
     command:
     - /app-service-configurable
     - -cp=consul.http://edgex-core-consul:8500
@@ -222,7 +222,7 @@ services:
     depends_on:
       consul:
         condition: service_started
-      data:
+      core-data:
         condition: service_started
       security-bootstrapper:
         condition: service_started
@@ -246,8 +246,6 @@ services:
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
       STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
-      WRITABLE_INSECURESECRETS_MQTT_SECRETS_PASSWORD: PASSWORD_PLACE_HOLDER
-      WRITABLE_INSECURESECRETS_MQTT_SECRETS_USERNAME: USERNAME_PLACEH_OLDER
       WRITABLE_LOGLEVEL: INFO
       WRITABLE_PIPELINE_FUNCTIONS_MQTTEXPORT_PARAMETERS_BROKERADDRESS: MQTT_BROKER_ADDRESS_PLACE_HOLDER
       WRITABLE_PIPELINE_FUNCTIONS_MQTTEXPORT_PARAMETERS_TOPIC: edgex-events
@@ -279,7 +277,7 @@ services:
       bind:
         selinux: z
         create_host_path: true
-  app-service-rules:
+  app-rules-engine:
     command:
     - /app-service-configurable
     - -cp=consul.http://edgex-core-consul:8500
@@ -288,7 +286,7 @@ services:
     depends_on:
       consul:
         condition: service_started
-      data:
+      core-data:
         condition: service_started
       security-bootstrapper:
         condition: service_started
@@ -340,7 +338,7 @@ services:
       bind:
         selinux: z
         create_host_path: true
-  app-service-sample:
+  app-sample:
     command:
     - /app-service-configurable
     - -cp=consul.http://edgex-core-consul:8500
@@ -349,7 +347,7 @@ services:
     depends_on:
       consul:
         condition: service_started
-      data:
+      core-data:
         condition: service_started
       security-bootstrapper:
         condition: service_started
@@ -404,31 +402,29 @@ services:
       bind:
         selinux: z
         create_host_path: true
-  command:
+  app-scalability-test-mqtt-export:
     command:
-    - /core-command
+    - /app-service-configurable
     - -cp=consul.http://edgex-core-consul:8500
     - --registry
-    container_name: edgex-core-command
+    container_name: edgex-app-scalability-test-mqtt-export
     depends_on:
       consul:
         condition: service_started
-      database:
-        condition: service_started
-      metadata:
-        condition: service_started
-      secretstore-setup:
+      core-data:
         condition: service_started
       security-bootstrapper:
         condition: service_started
     entrypoint:
     - /edgex-init/ready_to_run_wait_install.sh
     environment:
+      EDGEX_PROFILE: mqtt-export
       EDGEX_SECURITY_SECRET_STORE: "true"
-      EXTERNALMQTT_URL: tcp://edgex-mqtt-broker:1883
+      EDGEX_SERVICE_KEY: app-scalability-test-mqtt-export
+      MESSAGEBUS_OPTIONAL_CLIENTID: app-scalability-test-mqtt-export
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       SECRETSTORE_HOST: edgex-vault
-      SERVICE_HOST: edgex-core-command
+      SERVICE_HOST: edgex-app-scalability-test-mqtt-export
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
       STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
@@ -441,18 +437,22 @@ services:
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
       STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
-    hostname: edgex-core-command
-    image: nexus3.edgexfoundry.org:10004/core-command:latest
+      WRITABLE_INSECURESECRETS_MQTT_SECRETS_PASSWORD: PASSWORD_PLACE_HOLDER
+      WRITABLE_INSECURESECRETS_MQTT_SECRETS_USERNAME: USERNAME_PLACEH_OLDER
+      WRITABLE_LOGLEVEL: DEBUG
+      WRITABLE_PIPELINE_FUNCTIONS_MQTTEXPORT_PARAMETERS_BROKERADDRESS: MQTT_BROKER_ADDRESS_PLACE_HOLDER
+      WRITABLE_PIPELINE_FUNCTIONS_MQTTEXPORT_PARAMETERS_CLIENTID: app-scalability-test-mqtt-export
+      WRITABLE_PIPELINE_FUNCTIONS_MQTTEXPORT_PARAMETERS_TOPIC: edgex-events
+    hostname: edgex-app-scalability-test-mqtt-export
+    image: nexus3.edgexfoundry.org:10004/app-service-configurable:latest
     networks:
       edgex-network: null
     ports:
     - mode: ingress
-      host_ip: 127.0.0.1
-      target: 59882
-      published: "59882"
+      target: 59703
+      published: "59710"
       protocol: tcp
     read_only: true
-    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -463,70 +463,8 @@ services:
       read_only: true
       volume: {}
     - type: bind
-      source: /tmp/edgex/secrets/core-command
-      target: /tmp/edgex/secrets/core-command
-      read_only: true
-      bind:
-        selinux: z
-        create_host_path: true
-  common-config:
-    command:
-    - /entrypoint.sh
-    - /core-common-config-bootstrapper
-    - -cp=consul.http://edgex-core-consul:8500
-    container_name: edgex-core-common-config-bootstrapper
-    depends_on:
-      consul:
-        condition: service_started
-      secretstore-setup:
-        condition: service_started
-      security-bootstrapper:
-        condition: service_started
-    entrypoint:
-    - /edgex-init/ready_to_run_wait_install.sh
-    environment:
-      ALL_SERVICES_DATABASE_HOST: edgex-redis
-      ALL_SERVICES_MESSAGEBUS_AUTHMODE: usernamepassword
-      ALL_SERVICES_MESSAGEBUS_HOST: edgex-mqtt-broker
-      ALL_SERVICES_MESSAGEBUS_PORT: "1883"
-      ALL_SERVICES_MESSAGEBUS_PROTOCOL: tcp
-      ALL_SERVICES_MESSAGEBUS_SECRETNAME: message-bus
-      ALL_SERVICES_MESSAGEBUS_TYPE: mqtt
-      ALL_SERVICES_REGISTRY_HOST: edgex-core-consul
-      APP_SERVICES_CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
-      DEVICE_SERVICES_CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
-      EDGEX_SECURITY_SECRET_STORE: "true"
-      PROXY_SETUP_HOST: edgex-security-proxy-setup
-      SECRETSTORE_HOST: edgex-vault
-      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
-      STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: "6379"
-      STAGEGATE_DATABASE_READYPORT: "6379"
-      STAGEGATE_READY_TORUNPORT: "54329"
-      STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: "8500"
-      STAGEGATE_REGISTRY_READYPORT: "54324"
-      STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
-      STAGEGATE_WAITFOR_TIMEOUT: 60s
-    hostname: edgex-core-common-config-bootstrapper
-    image: nexus3.edgexfoundry.org:10004/core-common-config-bootstrapper:latest
-    networks:
-      edgex-network: null
-    read_only: true
-    security_opt:
-    - no-new-privileges:true
-    user: 2002:2001
-    volumes:
-    - type: volume
-      source: edgex-init
-      target: /edgex-init
-      read_only: true
-      volume: {}
-    - type: bind
-      source: /tmp/edgex/secrets/core-common-config-bootstrapper
-      target: /tmp/edgex/secrets/core-common-config-bootstrapper
+      source: /tmp/edgex/secrets/app-scalability-test-mqtt-export
+      target: /tmp/edgex/secrets/app-scalability-test-mqtt-export
       read_only: true
       bind:
         selinux: z
@@ -609,7 +547,134 @@ services:
       bind:
         selinux: z
         create_host_path: true
-  data:
+  core-command:
+    command:
+    - /core-command
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
+    container_name: edgex-core-command
+    depends_on:
+      consul:
+        condition: service_started
+      core-metadata:
+        condition: service_started
+      database:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
+      security-secretstore-setup:
+        condition: service_started
+    entrypoint:
+    - /edgex-init/ready_to_run_wait_install.sh
+    environment:
+      EDGEX_SECURITY_SECRET_STORE: "true"
+      EXTERNALMQTT_URL: tcp://edgex-mqtt-broker:1883
+      PROXY_SETUP_HOST: edgex-security-proxy-setup
+      SECRETSTORE_HOST: edgex-vault
+      SERVICE_HOST: edgex-core-command
+      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
+      STAGEGATE_DATABASE_HOST: edgex-redis
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
+      STAGEGATE_READY_TORUNPORT: "54329"
+      STAGEGATE_REGISTRY_HOST: edgex-core-consul
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
+      STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
+      STAGEGATE_WAITFOR_TIMEOUT: 60s
+    hostname: edgex-core-command
+    image: nexus3.edgexfoundry.org:10004/core-command:latest
+    networks:
+      edgex-network: null
+    ports:
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59882
+      published: "59882"
+      protocol: tcp
+    read_only: true
+    restart: always
+    security_opt:
+    - no-new-privileges:true
+    user: 2002:2001
+    volumes:
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/core-command
+      target: /tmp/edgex/secrets/core-command
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
+  core-common-config-bootstrapper:
+    command:
+    - /entrypoint.sh
+    - /core-common-config-bootstrapper
+    - -cp=consul.http://edgex-core-consul:8500
+    container_name: edgex-core-common-config-bootstrapper
+    depends_on:
+      consul:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
+      security-secretstore-setup:
+        condition: service_started
+    entrypoint:
+    - /edgex-init/ready_to_run_wait_install.sh
+    environment:
+      ALL_SERVICES_DATABASE_HOST: edgex-redis
+      ALL_SERVICES_MESSAGEBUS_AUTHMODE: usernamepassword
+      ALL_SERVICES_MESSAGEBUS_HOST: edgex-mqtt-broker
+      ALL_SERVICES_MESSAGEBUS_PORT: "1883"
+      ALL_SERVICES_MESSAGEBUS_PROTOCOL: tcp
+      ALL_SERVICES_MESSAGEBUS_SECRETNAME: message-bus
+      ALL_SERVICES_MESSAGEBUS_TYPE: mqtt
+      ALL_SERVICES_REGISTRY_HOST: edgex-core-consul
+      APP_SERVICES_CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
+      DEVICE_SERVICES_CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
+      EDGEX_SECURITY_SECRET_STORE: "true"
+      PROXY_SETUP_HOST: edgex-security-proxy-setup
+      SECRETSTORE_HOST: edgex-vault
+      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
+      STAGEGATE_DATABASE_HOST: edgex-redis
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
+      STAGEGATE_READY_TORUNPORT: "54329"
+      STAGEGATE_REGISTRY_HOST: edgex-core-consul
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
+      STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
+      STAGEGATE_WAITFOR_TIMEOUT: 60s
+    hostname: edgex-core-common-config-bootstrapper
+    image: nexus3.edgexfoundry.org:10004/core-common-config-bootstrapper:latest
+    networks:
+      edgex-network: null
+    read_only: true
+    security_opt:
+    - no-new-privileges:true
+    user: 2002:2001
+    volumes:
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/core-common-config-bootstrapper
+      target: /tmp/edgex/secrets/core-common-config-bootstrapper
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
+  core-data:
     command:
     - /core-data
     - -cp=consul.http://edgex-core-consul:8500
@@ -618,13 +683,13 @@ services:
     depends_on:
       consul:
         condition: service_started
+      core-metadata:
+        condition: service_started
       database:
         condition: service_started
-      metadata:
-        condition: service_started
-      secretstore-setup:
-        condition: service_started
       security-bootstrapper:
+        condition: service_started
+      security-secretstore-setup:
         condition: service_started
     entrypoint:
     - /edgex-init/ready_to_run_wait_install.sh
@@ -673,12 +738,74 @@ services:
       bind:
         selinux: z
         create_host_path: true
+  core-metadata:
+    command:
+    - /core-metadata
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
+    container_name: edgex-core-metadata
+    depends_on:
+      consul:
+        condition: service_started
+      database:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
+      security-secretstore-setup:
+        condition: service_started
+    entrypoint:
+    - /edgex-init/ready_to_run_wait_install.sh
+    environment:
+      EDGEX_SECURITY_SECRET_STORE: "true"
+      PROXY_SETUP_HOST: edgex-security-proxy-setup
+      SECRETSTORE_HOST: edgex-vault
+      SERVICE_HOST: edgex-core-metadata
+      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
+      STAGEGATE_DATABASE_HOST: edgex-redis
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
+      STAGEGATE_READY_TORUNPORT: "54329"
+      STAGEGATE_REGISTRY_HOST: edgex-core-consul
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
+      STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
+      STAGEGATE_WAITFOR_TIMEOUT: 60s
+    hostname: edgex-core-metadata
+    image: nexus3.edgexfoundry.org:10004/core-metadata:latest
+    networks:
+      edgex-network: null
+    ports:
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59881
+      published: "59881"
+      protocol: tcp
+    read_only: true
+    restart: always
+    security_opt:
+    - no-new-privileges:true
+    user: 2002:2001
+    volumes:
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/core-metadata
+      target: /tmp/edgex/secrets/core-metadata
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   database:
     container_name: edgex-redis
     depends_on:
-      secretstore-setup:
-        condition: service_started
       security-bootstrapper:
+        condition: service_started
+      security-secretstore-setup:
         condition: service_started
     entrypoint:
     - /edgex-init/redis_wait_install.sh
@@ -748,9 +875,9 @@ services:
     depends_on:
       consul:
         condition: service_started
-      data:
+      core-data:
         condition: service_started
-      metadata:
+      core-metadata:
         condition: service_started
       modbus-simulator:
         condition: service_started
@@ -818,9 +945,9 @@ services:
     depends_on:
       consul:
         condition: service_started
-      data:
+      core-data:
         condition: service_started
-      metadata:
+      core-metadata:
         condition: service_started
       security-bootstrapper:
         condition: service_started
@@ -880,9 +1007,9 @@ services:
     depends_on:
       consul:
         condition: service_started
-      data:
+      core-data:
         condition: service_started
-      metadata:
+      core-metadata:
         condition: service_started
       security-bootstrapper:
         condition: service_started
@@ -943,9 +1070,9 @@ services:
     depends_on:
       consul:
         condition: service_started
-      data:
+      core-data:
         condition: service_started
-      metadata:
+      core-metadata:
         condition: service_started
       security-bootstrapper:
         condition: service_started
@@ -1002,68 +1129,6 @@ services:
       bind:
         selinux: z
         create_host_path: true
-  metadata:
-    command:
-    - /core-metadata
-    - -cp=consul.http://edgex-core-consul:8500
-    - --registry
-    container_name: edgex-core-metadata
-    depends_on:
-      consul:
-        condition: service_started
-      database:
-        condition: service_started
-      secretstore-setup:
-        condition: service_started
-      security-bootstrapper:
-        condition: service_started
-    entrypoint:
-    - /edgex-init/ready_to_run_wait_install.sh
-    environment:
-      EDGEX_SECURITY_SECRET_STORE: "true"
-      PROXY_SETUP_HOST: edgex-security-proxy-setup
-      SECRETSTORE_HOST: edgex-vault
-      SERVICE_HOST: edgex-core-metadata
-      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
-      STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: "6379"
-      STAGEGATE_DATABASE_READYPORT: "6379"
-      STAGEGATE_READY_TORUNPORT: "54329"
-      STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: "8500"
-      STAGEGATE_REGISTRY_READYPORT: "54324"
-      STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
-      STAGEGATE_WAITFOR_TIMEOUT: 60s
-    hostname: edgex-core-metadata
-    image: nexus3.edgexfoundry.org:10004/core-metadata:latest
-    networks:
-      edgex-network: null
-    ports:
-    - mode: ingress
-      host_ip: 127.0.0.1
-      target: 59881
-      published: "59881"
-      protocol: tcp
-    read_only: true
-    restart: always
-    security_opt:
-    - no-new-privileges:true
-    user: 2002:2001
-    volumes:
-    - type: volume
-      source: edgex-init
-      target: /edgex-init
-      read_only: true
-      volume: {}
-    - type: bind
-      source: /tmp/edgex/secrets/core-metadata
-      target: /tmp/edgex/secrets/core-metadata
-      read_only: true
-      bind:
-        selinux: z
-        create_host_path: true
   modbus-simulator:
     container_name: edgex-modbus-simulator
     hostname: edgex-modbus-simulator
@@ -1089,9 +1154,9 @@ services:
     - /mosquitto/config/mosquitto.conf
     container_name: edgex-mqtt-broker
     depends_on:
-      secretstore-setup:
-        condition: service_started
       security-bootstrapper:
+        condition: service_started
+      security-secretstore-setup:
         condition: service_started
     entrypoint:
     - /edgex-init/messagebus_wait_install.sh
@@ -1175,7 +1240,7 @@ services:
     - daemon off;
     container_name: edgex-nginx
     depends_on:
-      secretstore-setup:
+      security-secretstore-setup:
         condition: service_started
     entrypoint:
     - /bin/sh
@@ -1228,208 +1293,16 @@ services:
       source: nginx-tls
       target: /etc/ssl/nginx
       volume: {}
-  notifications:
-    command:
-    - /support-notifications
-    - -cp=consul.http://edgex-core-consul:8500
-    - --registry
-    container_name: edgex-support-notifications
-    depends_on:
-      consul:
-        condition: service_started
-      database:
-        condition: service_started
-      secretstore-setup:
-        condition: service_started
-      security-bootstrapper:
-        condition: service_started
-    entrypoint:
-    - /edgex-init/ready_to_run_wait_install.sh
-    environment:
-      EDGEX_SECURITY_SECRET_STORE: "true"
-      PROXY_SETUP_HOST: edgex-security-proxy-setup
-      SECRETSTORE_HOST: edgex-vault
-      SERVICE_HOST: edgex-support-notifications
-      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
-      STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: "6379"
-      STAGEGATE_DATABASE_READYPORT: "6379"
-      STAGEGATE_READY_TORUNPORT: "54329"
-      STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: "8500"
-      STAGEGATE_REGISTRY_READYPORT: "54324"
-      STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
-      STAGEGATE_WAITFOR_TIMEOUT: 60s
-    hostname: edgex-support-notifications
-    image: nexus3.edgexfoundry.org:10004/support-notifications:latest
-    networks:
-      edgex-network: null
-    ports:
-    - mode: ingress
-      host_ip: 127.0.0.1
-      target: 59860
-      published: "59860"
-      protocol: tcp
-    read_only: true
-    restart: always
-    security_opt:
-    - no-new-privileges:true
-    user: 2002:2001
-    volumes:
-    - type: volume
-      source: edgex-init
-      target: /edgex-init
-      read_only: true
-      volume: {}
-    - type: bind
-      source: /tmp/edgex/secrets/support-notifications
-      target: /tmp/edgex/secrets/support-notifications
-      read_only: true
-      bind:
-        selinux: z
-        create_host_path: true
-  proxy-auth:
-    command:
-    - entrypoint.sh
-    - /security-proxy-auth
-    - -cp=consul.http://edgex-core-consul:8500
-    - --registry
-    container_name: edgex-proxy-auth
-    depends_on:
-      secretstore-setup:
-        condition: service_started
-    entrypoint:
-    - /bin/sh
-    - /edgex-init/ready_to_run_wait_install.sh
-    environment:
-      EDGEX_SECURITY_SECRET_STORE: "true"
-      PROXY_SETUP_HOST: edgex-security-proxy-setup
-      SECRETSTORE_HOST: edgex-vault
-      SERVICE_HOST: edgex-proxy-auth
-      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
-      STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: "6379"
-      STAGEGATE_DATABASE_READYPORT: "6379"
-      STAGEGATE_READY_TORUNPORT: "54329"
-      STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: "8500"
-      STAGEGATE_REGISTRY_READYPORT: "54324"
-      STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
-      STAGEGATE_WAITFOR_TIMEOUT: 60s
-    hostname: edgex-proxy-auth
-    image: nexus3.edgexfoundry.org:10004/security-proxy-auth:latest
-    networks:
-      edgex-network: null
-    ports:
-    - mode: ingress
-      host_ip: 127.0.0.1
-      target: 59842
-      published: "59842"
-      protocol: tcp
-    read_only: true
-    restart: always
-    security_opt:
-    - no-new-privileges:true
-    volumes:
-    - type: volume
-      source: edgex-init
-      target: /edgex-init
-      read_only: true
-      volume: {}
-    - type: bind
-      source: /tmp/edgex/secrets/security-proxy-auth
-      target: /tmp/edgex/secrets/security-proxy-auth
-      read_only: true
-      bind:
-        selinux: z
-        create_host_path: true
-  proxy-setup:
-    container_name: edgex-security-proxy-setup
-    depends_on:
-      secretstore-setup:
-        condition: service_started
-      security-bootstrapper:
-        condition: service_started
-    entrypoint:
-    - /edgex-init/proxy_setup_wait_install.sh
-    environment:
-      ADD_PROXY_ROUTE: device-modbus.http://edgex-device-modbus:59901
-      EDGEX_SECURITY_SECRET_STORE: "true"
-      PROXY_SETUP_HOST: edgex-security-proxy-setup
-      ROUTES_CORE_COMMAND_HOST: edgex-core-command
-      ROUTES_CORE_CONSUL_HOST: edgex-core-consul
-      ROUTES_CORE_DATA_HOST: edgex-core-data
-      ROUTES_CORE_METADATA_HOST: edgex-core-metadata
-      ROUTES_DEVICE_VIRTUAL_HOST: device-virtual
-      ROUTES_RULES_ENGINE_HOST: edgex-kuiper
-      ROUTES_SUPPORT_NOTIFICATIONS_HOST: edgex-support-notifications
-      ROUTES_SUPPORT_SCHEDULER_HOST: edgex-support-scheduler
-      ROUTES_SYS_MGMT_AGENT_HOST: edgex-sys-mgmt-agent
-      SECRETSTORE_HOST: edgex-vault
-      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
-      STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: "6379"
-      STAGEGATE_DATABASE_READYPORT: "6379"
-      STAGEGATE_READY_TORUNPORT: "54329"
-      STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: "8500"
-      STAGEGATE_REGISTRY_READYPORT: "54324"
-      STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
-      STAGEGATE_WAITFOR_TIMEOUT: 60s
-    hostname: edgex-security-proxy-setup
-    image: nexus3.edgexfoundry.org:10004/security-proxy-setup:latest
-    networks:
-      edgex-network: null
-    read_only: true
-    security_opt:
-    - no-new-privileges:true
-    user: root:root
-    volumes:
-    - type: volume
-      source: edgex-init
-      target: /edgex-init
-      read_only: true
-      volume: {}
-    - type: volume
-      source: nginx-templates
-      target: /etc/nginx/templates
-      volume: {}
-    - type: volume
-      source: nginx-tls
-      target: /etc/ssl/nginx
-      volume: {}
-    - type: volume
-      source: consul-acl-token
-      target: /tmp/edgex/secrets/consul-acl-token
-      read_only: true
-      volume: {}
-    - type: bind
-      source: /tmp/edgex/secrets/security-proxy-setup
-      target: /tmp/edgex/secrets/security-proxy-setup
-      read_only: true
-      bind:
-        selinux: z
-        create_host_path: true
-    - type: volume
-      source: vault-config
-      target: /vault/config
-      volume: {}
-  rulesengine:
+  rules-engine:
     container_name: edgex-kuiper
     depends_on:
       database:
         condition: service_started
       mqtt-broker:
         condition: service_started
-      secretstore-setup:
-        condition: service_started
       security-bootstrapper:
+        condition: service_started
+      security-secretstore-setup:
         condition: service_started
     entrypoint:
     - /edgex-init/kuiper_wait_install.sh
@@ -1511,29 +1384,12 @@ services:
       source: kuiper-plugins
       target: /kuiper/plugins
       volume: {}
-  scalability-test-mqtt-export:
-    command:
-    - /app-service-configurable
-    - -cp=consul.http://edgex-core-consul:8500
-    - --registry
-    container_name: edgex-scalability-test-mqtt-export
-    depends_on:
-      consul:
-        condition: service_started
-      data:
-        condition: service_started
-      security-bootstrapper:
-        condition: service_started
-    entrypoint:
-    - /edgex-init/ready_to_run_wait_install.sh
+  security-bootstrapper:
+    container_name: edgex-security-bootstrapper
     environment:
-      EDGEX_PROFILE: mqtt-export
-      EDGEX_SECURITY_SECRET_STORE: "true"
-      EDGEX_SERVICE_KEY: app-scalability-test-mqtt-export
-      MESSAGEBUS_OPTIONAL_CLIENTID: app-scalability-test-mqtt-export
+      EDGEX_GROUP: "2001"
+      EDGEX_USER: "2002"
       PROXY_SETUP_HOST: edgex-security-proxy-setup
-      SECRETSTORE_HOST: edgex-vault
-      SERVICE_HOST: edgex-scalability-test-mqtt-export
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
       STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
@@ -1546,62 +1402,38 @@ services:
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
       STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
-      WRITABLE_INSECURESECRETS_MQTT_SECRETS_PASSWORD: PASSWORD_PLACE_HOLDER
-      WRITABLE_INSECURESECRETS_MQTT_SECRETS_USERNAME: USERNAME_PLACEH_OLDER
-      WRITABLE_LOGLEVEL: DEBUG
-      WRITABLE_PIPELINE_FUNCTIONS_MQTTEXPORT_PARAMETERS_BROKERADDRESS: MQTT_BROKER_ADDRESS_PLACE_HOLDER
-      WRITABLE_PIPELINE_FUNCTIONS_MQTTEXPORT_PARAMETERS_CLIENTID: scalability-test-mqtt-export
-      WRITABLE_PIPELINE_FUNCTIONS_MQTTEXPORT_PARAMETERS_TOPIC: edgex-events
-    hostname: edgex-scalability-test-mqtt-export
-    image: nexus3.edgexfoundry.org:10004/app-service-configurable:latest
+    hostname: edgex-security-bootstrapper
+    image: nexus3.edgexfoundry.org:10004/security-bootstrapper:latest
     networks:
       edgex-network: null
-    ports:
-    - mode: ingress
-      target: 59703
-      published: "59710"
-      protocol: tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
-    user: 2002:2001
+    user: root:root
     volumes:
     - type: volume
       source: edgex-init
       target: /edgex-init
-      read_only: true
       volume: {}
-    - type: bind
-      source: /tmp/edgex/secrets/app-scalability-test-mqtt-export
-      target: /tmp/edgex/secrets/app-scalability-test-mqtt-export
-      read_only: true
-      bind:
-        selinux: z
-        create_host_path: true
-  scheduler:
+  security-proxy-auth:
     command:
-    - /support-scheduler
+    - entrypoint.sh
+    - /security-proxy-auth
     - -cp=consul.http://edgex-core-consul:8500
     - --registry
-    container_name: edgex-support-scheduler
+    container_name: edgex-proxy-auth
     depends_on:
-      consul:
-        condition: service_started
-      database:
-        condition: service_started
-      secretstore-setup:
-        condition: service_started
-      security-bootstrapper:
+      security-secretstore-setup:
         condition: service_started
     entrypoint:
+    - /bin/sh
     - /edgex-init/ready_to_run_wait_install.sh
     environment:
       EDGEX_SECURITY_SECRET_STORE: "true"
-      INTERVALACTIONS_SCRUBAGED_HOST: edgex-core-data
-      INTERVALACTIONS_SCRUBPUSHED_HOST: edgex-core-data
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       SECRETSTORE_HOST: edgex-vault
-      SERVICE_HOST: edgex-support-scheduler
+      SERVICE_HOST: edgex-proxy-auth
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
       STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
@@ -1614,21 +1446,20 @@ services:
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
       STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
-    hostname: edgex-support-scheduler
-    image: nexus3.edgexfoundry.org:10004/support-scheduler:latest
+    hostname: edgex-proxy-auth
+    image: nexus3.edgexfoundry.org:10004/security-proxy-auth:latest
     networks:
       edgex-network: null
     ports:
     - mode: ingress
       host_ip: 127.0.0.1
-      target: 59861
-      published: "59861"
+      target: 59842
+      published: "59842"
       protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
-    user: 2002:2001
     volumes:
     - type: volume
       source: edgex-init
@@ -1636,13 +1467,86 @@ services:
       read_only: true
       volume: {}
     - type: bind
-      source: /tmp/edgex/secrets/support-scheduler
-      target: /tmp/edgex/secrets/support-scheduler
+      source: /tmp/edgex/secrets/security-proxy-auth
+      target: /tmp/edgex/secrets/security-proxy-auth
       read_only: true
       bind:
         selinux: z
         create_host_path: true
-  secretstore-setup:
+  security-proxy-setup:
+    container_name: edgex-security-proxy-setup
+    depends_on:
+      security-bootstrapper:
+        condition: service_started
+      security-secretstore-setup:
+        condition: service_started
+    entrypoint:
+    - /edgex-init/proxy_setup_wait_install.sh
+    environment:
+      ADD_PROXY_ROUTE: device-modbus.http://edgex-device-modbus:59901
+      EDGEX_SECURITY_SECRET_STORE: "true"
+      PROXY_SETUP_HOST: edgex-security-proxy-setup
+      ROUTES_CORE_COMMAND_HOST: edgex-core-command
+      ROUTES_CORE_CONSUL_HOST: edgex-core-consul
+      ROUTES_CORE_DATA_HOST: edgex-core-data
+      ROUTES_CORE_METADATA_HOST: edgex-core-metadata
+      ROUTES_DEVICE_VIRTUAL_HOST: device-virtual
+      ROUTES_RULES_ENGINE_HOST: edgex-kuiper
+      ROUTES_SUPPORT_NOTIFICATIONS_HOST: edgex-support-notifications
+      ROUTES_SUPPORT_SCHEDULER_HOST: edgex-support-scheduler
+      ROUTES_SYS_MGMT_AGENT_HOST: edgex-sys-mgmt-agent
+      SECRETSTORE_HOST: edgex-vault
+      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
+      STAGEGATE_DATABASE_HOST: edgex-redis
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
+      STAGEGATE_READY_TORUNPORT: "54329"
+      STAGEGATE_REGISTRY_HOST: edgex-core-consul
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
+      STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
+      STAGEGATE_WAITFOR_TIMEOUT: 60s
+    hostname: edgex-security-proxy-setup
+    image: nexus3.edgexfoundry.org:10004/security-proxy-setup:latest
+    networks:
+      edgex-network: null
+    read_only: true
+    security_opt:
+    - no-new-privileges:true
+    user: root:root
+    volumes:
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      volume: {}
+    - type: volume
+      source: nginx-templates
+      target: /etc/nginx/templates
+      volume: {}
+    - type: volume
+      source: nginx-tls
+      target: /etc/ssl/nginx
+      volume: {}
+    - type: volume
+      source: consul-acl-token
+      target: /tmp/edgex/secrets/consul-acl-token
+      read_only: true
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/security-proxy-setup
+      target: /tmp/edgex/secrets/security-proxy-setup
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
+    - type: volume
+      source: vault-config
+      target: /vault/config
+      volume: {}
+  security-secretstore-setup:
     container_name: edgex-security-secretstore-setup
     depends_on:
       security-bootstrapper:
@@ -1705,38 +1609,6 @@ services:
     - type: volume
       source: vault-config
       target: /vault/config
-      volume: {}
-  security-bootstrapper:
-    container_name: edgex-security-bootstrapper
-    environment:
-      EDGEX_GROUP: "2001"
-      EDGEX_USER: "2002"
-      PROXY_SETUP_HOST: edgex-security-proxy-setup
-      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
-      STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: "6379"
-      STAGEGATE_DATABASE_READYPORT: "6379"
-      STAGEGATE_READY_TORUNPORT: "54329"
-      STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: "8500"
-      STAGEGATE_REGISTRY_READYPORT: "54324"
-      STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
-      STAGEGATE_WAITFOR_TIMEOUT: 60s
-    hostname: edgex-security-bootstrapper
-    image: nexus3.edgexfoundry.org:10004/security-bootstrapper:latest
-    networks:
-      edgex-network: null
-    read_only: true
-    restart: always
-    security_opt:
-    - no-new-privileges:true
-    user: root:root
-    volumes:
-    - type: volume
-      source: edgex-init
-      target: /edgex-init
       volume: {}
   security-spiffe-token-provider:
     command:
@@ -1972,6 +1844,132 @@ services:
     - type: bind
       source: /tmp/edgex/secrets/spiffe
       target: /tmp/edgex/secrets/spiffe
+      bind:
+        selinux: z
+        create_host_path: true
+  support-notifications:
+    command:
+    - /support-notifications
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
+    container_name: edgex-support-notifications
+    depends_on:
+      consul:
+        condition: service_started
+      database:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
+      security-secretstore-setup:
+        condition: service_started
+    entrypoint:
+    - /edgex-init/ready_to_run_wait_install.sh
+    environment:
+      EDGEX_SECURITY_SECRET_STORE: "true"
+      PROXY_SETUP_HOST: edgex-security-proxy-setup
+      SECRETSTORE_HOST: edgex-vault
+      SERVICE_HOST: edgex-support-notifications
+      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
+      STAGEGATE_DATABASE_HOST: edgex-redis
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
+      STAGEGATE_READY_TORUNPORT: "54329"
+      STAGEGATE_REGISTRY_HOST: edgex-core-consul
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
+      STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
+      STAGEGATE_WAITFOR_TIMEOUT: 60s
+    hostname: edgex-support-notifications
+    image: nexus3.edgexfoundry.org:10004/support-notifications:latest
+    networks:
+      edgex-network: null
+    ports:
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59860
+      published: "59860"
+      protocol: tcp
+    read_only: true
+    restart: always
+    security_opt:
+    - no-new-privileges:true
+    user: 2002:2001
+    volumes:
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/support-notifications
+      target: /tmp/edgex/secrets/support-notifications
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
+  support-scheduler:
+    command:
+    - /support-scheduler
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
+    container_name: edgex-support-scheduler
+    depends_on:
+      consul:
+        condition: service_started
+      database:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
+      security-secretstore-setup:
+        condition: service_started
+    entrypoint:
+    - /edgex-init/ready_to_run_wait_install.sh
+    environment:
+      EDGEX_SECURITY_SECRET_STORE: "true"
+      INTERVALACTIONS_SCRUBAGED_HOST: edgex-core-data
+      INTERVALACTIONS_SCRUBPUSHED_HOST: edgex-core-data
+      PROXY_SETUP_HOST: edgex-security-proxy-setup
+      SECRETSTORE_HOST: edgex-vault
+      SERVICE_HOST: edgex-support-scheduler
+      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
+      STAGEGATE_DATABASE_HOST: edgex-redis
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
+      STAGEGATE_READY_TORUNPORT: "54329"
+      STAGEGATE_REGISTRY_HOST: edgex-core-consul
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
+      STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
+      STAGEGATE_WAITFOR_TIMEOUT: 60s
+    hostname: edgex-support-scheduler
+    image: nexus3.edgexfoundry.org:10004/support-scheduler:latest
+    networks:
+      edgex-network: null
+    ports:
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59861
+      published: "59861"
+      protocol: tcp
+    read_only: true
+    restart: always
+    security_opt:
+    - no-new-privileges:true
+    user: 2002:2001
+    volumes:
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/support-scheduler
+      target: /tmp/edgex/secrets/support-scheduler
+      read_only: true
       bind:
         selinux: z
         create_host_path: true

--- a/taf/docker-compose-taf-no-secty-arm64.yml
+++ b/taf/docker-compose-taf-no-secty-arm64.yml
@@ -26,12 +26,12 @@
 #
 name: edgex
 services:
-  app-service-external-mqtt-trigger:
+  app-external-mqtt-trigger:
     container_name: edgex-app-external-mqtt-trigger
     depends_on:
       consul:
         condition: service_started
-      data:
+      core-data:
         condition: service_started
     environment:
       EDGEX_PROFILE: external-mqtt-trigger
@@ -56,18 +56,18 @@ services:
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
-  app-service-functional-tests:
-    container_name: app-functional-tests
+  app-functional-tests:
+    container_name: edgex-app-functional-tests
     depends_on:
       consul:
         condition: service_started
-      data:
+      core-data:
         condition: service_started
     environment:
       EDGEX_PROFILE: functional-tests
       EDGEX_SECURITY_SECRET_STORE: "false"
-      SERVICE_HOST: app-functional-tests
-    hostname: app-functional-tests
+      SERVICE_HOST: edgex-app-functional-tests
+    hostname: edgex-app-functional-tests
     image: nexus3.edgexfoundry.org:10004/app-service-configurable-arm64:latest
     networks:
       edgex-network: null
@@ -80,12 +80,12 @@ services:
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
-  app-service-http-export:
+  app-http-export:
     container_name: edgex-app-http-export
     depends_on:
       consul:
         condition: service_started
-      data:
+      core-data:
         condition: service_started
     environment:
       EDGEX_PROFILE: http-export
@@ -108,12 +108,12 @@ services:
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
-  app-service-mqtt-export:
+  app-mqtt-export:
     container_name: edgex-app-mqtt-export
     depends_on:
       consul:
         condition: service_started
-      data:
+      core-data:
         condition: service_started
     environment:
       EDGEX_PROFILE: mqtt-export
@@ -137,12 +137,12 @@ services:
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
-  app-service-rules:
+  app-rules-engine:
     container_name: edgex-app-rules-engine
     depends_on:
       consul:
         condition: service_started
-      data:
+      core-data:
         condition: service_started
     environment:
       EDGEX_PROFILE: rules-engine
@@ -163,12 +163,12 @@ services:
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
-  app-service-sample:
+  app-sample:
     container_name: edgex-app-sample
     depends_on:
       consul:
         condition: service_started
-      data:
+      core-data:
         condition: service_started
     environment:
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
@@ -192,50 +192,32 @@ services:
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
-  command:
-    container_name: edgex-core-command
+  app-scalability-test-mqtt-export:
+    container_name: edgex-app-scalability-test-mqtt-export
     depends_on:
       consul:
         condition: service_started
-      database:
-        condition: service_started
-      metadata:
+      core-data:
         condition: service_started
     environment:
+      EDGEX_PROFILE: mqtt-export
       EDGEX_SECURITY_SECRET_STORE: "false"
-      EXTERNALMQTT_URL: tcp://edgex-mqtt-broker:1883
-      SERVICE_HOST: edgex-core-command
-    hostname: edgex-core-command
-    image: nexus3.edgexfoundry.org:10004/core-command-arm64:latest
+      EDGEX_SERVICE_KEY: app-scalability-test-mqtt-export
+      MESSAGEBUS_OPTIONAL_CLIENTID: app-scalability-test-mqtt-export
+      SERVICE_HOST: edgex-app-scalability-test-mqtt-export
+      WRITABLE_LOGLEVEL: DEBUG
+      WRITABLE_PIPELINE_FUNCTIONS_MQTTEXPORT_PARAMETERS_BROKERADDRESS: MQTT_BROKER_ADDRESS_PLACE_HOLDER
+      WRITABLE_PIPELINE_FUNCTIONS_MQTTEXPORT_PARAMETERS_CLIENTID: app-scalability-test-mqtt-export
+      WRITABLE_PIPELINE_FUNCTIONS_MQTTEXPORT_PARAMETERS_TOPIC: edgex-events
+    hostname: edgex-app-scalability-test-mqtt-export
+    image: nexus3.edgexfoundry.org:10004/app-service-configurable-arm64:latest
     networks:
       edgex-network: null
     ports:
     - mode: ingress
-      host_ip: 127.0.0.1
-      target: 59882
-      published: "59882"
+      target: 59703
+      published: "59710"
       protocol: tcp
-    read_only: true
-    restart: always
-    security_opt:
-    - no-new-privileges:true
-    user: 2002:2001
-  common-config:
-    container_name: edgex-core-common-config-bootstrapper
-    depends_on:
-      consul:
-        condition: service_started
-    environment:
-      ALL_SERVICES_DATABASE_HOST: edgex-redis
-      ALL_SERVICES_MESSAGEBUS_HOST: edgex-redis
-      ALL_SERVICES_REGISTRY_HOST: edgex-core-consul
-      APP_SERVICES_CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
-      DEVICE_SERVICES_CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
-      EDGEX_SECURITY_SECRET_STORE: "false"
-    hostname: edgex-core-common-config-bootstrapper
-    image: nexus3.edgexfoundry.org:10004/core-common-config-bootstrapper-arm64:latest
-    networks:
-      edgex-network: null
     read_only: true
     security_opt:
     - no-new-privileges:true
@@ -273,14 +255,62 @@ services:
       source: consul-data
       target: /consul/data
       volume: {}
-  data:
+  core-command:
+    container_name: edgex-core-command
+    depends_on:
+      consul:
+        condition: service_started
+      core-metadata:
+        condition: service_started
+      database:
+        condition: service_started
+    environment:
+      EDGEX_SECURITY_SECRET_STORE: "false"
+      EXTERNALMQTT_URL: tcp://edgex-mqtt-broker:1883
+      SERVICE_HOST: edgex-core-command
+    hostname: edgex-core-command
+    image: nexus3.edgexfoundry.org:10004/core-command-arm64:latest
+    networks:
+      edgex-network: null
+    ports:
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59882
+      published: "59882"
+      protocol: tcp
+    read_only: true
+    restart: always
+    security_opt:
+    - no-new-privileges:true
+    user: 2002:2001
+  core-common-config-bootstrapper:
+    container_name: edgex-core-common-config-bootstrapper
+    depends_on:
+      consul:
+        condition: service_started
+    environment:
+      ALL_SERVICES_DATABASE_HOST: edgex-redis
+      ALL_SERVICES_MESSAGEBUS_HOST: edgex-redis
+      ALL_SERVICES_REGISTRY_HOST: edgex-core-consul
+      APP_SERVICES_CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
+      DEVICE_SERVICES_CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
+      EDGEX_SECURITY_SECRET_STORE: "false"
+    hostname: edgex-core-common-config-bootstrapper
+    image: nexus3.edgexfoundry.org:10004/core-common-config-bootstrapper-arm64:latest
+    networks:
+      edgex-network: null
+    read_only: true
+    security_opt:
+    - no-new-privileges:true
+    user: 2002:2001
+  core-data:
     container_name: edgex-core-data
     depends_on:
       consul:
         condition: service_started
-      database:
+      core-metadata:
         condition: service_started
-      metadata:
+      database:
         condition: service_started
     environment:
       EDGEX_SECURITY_SECRET_STORE: "false"
@@ -294,6 +324,31 @@ services:
       host_ip: 127.0.0.1
       target: 59880
       published: "59880"
+      protocol: tcp
+    read_only: true
+    restart: always
+    security_opt:
+    - no-new-privileges:true
+    user: 2002:2001
+  core-metadata:
+    container_name: edgex-core-metadata
+    depends_on:
+      consul:
+        condition: service_started
+      database:
+        condition: service_started
+    environment:
+      EDGEX_SECURITY_SECRET_STORE: "false"
+      SERVICE_HOST: edgex-core-metadata
+    hostname: edgex-core-metadata
+    image: nexus3.edgexfoundry.org:10004/core-metadata-arm64:latest
+    networks:
+      edgex-network: null
+    ports:
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59881
+      published: "59881"
       protocol: tcp
     read_only: true
     restart: always
@@ -331,9 +386,9 @@ services:
     depends_on:
       consul:
         condition: service_started
-      data:
+      core-data:
         condition: service_started
-      metadata:
+      core-metadata:
         condition: service_started
       modbus-simulator:
         condition: service_started
@@ -367,9 +422,9 @@ services:
     depends_on:
       consul:
         condition: service_started
-      data:
+      core-data:
         condition: service_started
-      metadata:
+      core-metadata:
         condition: service_started
     environment:
       EDGEX_SECURITY_SECRET_STORE: "false"
@@ -394,9 +449,9 @@ services:
     depends_on:
       consul:
         condition: service_started
-      data:
+      core-data:
         condition: service_started
-      metadata:
+      core-metadata:
         condition: service_started
     environment:
       EDGEX_SECURITY_SECRET_STORE: "false"
@@ -425,9 +480,9 @@ services:
     depends_on:
       consul:
         condition: service_started
-      data:
+      core-data:
         condition: service_started
-      metadata:
+      core-metadata:
         condition: service_started
     environment:
       EDGEX_SECURITY_SECRET_STORE: "false"
@@ -454,31 +509,6 @@ services:
       bind:
         selinux: z
         create_host_path: true
-  metadata:
-    container_name: edgex-core-metadata
-    depends_on:
-      consul:
-        condition: service_started
-      database:
-        condition: service_started
-    environment:
-      EDGEX_SECURITY_SECRET_STORE: "false"
-      SERVICE_HOST: edgex-core-metadata
-    hostname: edgex-core-metadata
-    image: nexus3.edgexfoundry.org:10004/core-metadata-arm64:latest
-    networks:
-      edgex-network: null
-    ports:
-    - mode: ingress
-      host_ip: 127.0.0.1
-      target: 59881
-      published: "59881"
-      protocol: tcp
-    read_only: true
-    restart: always
-    security_opt:
-    - no-new-privileges:true
-    user: 2002:2001
   modbus-simulator:
     container_name: edgex-modbus-simulator
     hostname: edgex-modbus-simulator
@@ -538,32 +568,7 @@ services:
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
-  notifications:
-    container_name: edgex-support-notifications
-    depends_on:
-      consul:
-        condition: service_started
-      database:
-        condition: service_started
-    environment:
-      EDGEX_SECURITY_SECRET_STORE: "false"
-      SERVICE_HOST: edgex-support-notifications
-    hostname: edgex-support-notifications
-    image: nexus3.edgexfoundry.org:10004/support-notifications-arm64:latest
-    networks:
-      edgex-network: null
-    ports:
-    - mode: ingress
-      host_ip: 127.0.0.1
-      target: 59860
-      published: "59860"
-      protocol: tcp
-    read_only: true
-    restart: always
-    security_opt:
-    - no-new-privileges:true
-    user: 2002:2001
-  rulesengine:
+  rules-engine:
     container_name: edgex-kuiper
     depends_on:
       database:
@@ -612,37 +617,32 @@ services:
       source: kuiper-plugins
       target: /kuiper/plugins
       volume: {}
-  scalability-test-mqtt-export:
-    container_name: edgex-scalability-test-mqtt-export
+  support-notifications:
+    container_name: edgex-support-notifications
     depends_on:
       consul:
         condition: service_started
-      data:
+      database:
         condition: service_started
     environment:
-      EDGEX_PROFILE: mqtt-export
       EDGEX_SECURITY_SECRET_STORE: "false"
-      EDGEX_SERVICE_KEY: app-scalability-test-mqtt-export
-      MESSAGEBUS_OPTIONAL_CLIENTID: app-scalability-test-mqtt-export
-      SERVICE_HOST: edgex-scalability-test-mqtt-export
-      WRITABLE_LOGLEVEL: DEBUG
-      WRITABLE_PIPELINE_FUNCTIONS_MQTTEXPORT_PARAMETERS_BROKERADDRESS: MQTT_BROKER_ADDRESS_PLACE_HOLDER
-      WRITABLE_PIPELINE_FUNCTIONS_MQTTEXPORT_PARAMETERS_CLIENTID: scalability-test-mqtt-export
-      WRITABLE_PIPELINE_FUNCTIONS_MQTTEXPORT_PARAMETERS_TOPIC: edgex-events
-    hostname: edgex-scalability-test-mqtt-export
-    image: nexus3.edgexfoundry.org:10004/app-service-configurable-arm64:latest
+      SERVICE_HOST: edgex-support-notifications
+    hostname: edgex-support-notifications
+    image: nexus3.edgexfoundry.org:10004/support-notifications-arm64:latest
     networks:
       edgex-network: null
     ports:
     - mode: ingress
-      target: 59703
-      published: "59710"
+      host_ip: 127.0.0.1
+      target: 59860
+      published: "59860"
       protocol: tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
-  scheduler:
+  support-scheduler:
     container_name: edgex-support-scheduler
     depends_on:
       consul:

--- a/taf/docker-compose-taf-no-secty-mqtt-bus-arm64.yml
+++ b/taf/docker-compose-taf-no-secty-mqtt-bus-arm64.yml
@@ -26,12 +26,12 @@
 #
 name: edgex
 services:
-  app-service-external-mqtt-trigger:
+  app-external-mqtt-trigger:
     container_name: edgex-app-external-mqtt-trigger
     depends_on:
       consul:
         condition: service_started
-      data:
+      core-data:
         condition: service_started
     environment:
       EDGEX_PROFILE: external-mqtt-trigger
@@ -56,18 +56,18 @@ services:
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
-  app-service-functional-tests:
-    container_name: app-functional-tests
+  app-functional-tests:
+    container_name: edgex-app-functional-tests
     depends_on:
       consul:
         condition: service_started
-      data:
+      core-data:
         condition: service_started
     environment:
       EDGEX_PROFILE: functional-tests
       EDGEX_SECURITY_SECRET_STORE: "false"
-      SERVICE_HOST: app-functional-tests
-    hostname: app-functional-tests
+      SERVICE_HOST: edgex-app-functional-tests
+    hostname: edgex-app-functional-tests
     image: nexus3.edgexfoundry.org:10004/app-service-configurable-arm64:latest
     networks:
       edgex-network: null
@@ -80,12 +80,12 @@ services:
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
-  app-service-http-export:
+  app-http-export:
     container_name: edgex-app-http-export
     depends_on:
       consul:
         condition: service_started
-      data:
+      core-data:
         condition: service_started
     environment:
       EDGEX_PROFILE: http-export
@@ -108,12 +108,12 @@ services:
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
-  app-service-mqtt-export:
+  app-mqtt-export:
     container_name: edgex-app-mqtt-export
     depends_on:
       consul:
         condition: service_started
-      data:
+      core-data:
         condition: service_started
     environment:
       EDGEX_PROFILE: mqtt-export
@@ -137,12 +137,12 @@ services:
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
-  app-service-rules:
+  app-rules-engine:
     container_name: edgex-app-rules-engine
     depends_on:
       consul:
         condition: service_started
-      data:
+      core-data:
         condition: service_started
     environment:
       EDGEX_PROFILE: rules-engine
@@ -163,12 +163,12 @@ services:
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
-  app-service-sample:
+  app-sample:
     container_name: edgex-app-sample
     depends_on:
       consul:
         condition: service_started
-      data:
+      core-data:
         condition: service_started
     environment:
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
@@ -192,54 +192,32 @@ services:
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
-  command:
-    container_name: edgex-core-command
+  app-scalability-test-mqtt-export:
+    container_name: edgex-app-scalability-test-mqtt-export
     depends_on:
       consul:
         condition: service_started
-      database:
-        condition: service_started
-      metadata:
+      core-data:
         condition: service_started
     environment:
+      EDGEX_PROFILE: mqtt-export
       EDGEX_SECURITY_SECRET_STORE: "false"
-      EXTERNALMQTT_URL: tcp://edgex-mqtt-broker:1883
-      SERVICE_HOST: edgex-core-command
-    hostname: edgex-core-command
-    image: nexus3.edgexfoundry.org:10004/core-command-arm64:latest
+      EDGEX_SERVICE_KEY: app-scalability-test-mqtt-export
+      MESSAGEBUS_OPTIONAL_CLIENTID: app-scalability-test-mqtt-export
+      SERVICE_HOST: edgex-app-scalability-test-mqtt-export
+      WRITABLE_LOGLEVEL: DEBUG
+      WRITABLE_PIPELINE_FUNCTIONS_MQTTEXPORT_PARAMETERS_BROKERADDRESS: MQTT_BROKER_ADDRESS_PLACE_HOLDER
+      WRITABLE_PIPELINE_FUNCTIONS_MQTTEXPORT_PARAMETERS_CLIENTID: app-scalability-test-mqtt-export
+      WRITABLE_PIPELINE_FUNCTIONS_MQTTEXPORT_PARAMETERS_TOPIC: edgex-events
+    hostname: edgex-app-scalability-test-mqtt-export
+    image: nexus3.edgexfoundry.org:10004/app-service-configurable-arm64:latest
     networks:
       edgex-network: null
     ports:
     - mode: ingress
-      host_ip: 127.0.0.1
-      target: 59882
-      published: "59882"
+      target: 59703
+      published: "59710"
       protocol: tcp
-    read_only: true
-    restart: always
-    security_opt:
-    - no-new-privileges:true
-    user: 2002:2001
-  common-config:
-    container_name: edgex-core-common-config-bootstrapper
-    depends_on:
-      consul:
-        condition: service_started
-    environment:
-      ALL_SERVICES_DATABASE_HOST: edgex-redis
-      ALL_SERVICES_MESSAGEBUS_AUTHMODE: none
-      ALL_SERVICES_MESSAGEBUS_HOST: edgex-mqtt-broker
-      ALL_SERVICES_MESSAGEBUS_PORT: "1883"
-      ALL_SERVICES_MESSAGEBUS_PROTOCOL: tcp
-      ALL_SERVICES_MESSAGEBUS_TYPE: mqtt
-      ALL_SERVICES_REGISTRY_HOST: edgex-core-consul
-      APP_SERVICES_CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
-      DEVICE_SERVICES_CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
-      EDGEX_SECURITY_SECRET_STORE: "false"
-    hostname: edgex-core-common-config-bootstrapper
-    image: nexus3.edgexfoundry.org:10004/core-common-config-bootstrapper-arm64:latest
-    networks:
-      edgex-network: null
     read_only: true
     security_opt:
     - no-new-privileges:true
@@ -277,14 +255,66 @@ services:
       source: consul-data
       target: /consul/data
       volume: {}
-  data:
+  core-command:
+    container_name: edgex-core-command
+    depends_on:
+      consul:
+        condition: service_started
+      core-metadata:
+        condition: service_started
+      database:
+        condition: service_started
+    environment:
+      EDGEX_SECURITY_SECRET_STORE: "false"
+      EXTERNALMQTT_URL: tcp://edgex-mqtt-broker:1883
+      SERVICE_HOST: edgex-core-command
+    hostname: edgex-core-command
+    image: nexus3.edgexfoundry.org:10004/core-command-arm64:latest
+    networks:
+      edgex-network: null
+    ports:
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59882
+      published: "59882"
+      protocol: tcp
+    read_only: true
+    restart: always
+    security_opt:
+    - no-new-privileges:true
+    user: 2002:2001
+  core-common-config-bootstrapper:
+    container_name: edgex-core-common-config-bootstrapper
+    depends_on:
+      consul:
+        condition: service_started
+    environment:
+      ALL_SERVICES_DATABASE_HOST: edgex-redis
+      ALL_SERVICES_MESSAGEBUS_AUTHMODE: none
+      ALL_SERVICES_MESSAGEBUS_HOST: edgex-mqtt-broker
+      ALL_SERVICES_MESSAGEBUS_PORT: "1883"
+      ALL_SERVICES_MESSAGEBUS_PROTOCOL: tcp
+      ALL_SERVICES_MESSAGEBUS_TYPE: mqtt
+      ALL_SERVICES_REGISTRY_HOST: edgex-core-consul
+      APP_SERVICES_CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
+      DEVICE_SERVICES_CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
+      EDGEX_SECURITY_SECRET_STORE: "false"
+    hostname: edgex-core-common-config-bootstrapper
+    image: nexus3.edgexfoundry.org:10004/core-common-config-bootstrapper-arm64:latest
+    networks:
+      edgex-network: null
+    read_only: true
+    security_opt:
+    - no-new-privileges:true
+    user: 2002:2001
+  core-data:
     container_name: edgex-core-data
     depends_on:
       consul:
         condition: service_started
-      database:
+      core-metadata:
         condition: service_started
-      metadata:
+      database:
         condition: service_started
     environment:
       EDGEX_SECURITY_SECRET_STORE: "false"
@@ -298,6 +328,31 @@ services:
       host_ip: 127.0.0.1
       target: 59880
       published: "59880"
+      protocol: tcp
+    read_only: true
+    restart: always
+    security_opt:
+    - no-new-privileges:true
+    user: 2002:2001
+  core-metadata:
+    container_name: edgex-core-metadata
+    depends_on:
+      consul:
+        condition: service_started
+      database:
+        condition: service_started
+    environment:
+      EDGEX_SECURITY_SECRET_STORE: "false"
+      SERVICE_HOST: edgex-core-metadata
+    hostname: edgex-core-metadata
+    image: nexus3.edgexfoundry.org:10004/core-metadata-arm64:latest
+    networks:
+      edgex-network: null
+    ports:
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59881
+      published: "59881"
       protocol: tcp
     read_only: true
     restart: always
@@ -335,9 +390,9 @@ services:
     depends_on:
       consul:
         condition: service_started
-      data:
+      core-data:
         condition: service_started
-      metadata:
+      core-metadata:
         condition: service_started
       modbus-simulator:
         condition: service_started
@@ -371,9 +426,9 @@ services:
     depends_on:
       consul:
         condition: service_started
-      data:
+      core-data:
         condition: service_started
-      metadata:
+      core-metadata:
         condition: service_started
     environment:
       EDGEX_SECURITY_SECRET_STORE: "false"
@@ -398,9 +453,9 @@ services:
     depends_on:
       consul:
         condition: service_started
-      data:
+      core-data:
         condition: service_started
-      metadata:
+      core-metadata:
         condition: service_started
     environment:
       EDGEX_SECURITY_SECRET_STORE: "false"
@@ -429,9 +484,9 @@ services:
     depends_on:
       consul:
         condition: service_started
-      data:
+      core-data:
         condition: service_started
-      metadata:
+      core-metadata:
         condition: service_started
     environment:
       EDGEX_SECURITY_SECRET_STORE: "false"
@@ -458,31 +513,6 @@ services:
       bind:
         selinux: z
         create_host_path: true
-  metadata:
-    container_name: edgex-core-metadata
-    depends_on:
-      consul:
-        condition: service_started
-      database:
-        condition: service_started
-    environment:
-      EDGEX_SECURITY_SECRET_STORE: "false"
-      SERVICE_HOST: edgex-core-metadata
-    hostname: edgex-core-metadata
-    image: nexus3.edgexfoundry.org:10004/core-metadata-arm64:latest
-    networks:
-      edgex-network: null
-    ports:
-    - mode: ingress
-      host_ip: 127.0.0.1
-      target: 59881
-      published: "59881"
-      protocol: tcp
-    read_only: true
-    restart: always
-    security_opt:
-    - no-new-privileges:true
-    user: 2002:2001
   modbus-simulator:
     container_name: edgex-modbus-simulator
     hostname: edgex-modbus-simulator
@@ -543,32 +573,7 @@ services:
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
-  notifications:
-    container_name: edgex-support-notifications
-    depends_on:
-      consul:
-        condition: service_started
-      database:
-        condition: service_started
-    environment:
-      EDGEX_SECURITY_SECRET_STORE: "false"
-      SERVICE_HOST: edgex-support-notifications
-    hostname: edgex-support-notifications
-    image: nexus3.edgexfoundry.org:10004/support-notifications-arm64:latest
-    networks:
-      edgex-network: null
-    ports:
-    - mode: ingress
-      host_ip: 127.0.0.1
-      target: 59860
-      published: "59860"
-      protocol: tcp
-    read_only: true
-    restart: always
-    security_opt:
-    - no-new-privileges:true
-    user: 2002:2001
-  rulesengine:
+  rules-engine:
     container_name: edgex-kuiper
     depends_on:
       database:
@@ -627,37 +632,32 @@ services:
       source: kuiper-plugins
       target: /kuiper/plugins
       volume: {}
-  scalability-test-mqtt-export:
-    container_name: edgex-scalability-test-mqtt-export
+  support-notifications:
+    container_name: edgex-support-notifications
     depends_on:
       consul:
         condition: service_started
-      data:
+      database:
         condition: service_started
     environment:
-      EDGEX_PROFILE: mqtt-export
       EDGEX_SECURITY_SECRET_STORE: "false"
-      EDGEX_SERVICE_KEY: app-scalability-test-mqtt-export
-      MESSAGEBUS_OPTIONAL_CLIENTID: app-scalability-test-mqtt-export
-      SERVICE_HOST: edgex-scalability-test-mqtt-export
-      WRITABLE_LOGLEVEL: DEBUG
-      WRITABLE_PIPELINE_FUNCTIONS_MQTTEXPORT_PARAMETERS_BROKERADDRESS: MQTT_BROKER_ADDRESS_PLACE_HOLDER
-      WRITABLE_PIPELINE_FUNCTIONS_MQTTEXPORT_PARAMETERS_CLIENTID: scalability-test-mqtt-export
-      WRITABLE_PIPELINE_FUNCTIONS_MQTTEXPORT_PARAMETERS_TOPIC: edgex-events
-    hostname: edgex-scalability-test-mqtt-export
-    image: nexus3.edgexfoundry.org:10004/app-service-configurable-arm64:latest
+      SERVICE_HOST: edgex-support-notifications
+    hostname: edgex-support-notifications
+    image: nexus3.edgexfoundry.org:10004/support-notifications-arm64:latest
     networks:
       edgex-network: null
     ports:
     - mode: ingress
-      target: 59703
-      published: "59710"
+      host_ip: 127.0.0.1
+      target: 59860
+      published: "59860"
       protocol: tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
-  scheduler:
+  support-scheduler:
     container_name: edgex-support-scheduler
     depends_on:
       consul:

--- a/taf/docker-compose-taf-no-secty-mqtt-bus.yml
+++ b/taf/docker-compose-taf-no-secty-mqtt-bus.yml
@@ -26,12 +26,12 @@
 #
 name: edgex
 services:
-  app-service-external-mqtt-trigger:
+  app-external-mqtt-trigger:
     container_name: edgex-app-external-mqtt-trigger
     depends_on:
       consul:
         condition: service_started
-      data:
+      core-data:
         condition: service_started
     environment:
       EDGEX_PROFILE: external-mqtt-trigger
@@ -56,18 +56,18 @@ services:
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
-  app-service-functional-tests:
-    container_name: app-functional-tests
+  app-functional-tests:
+    container_name: edgex-app-functional-tests
     depends_on:
       consul:
         condition: service_started
-      data:
+      core-data:
         condition: service_started
     environment:
       EDGEX_PROFILE: functional-tests
       EDGEX_SECURITY_SECRET_STORE: "false"
-      SERVICE_HOST: app-functional-tests
-    hostname: app-functional-tests
+      SERVICE_HOST: edgex-app-functional-tests
+    hostname: edgex-app-functional-tests
     image: nexus3.edgexfoundry.org:10004/app-service-configurable:latest
     networks:
       edgex-network: null
@@ -80,12 +80,12 @@ services:
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
-  app-service-http-export:
+  app-http-export:
     container_name: edgex-app-http-export
     depends_on:
       consul:
         condition: service_started
-      data:
+      core-data:
         condition: service_started
     environment:
       EDGEX_PROFILE: http-export
@@ -108,12 +108,12 @@ services:
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
-  app-service-mqtt-export:
+  app-mqtt-export:
     container_name: edgex-app-mqtt-export
     depends_on:
       consul:
         condition: service_started
-      data:
+      core-data:
         condition: service_started
     environment:
       EDGEX_PROFILE: mqtt-export
@@ -137,12 +137,12 @@ services:
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
-  app-service-rules:
+  app-rules-engine:
     container_name: edgex-app-rules-engine
     depends_on:
       consul:
         condition: service_started
-      data:
+      core-data:
         condition: service_started
     environment:
       EDGEX_PROFILE: rules-engine
@@ -163,12 +163,12 @@ services:
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
-  app-service-sample:
+  app-sample:
     container_name: edgex-app-sample
     depends_on:
       consul:
         condition: service_started
-      data:
+      core-data:
         condition: service_started
     environment:
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
@@ -192,54 +192,32 @@ services:
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
-  command:
-    container_name: edgex-core-command
+  app-scalability-test-mqtt-export:
+    container_name: edgex-app-scalability-test-mqtt-export
     depends_on:
       consul:
         condition: service_started
-      database:
-        condition: service_started
-      metadata:
+      core-data:
         condition: service_started
     environment:
+      EDGEX_PROFILE: mqtt-export
       EDGEX_SECURITY_SECRET_STORE: "false"
-      EXTERNALMQTT_URL: tcp://edgex-mqtt-broker:1883
-      SERVICE_HOST: edgex-core-command
-    hostname: edgex-core-command
-    image: nexus3.edgexfoundry.org:10004/core-command:latest
+      EDGEX_SERVICE_KEY: app-scalability-test-mqtt-export
+      MESSAGEBUS_OPTIONAL_CLIENTID: app-scalability-test-mqtt-export
+      SERVICE_HOST: edgex-app-scalability-test-mqtt-export
+      WRITABLE_LOGLEVEL: DEBUG
+      WRITABLE_PIPELINE_FUNCTIONS_MQTTEXPORT_PARAMETERS_BROKERADDRESS: MQTT_BROKER_ADDRESS_PLACE_HOLDER
+      WRITABLE_PIPELINE_FUNCTIONS_MQTTEXPORT_PARAMETERS_CLIENTID: app-scalability-test-mqtt-export
+      WRITABLE_PIPELINE_FUNCTIONS_MQTTEXPORT_PARAMETERS_TOPIC: edgex-events
+    hostname: edgex-app-scalability-test-mqtt-export
+    image: nexus3.edgexfoundry.org:10004/app-service-configurable:latest
     networks:
       edgex-network: null
     ports:
     - mode: ingress
-      host_ip: 127.0.0.1
-      target: 59882
-      published: "59882"
+      target: 59703
+      published: "59710"
       protocol: tcp
-    read_only: true
-    restart: always
-    security_opt:
-    - no-new-privileges:true
-    user: 2002:2001
-  common-config:
-    container_name: edgex-core-common-config-bootstrapper
-    depends_on:
-      consul:
-        condition: service_started
-    environment:
-      ALL_SERVICES_DATABASE_HOST: edgex-redis
-      ALL_SERVICES_MESSAGEBUS_AUTHMODE: none
-      ALL_SERVICES_MESSAGEBUS_HOST: edgex-mqtt-broker
-      ALL_SERVICES_MESSAGEBUS_PORT: "1883"
-      ALL_SERVICES_MESSAGEBUS_PROTOCOL: tcp
-      ALL_SERVICES_MESSAGEBUS_TYPE: mqtt
-      ALL_SERVICES_REGISTRY_HOST: edgex-core-consul
-      APP_SERVICES_CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
-      DEVICE_SERVICES_CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
-      EDGEX_SECURITY_SECRET_STORE: "false"
-    hostname: edgex-core-common-config-bootstrapper
-    image: nexus3.edgexfoundry.org:10004/core-common-config-bootstrapper:latest
-    networks:
-      edgex-network: null
     read_only: true
     security_opt:
     - no-new-privileges:true
@@ -277,14 +255,66 @@ services:
       source: consul-data
       target: /consul/data
       volume: {}
-  data:
+  core-command:
+    container_name: edgex-core-command
+    depends_on:
+      consul:
+        condition: service_started
+      core-metadata:
+        condition: service_started
+      database:
+        condition: service_started
+    environment:
+      EDGEX_SECURITY_SECRET_STORE: "false"
+      EXTERNALMQTT_URL: tcp://edgex-mqtt-broker:1883
+      SERVICE_HOST: edgex-core-command
+    hostname: edgex-core-command
+    image: nexus3.edgexfoundry.org:10004/core-command:latest
+    networks:
+      edgex-network: null
+    ports:
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59882
+      published: "59882"
+      protocol: tcp
+    read_only: true
+    restart: always
+    security_opt:
+    - no-new-privileges:true
+    user: 2002:2001
+  core-common-config-bootstrapper:
+    container_name: edgex-core-common-config-bootstrapper
+    depends_on:
+      consul:
+        condition: service_started
+    environment:
+      ALL_SERVICES_DATABASE_HOST: edgex-redis
+      ALL_SERVICES_MESSAGEBUS_AUTHMODE: none
+      ALL_SERVICES_MESSAGEBUS_HOST: edgex-mqtt-broker
+      ALL_SERVICES_MESSAGEBUS_PORT: "1883"
+      ALL_SERVICES_MESSAGEBUS_PROTOCOL: tcp
+      ALL_SERVICES_MESSAGEBUS_TYPE: mqtt
+      ALL_SERVICES_REGISTRY_HOST: edgex-core-consul
+      APP_SERVICES_CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
+      DEVICE_SERVICES_CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
+      EDGEX_SECURITY_SECRET_STORE: "false"
+    hostname: edgex-core-common-config-bootstrapper
+    image: nexus3.edgexfoundry.org:10004/core-common-config-bootstrapper:latest
+    networks:
+      edgex-network: null
+    read_only: true
+    security_opt:
+    - no-new-privileges:true
+    user: 2002:2001
+  core-data:
     container_name: edgex-core-data
     depends_on:
       consul:
         condition: service_started
-      database:
+      core-metadata:
         condition: service_started
-      metadata:
+      database:
         condition: service_started
     environment:
       EDGEX_SECURITY_SECRET_STORE: "false"
@@ -298,6 +328,31 @@ services:
       host_ip: 127.0.0.1
       target: 59880
       published: "59880"
+      protocol: tcp
+    read_only: true
+    restart: always
+    security_opt:
+    - no-new-privileges:true
+    user: 2002:2001
+  core-metadata:
+    container_name: edgex-core-metadata
+    depends_on:
+      consul:
+        condition: service_started
+      database:
+        condition: service_started
+    environment:
+      EDGEX_SECURITY_SECRET_STORE: "false"
+      SERVICE_HOST: edgex-core-metadata
+    hostname: edgex-core-metadata
+    image: nexus3.edgexfoundry.org:10004/core-metadata:latest
+    networks:
+      edgex-network: null
+    ports:
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59881
+      published: "59881"
       protocol: tcp
     read_only: true
     restart: always
@@ -335,9 +390,9 @@ services:
     depends_on:
       consul:
         condition: service_started
-      data:
+      core-data:
         condition: service_started
-      metadata:
+      core-metadata:
         condition: service_started
       modbus-simulator:
         condition: service_started
@@ -371,9 +426,9 @@ services:
     depends_on:
       consul:
         condition: service_started
-      data:
+      core-data:
         condition: service_started
-      metadata:
+      core-metadata:
         condition: service_started
     environment:
       EDGEX_SECURITY_SECRET_STORE: "false"
@@ -398,9 +453,9 @@ services:
     depends_on:
       consul:
         condition: service_started
-      data:
+      core-data:
         condition: service_started
-      metadata:
+      core-metadata:
         condition: service_started
     environment:
       EDGEX_SECURITY_SECRET_STORE: "false"
@@ -429,9 +484,9 @@ services:
     depends_on:
       consul:
         condition: service_started
-      data:
+      core-data:
         condition: service_started
-      metadata:
+      core-metadata:
         condition: service_started
     environment:
       EDGEX_SECURITY_SECRET_STORE: "false"
@@ -458,31 +513,6 @@ services:
       bind:
         selinux: z
         create_host_path: true
-  metadata:
-    container_name: edgex-core-metadata
-    depends_on:
-      consul:
-        condition: service_started
-      database:
-        condition: service_started
-    environment:
-      EDGEX_SECURITY_SECRET_STORE: "false"
-      SERVICE_HOST: edgex-core-metadata
-    hostname: edgex-core-metadata
-    image: nexus3.edgexfoundry.org:10004/core-metadata:latest
-    networks:
-      edgex-network: null
-    ports:
-    - mode: ingress
-      host_ip: 127.0.0.1
-      target: 59881
-      published: "59881"
-      protocol: tcp
-    read_only: true
-    restart: always
-    security_opt:
-    - no-new-privileges:true
-    user: 2002:2001
   modbus-simulator:
     container_name: edgex-modbus-simulator
     hostname: edgex-modbus-simulator
@@ -543,32 +573,7 @@ services:
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
-  notifications:
-    container_name: edgex-support-notifications
-    depends_on:
-      consul:
-        condition: service_started
-      database:
-        condition: service_started
-    environment:
-      EDGEX_SECURITY_SECRET_STORE: "false"
-      SERVICE_HOST: edgex-support-notifications
-    hostname: edgex-support-notifications
-    image: nexus3.edgexfoundry.org:10004/support-notifications:latest
-    networks:
-      edgex-network: null
-    ports:
-    - mode: ingress
-      host_ip: 127.0.0.1
-      target: 59860
-      published: "59860"
-      protocol: tcp
-    read_only: true
-    restart: always
-    security_opt:
-    - no-new-privileges:true
-    user: 2002:2001
-  rulesengine:
+  rules-engine:
     container_name: edgex-kuiper
     depends_on:
       database:
@@ -627,37 +632,32 @@ services:
       source: kuiper-plugins
       target: /kuiper/plugins
       volume: {}
-  scalability-test-mqtt-export:
-    container_name: edgex-scalability-test-mqtt-export
+  support-notifications:
+    container_name: edgex-support-notifications
     depends_on:
       consul:
         condition: service_started
-      data:
+      database:
         condition: service_started
     environment:
-      EDGEX_PROFILE: mqtt-export
       EDGEX_SECURITY_SECRET_STORE: "false"
-      EDGEX_SERVICE_KEY: app-scalability-test-mqtt-export
-      MESSAGEBUS_OPTIONAL_CLIENTID: app-scalability-test-mqtt-export
-      SERVICE_HOST: edgex-scalability-test-mqtt-export
-      WRITABLE_LOGLEVEL: DEBUG
-      WRITABLE_PIPELINE_FUNCTIONS_MQTTEXPORT_PARAMETERS_BROKERADDRESS: MQTT_BROKER_ADDRESS_PLACE_HOLDER
-      WRITABLE_PIPELINE_FUNCTIONS_MQTTEXPORT_PARAMETERS_CLIENTID: scalability-test-mqtt-export
-      WRITABLE_PIPELINE_FUNCTIONS_MQTTEXPORT_PARAMETERS_TOPIC: edgex-events
-    hostname: edgex-scalability-test-mqtt-export
-    image: nexus3.edgexfoundry.org:10004/app-service-configurable:latest
+      SERVICE_HOST: edgex-support-notifications
+    hostname: edgex-support-notifications
+    image: nexus3.edgexfoundry.org:10004/support-notifications:latest
     networks:
       edgex-network: null
     ports:
     - mode: ingress
-      target: 59703
-      published: "59710"
+      host_ip: 127.0.0.1
+      target: 59860
+      published: "59860"
       protocol: tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
-  scheduler:
+  support-scheduler:
     container_name: edgex-support-scheduler
     depends_on:
       consul:

--- a/taf/docker-compose-taf-no-secty.yml
+++ b/taf/docker-compose-taf-no-secty.yml
@@ -26,12 +26,12 @@
 #
 name: edgex
 services:
-  app-service-external-mqtt-trigger:
+  app-external-mqtt-trigger:
     container_name: edgex-app-external-mqtt-trigger
     depends_on:
       consul:
         condition: service_started
-      data:
+      core-data:
         condition: service_started
     environment:
       EDGEX_PROFILE: external-mqtt-trigger
@@ -56,18 +56,18 @@ services:
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
-  app-service-functional-tests:
-    container_name: app-functional-tests
+  app-functional-tests:
+    container_name: edgex-app-functional-tests
     depends_on:
       consul:
         condition: service_started
-      data:
+      core-data:
         condition: service_started
     environment:
       EDGEX_PROFILE: functional-tests
       EDGEX_SECURITY_SECRET_STORE: "false"
-      SERVICE_HOST: app-functional-tests
-    hostname: app-functional-tests
+      SERVICE_HOST: edgex-app-functional-tests
+    hostname: edgex-app-functional-tests
     image: nexus3.edgexfoundry.org:10004/app-service-configurable:latest
     networks:
       edgex-network: null
@@ -80,12 +80,12 @@ services:
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
-  app-service-http-export:
+  app-http-export:
     container_name: edgex-app-http-export
     depends_on:
       consul:
         condition: service_started
-      data:
+      core-data:
         condition: service_started
     environment:
       EDGEX_PROFILE: http-export
@@ -108,12 +108,12 @@ services:
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
-  app-service-mqtt-export:
+  app-mqtt-export:
     container_name: edgex-app-mqtt-export
     depends_on:
       consul:
         condition: service_started
-      data:
+      core-data:
         condition: service_started
     environment:
       EDGEX_PROFILE: mqtt-export
@@ -137,12 +137,12 @@ services:
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
-  app-service-rules:
+  app-rules-engine:
     container_name: edgex-app-rules-engine
     depends_on:
       consul:
         condition: service_started
-      data:
+      core-data:
         condition: service_started
     environment:
       EDGEX_PROFILE: rules-engine
@@ -163,12 +163,12 @@ services:
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
-  app-service-sample:
+  app-sample:
     container_name: edgex-app-sample
     depends_on:
       consul:
         condition: service_started
-      data:
+      core-data:
         condition: service_started
     environment:
       CLIENTS_CORE_COMMAND_HOST: edgex-core-command
@@ -192,50 +192,32 @@ services:
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
-  command:
-    container_name: edgex-core-command
+  app-scalability-test-mqtt-export:
+    container_name: edgex-app-scalability-test-mqtt-export
     depends_on:
       consul:
         condition: service_started
-      database:
-        condition: service_started
-      metadata:
+      core-data:
         condition: service_started
     environment:
+      EDGEX_PROFILE: mqtt-export
       EDGEX_SECURITY_SECRET_STORE: "false"
-      EXTERNALMQTT_URL: tcp://edgex-mqtt-broker:1883
-      SERVICE_HOST: edgex-core-command
-    hostname: edgex-core-command
-    image: nexus3.edgexfoundry.org:10004/core-command:latest
+      EDGEX_SERVICE_KEY: app-scalability-test-mqtt-export
+      MESSAGEBUS_OPTIONAL_CLIENTID: app-scalability-test-mqtt-export
+      SERVICE_HOST: edgex-app-scalability-test-mqtt-export
+      WRITABLE_LOGLEVEL: DEBUG
+      WRITABLE_PIPELINE_FUNCTIONS_MQTTEXPORT_PARAMETERS_BROKERADDRESS: MQTT_BROKER_ADDRESS_PLACE_HOLDER
+      WRITABLE_PIPELINE_FUNCTIONS_MQTTEXPORT_PARAMETERS_CLIENTID: app-scalability-test-mqtt-export
+      WRITABLE_PIPELINE_FUNCTIONS_MQTTEXPORT_PARAMETERS_TOPIC: edgex-events
+    hostname: edgex-app-scalability-test-mqtt-export
+    image: nexus3.edgexfoundry.org:10004/app-service-configurable:latest
     networks:
       edgex-network: null
     ports:
     - mode: ingress
-      host_ip: 127.0.0.1
-      target: 59882
-      published: "59882"
+      target: 59703
+      published: "59710"
       protocol: tcp
-    read_only: true
-    restart: always
-    security_opt:
-    - no-new-privileges:true
-    user: 2002:2001
-  common-config:
-    container_name: edgex-core-common-config-bootstrapper
-    depends_on:
-      consul:
-        condition: service_started
-    environment:
-      ALL_SERVICES_DATABASE_HOST: edgex-redis
-      ALL_SERVICES_MESSAGEBUS_HOST: edgex-redis
-      ALL_SERVICES_REGISTRY_HOST: edgex-core-consul
-      APP_SERVICES_CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
-      DEVICE_SERVICES_CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
-      EDGEX_SECURITY_SECRET_STORE: "false"
-    hostname: edgex-core-common-config-bootstrapper
-    image: nexus3.edgexfoundry.org:10004/core-common-config-bootstrapper:latest
-    networks:
-      edgex-network: null
     read_only: true
     security_opt:
     - no-new-privileges:true
@@ -273,14 +255,62 @@ services:
       source: consul-data
       target: /consul/data
       volume: {}
-  data:
+  core-command:
+    container_name: edgex-core-command
+    depends_on:
+      consul:
+        condition: service_started
+      core-metadata:
+        condition: service_started
+      database:
+        condition: service_started
+    environment:
+      EDGEX_SECURITY_SECRET_STORE: "false"
+      EXTERNALMQTT_URL: tcp://edgex-mqtt-broker:1883
+      SERVICE_HOST: edgex-core-command
+    hostname: edgex-core-command
+    image: nexus3.edgexfoundry.org:10004/core-command:latest
+    networks:
+      edgex-network: null
+    ports:
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59882
+      published: "59882"
+      protocol: tcp
+    read_only: true
+    restart: always
+    security_opt:
+    - no-new-privileges:true
+    user: 2002:2001
+  core-common-config-bootstrapper:
+    container_name: edgex-core-common-config-bootstrapper
+    depends_on:
+      consul:
+        condition: service_started
+    environment:
+      ALL_SERVICES_DATABASE_HOST: edgex-redis
+      ALL_SERVICES_MESSAGEBUS_HOST: edgex-redis
+      ALL_SERVICES_REGISTRY_HOST: edgex-core-consul
+      APP_SERVICES_CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
+      DEVICE_SERVICES_CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
+      EDGEX_SECURITY_SECRET_STORE: "false"
+    hostname: edgex-core-common-config-bootstrapper
+    image: nexus3.edgexfoundry.org:10004/core-common-config-bootstrapper:latest
+    networks:
+      edgex-network: null
+    read_only: true
+    security_opt:
+    - no-new-privileges:true
+    user: 2002:2001
+  core-data:
     container_name: edgex-core-data
     depends_on:
       consul:
         condition: service_started
-      database:
+      core-metadata:
         condition: service_started
-      metadata:
+      database:
         condition: service_started
     environment:
       EDGEX_SECURITY_SECRET_STORE: "false"
@@ -294,6 +324,31 @@ services:
       host_ip: 127.0.0.1
       target: 59880
       published: "59880"
+      protocol: tcp
+    read_only: true
+    restart: always
+    security_opt:
+    - no-new-privileges:true
+    user: 2002:2001
+  core-metadata:
+    container_name: edgex-core-metadata
+    depends_on:
+      consul:
+        condition: service_started
+      database:
+        condition: service_started
+    environment:
+      EDGEX_SECURITY_SECRET_STORE: "false"
+      SERVICE_HOST: edgex-core-metadata
+    hostname: edgex-core-metadata
+    image: nexus3.edgexfoundry.org:10004/core-metadata:latest
+    networks:
+      edgex-network: null
+    ports:
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59881
+      published: "59881"
       protocol: tcp
     read_only: true
     restart: always
@@ -331,9 +386,9 @@ services:
     depends_on:
       consul:
         condition: service_started
-      data:
+      core-data:
         condition: service_started
-      metadata:
+      core-metadata:
         condition: service_started
       modbus-simulator:
         condition: service_started
@@ -367,9 +422,9 @@ services:
     depends_on:
       consul:
         condition: service_started
-      data:
+      core-data:
         condition: service_started
-      metadata:
+      core-metadata:
         condition: service_started
     environment:
       EDGEX_SECURITY_SECRET_STORE: "false"
@@ -394,9 +449,9 @@ services:
     depends_on:
       consul:
         condition: service_started
-      data:
+      core-data:
         condition: service_started
-      metadata:
+      core-metadata:
         condition: service_started
     environment:
       EDGEX_SECURITY_SECRET_STORE: "false"
@@ -425,9 +480,9 @@ services:
     depends_on:
       consul:
         condition: service_started
-      data:
+      core-data:
         condition: service_started
-      metadata:
+      core-metadata:
         condition: service_started
     environment:
       EDGEX_SECURITY_SECRET_STORE: "false"
@@ -454,31 +509,6 @@ services:
       bind:
         selinux: z
         create_host_path: true
-  metadata:
-    container_name: edgex-core-metadata
-    depends_on:
-      consul:
-        condition: service_started
-      database:
-        condition: service_started
-    environment:
-      EDGEX_SECURITY_SECRET_STORE: "false"
-      SERVICE_HOST: edgex-core-metadata
-    hostname: edgex-core-metadata
-    image: nexus3.edgexfoundry.org:10004/core-metadata:latest
-    networks:
-      edgex-network: null
-    ports:
-    - mode: ingress
-      host_ip: 127.0.0.1
-      target: 59881
-      published: "59881"
-      protocol: tcp
-    read_only: true
-    restart: always
-    security_opt:
-    - no-new-privileges:true
-    user: 2002:2001
   modbus-simulator:
     container_name: edgex-modbus-simulator
     hostname: edgex-modbus-simulator
@@ -538,32 +568,7 @@ services:
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
-  notifications:
-    container_name: edgex-support-notifications
-    depends_on:
-      consul:
-        condition: service_started
-      database:
-        condition: service_started
-    environment:
-      EDGEX_SECURITY_SECRET_STORE: "false"
-      SERVICE_HOST: edgex-support-notifications
-    hostname: edgex-support-notifications
-    image: nexus3.edgexfoundry.org:10004/support-notifications:latest
-    networks:
-      edgex-network: null
-    ports:
-    - mode: ingress
-      host_ip: 127.0.0.1
-      target: 59860
-      published: "59860"
-      protocol: tcp
-    read_only: true
-    restart: always
-    security_opt:
-    - no-new-privileges:true
-    user: 2002:2001
-  rulesengine:
+  rules-engine:
     container_name: edgex-kuiper
     depends_on:
       database:
@@ -612,37 +617,32 @@ services:
       source: kuiper-plugins
       target: /kuiper/plugins
       volume: {}
-  scalability-test-mqtt-export:
-    container_name: edgex-scalability-test-mqtt-export
+  support-notifications:
+    container_name: edgex-support-notifications
     depends_on:
       consul:
         condition: service_started
-      data:
+      database:
         condition: service_started
     environment:
-      EDGEX_PROFILE: mqtt-export
       EDGEX_SECURITY_SECRET_STORE: "false"
-      EDGEX_SERVICE_KEY: app-scalability-test-mqtt-export
-      MESSAGEBUS_OPTIONAL_CLIENTID: app-scalability-test-mqtt-export
-      SERVICE_HOST: edgex-scalability-test-mqtt-export
-      WRITABLE_LOGLEVEL: DEBUG
-      WRITABLE_PIPELINE_FUNCTIONS_MQTTEXPORT_PARAMETERS_BROKERADDRESS: MQTT_BROKER_ADDRESS_PLACE_HOLDER
-      WRITABLE_PIPELINE_FUNCTIONS_MQTTEXPORT_PARAMETERS_CLIENTID: scalability-test-mqtt-export
-      WRITABLE_PIPELINE_FUNCTIONS_MQTTEXPORT_PARAMETERS_TOPIC: edgex-events
-    hostname: edgex-scalability-test-mqtt-export
-    image: nexus3.edgexfoundry.org:10004/app-service-configurable:latest
+      SERVICE_HOST: edgex-support-notifications
+    hostname: edgex-support-notifications
+    image: nexus3.edgexfoundry.org:10004/support-notifications:latest
     networks:
       edgex-network: null
     ports:
     - mode: ingress
-      target: 59703
-      published: "59710"
+      host_ip: 127.0.0.1
+      target: 59860
+      published: "59860"
       protocol: tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
-  scheduler:
+  support-scheduler:
     container_name: edgex-support-scheduler
     depends_on:
       consul:

--- a/taf/docker-compose-taf-perf-arm64.yml
+++ b/taf/docker-compose-taf-perf-arm64.yml
@@ -26,7 +26,7 @@
 #
 name: edgex
 services:
-  app-service-mqtt-export:
+  app-mqtt-export:
     command:
     - /app-service-configurable
     - -cp=consul.http://edgex-core-consul:8500
@@ -35,7 +35,7 @@ services:
     depends_on:
       consul:
         condition: service_started
-      data:
+      core-data:
         condition: service_started
       security-bootstrapper:
         condition: service_started
@@ -90,7 +90,7 @@ services:
       bind:
         selinux: z
         create_host_path: true
-  app-service-rules:
+  app-rules-engine:
     command:
     - /app-service-configurable
     - -cp=consul.http://edgex-core-consul:8500
@@ -99,7 +99,7 @@ services:
     depends_on:
       consul:
         condition: service_started
-      data:
+      core-data:
         condition: service_started
       security-bootstrapper:
         condition: service_started
@@ -147,128 +147,6 @@ services:
     - type: bind
       source: /tmp/edgex/secrets/app-rules-engine
       target: /tmp/edgex/secrets/app-rules-engine
-      read_only: true
-      bind:
-        selinux: z
-        create_host_path: true
-  command:
-    command:
-    - /core-command
-    - -cp=consul.http://edgex-core-consul:8500
-    - --registry
-    container_name: edgex-core-command
-    depends_on:
-      consul:
-        condition: service_started
-      database:
-        condition: service_started
-      metadata:
-        condition: service_started
-      secretstore-setup:
-        condition: service_started
-      security-bootstrapper:
-        condition: service_started
-    entrypoint:
-    - /edgex-init/ready_to_run_wait_install.sh
-    environment:
-      EDGEX_SECURITY_SECRET_STORE: "true"
-      EXTERNALMQTT_URL: tcp://edgex-mqtt-broker:1883
-      PROXY_SETUP_HOST: edgex-security-proxy-setup
-      SECRETSTORE_HOST: edgex-vault
-      SERVICE_HOST: edgex-core-command
-      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
-      STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: "6379"
-      STAGEGATE_DATABASE_READYPORT: "6379"
-      STAGEGATE_READY_TORUNPORT: "54329"
-      STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: "8500"
-      STAGEGATE_REGISTRY_READYPORT: "54324"
-      STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
-      STAGEGATE_WAITFOR_TIMEOUT: 60s
-    hostname: edgex-core-command
-    image: nexus3.edgexfoundry.org:10004/core-command-arm64:latest
-    networks:
-      edgex-network: null
-    ports:
-    - mode: ingress
-      host_ip: 127.0.0.1
-      target: 59882
-      published: "59882"
-      protocol: tcp
-    read_only: true
-    restart: always
-    security_opt:
-    - no-new-privileges:true
-    user: 2002:2001
-    volumes:
-    - type: volume
-      source: edgex-init
-      target: /edgex-init
-      read_only: true
-      volume: {}
-    - type: bind
-      source: /tmp/edgex/secrets/core-command
-      target: /tmp/edgex/secrets/core-command
-      read_only: true
-      bind:
-        selinux: z
-        create_host_path: true
-  common-config:
-    command:
-    - /entrypoint.sh
-    - /core-common-config-bootstrapper
-    - -cp=consul.http://edgex-core-consul:8500
-    container_name: edgex-core-common-config-bootstrapper
-    depends_on:
-      consul:
-        condition: service_started
-      secretstore-setup:
-        condition: service_started
-      security-bootstrapper:
-        condition: service_started
-    entrypoint:
-    - /edgex-init/ready_to_run_wait_install.sh
-    environment:
-      ALL_SERVICES_DATABASE_HOST: edgex-redis
-      ALL_SERVICES_MESSAGEBUS_HOST: edgex-redis
-      ALL_SERVICES_REGISTRY_HOST: edgex-core-consul
-      APP_SERVICES_CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
-      DEVICE_SERVICES_CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
-      EDGEX_SECURITY_SECRET_STORE: "true"
-      PROXY_SETUP_HOST: edgex-security-proxy-setup
-      SECRETSTORE_HOST: edgex-vault
-      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
-      STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: "6379"
-      STAGEGATE_DATABASE_READYPORT: "6379"
-      STAGEGATE_READY_TORUNPORT: "54329"
-      STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: "8500"
-      STAGEGATE_REGISTRY_READYPORT: "54324"
-      STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
-      STAGEGATE_WAITFOR_TIMEOUT: 60s
-    hostname: edgex-core-common-config-bootstrapper
-    image: nexus3.edgexfoundry.org:10004/core-common-config-bootstrapper-arm64:latest
-    networks:
-      edgex-network: null
-    read_only: true
-    security_opt:
-    - no-new-privileges:true
-    user: 2002:2001
-    volumes:
-    - type: volume
-      source: edgex-init
-      target: /edgex-init
-      read_only: true
-      volume: {}
-    - type: bind
-      source: /tmp/edgex/secrets/core-common-config-bootstrapper
-      target: /tmp/edgex/secrets/core-common-config-bootstrapper
       read_only: true
       bind:
         selinux: z
@@ -351,7 +229,129 @@ services:
       bind:
         selinux: z
         create_host_path: true
-  data:
+  core-command:
+    command:
+    - /core-command
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
+    container_name: edgex-core-command
+    depends_on:
+      consul:
+        condition: service_started
+      core-metadata:
+        condition: service_started
+      database:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
+      security-secretstore-setup:
+        condition: service_started
+    entrypoint:
+    - /edgex-init/ready_to_run_wait_install.sh
+    environment:
+      EDGEX_SECURITY_SECRET_STORE: "true"
+      EXTERNALMQTT_URL: tcp://edgex-mqtt-broker:1883
+      PROXY_SETUP_HOST: edgex-security-proxy-setup
+      SECRETSTORE_HOST: edgex-vault
+      SERVICE_HOST: edgex-core-command
+      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
+      STAGEGATE_DATABASE_HOST: edgex-redis
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
+      STAGEGATE_READY_TORUNPORT: "54329"
+      STAGEGATE_REGISTRY_HOST: edgex-core-consul
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
+      STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
+      STAGEGATE_WAITFOR_TIMEOUT: 60s
+    hostname: edgex-core-command
+    image: nexus3.edgexfoundry.org:10004/core-command-arm64:latest
+    networks:
+      edgex-network: null
+    ports:
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59882
+      published: "59882"
+      protocol: tcp
+    read_only: true
+    restart: always
+    security_opt:
+    - no-new-privileges:true
+    user: 2002:2001
+    volumes:
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/core-command
+      target: /tmp/edgex/secrets/core-command
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
+  core-common-config-bootstrapper:
+    command:
+    - /entrypoint.sh
+    - /core-common-config-bootstrapper
+    - -cp=consul.http://edgex-core-consul:8500
+    container_name: edgex-core-common-config-bootstrapper
+    depends_on:
+      consul:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
+      security-secretstore-setup:
+        condition: service_started
+    entrypoint:
+    - /edgex-init/ready_to_run_wait_install.sh
+    environment:
+      ALL_SERVICES_DATABASE_HOST: edgex-redis
+      ALL_SERVICES_MESSAGEBUS_HOST: edgex-redis
+      ALL_SERVICES_REGISTRY_HOST: edgex-core-consul
+      APP_SERVICES_CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
+      DEVICE_SERVICES_CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
+      EDGEX_SECURITY_SECRET_STORE: "true"
+      PROXY_SETUP_HOST: edgex-security-proxy-setup
+      SECRETSTORE_HOST: edgex-vault
+      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
+      STAGEGATE_DATABASE_HOST: edgex-redis
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
+      STAGEGATE_READY_TORUNPORT: "54329"
+      STAGEGATE_REGISTRY_HOST: edgex-core-consul
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
+      STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
+      STAGEGATE_WAITFOR_TIMEOUT: 60s
+    hostname: edgex-core-common-config-bootstrapper
+    image: nexus3.edgexfoundry.org:10004/core-common-config-bootstrapper-arm64:latest
+    networks:
+      edgex-network: null
+    read_only: true
+    security_opt:
+    - no-new-privileges:true
+    user: 2002:2001
+    volumes:
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/core-common-config-bootstrapper
+      target: /tmp/edgex/secrets/core-common-config-bootstrapper
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
+  core-data:
     command:
     - /core-data
     - -cp=consul.http://edgex-core-consul:8500
@@ -360,13 +360,13 @@ services:
     depends_on:
       consul:
         condition: service_started
+      core-metadata:
+        condition: service_started
       database:
         condition: service_started
-      metadata:
-        condition: service_started
-      secretstore-setup:
-        condition: service_started
       security-bootstrapper:
+        condition: service_started
+      security-secretstore-setup:
         condition: service_started
     entrypoint:
     - /edgex-init/ready_to_run_wait_install.sh
@@ -415,12 +415,74 @@ services:
       bind:
         selinux: z
         create_host_path: true
+  core-metadata:
+    command:
+    - /core-metadata
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
+    container_name: edgex-core-metadata
+    depends_on:
+      consul:
+        condition: service_started
+      database:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
+      security-secretstore-setup:
+        condition: service_started
+    entrypoint:
+    - /edgex-init/ready_to_run_wait_install.sh
+    environment:
+      EDGEX_SECURITY_SECRET_STORE: "true"
+      PROXY_SETUP_HOST: edgex-security-proxy-setup
+      SECRETSTORE_HOST: edgex-vault
+      SERVICE_HOST: edgex-core-metadata
+      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
+      STAGEGATE_DATABASE_HOST: edgex-redis
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
+      STAGEGATE_READY_TORUNPORT: "54329"
+      STAGEGATE_REGISTRY_HOST: edgex-core-consul
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
+      STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
+      STAGEGATE_WAITFOR_TIMEOUT: 60s
+    hostname: edgex-core-metadata
+    image: nexus3.edgexfoundry.org:10004/core-metadata-arm64:latest
+    networks:
+      edgex-network: null
+    ports:
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59881
+      published: "59881"
+      protocol: tcp
+    read_only: true
+    restart: always
+    security_opt:
+    - no-new-privileges:true
+    user: 2002:2001
+    volumes:
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/core-metadata
+      target: /tmp/edgex/secrets/core-metadata
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   database:
     container_name: edgex-redis
     depends_on:
-      secretstore-setup:
-        condition: service_started
       security-bootstrapper:
+        condition: service_started
+      security-secretstore-setup:
         condition: service_started
     entrypoint:
     - /edgex-init/redis_wait_install.sh
@@ -489,9 +551,9 @@ services:
     depends_on:
       consul:
         condition: service_started
-      data:
+      core-data:
         condition: service_started
-      metadata:
+      core-metadata:
         condition: service_started
       security-bootstrapper:
         condition: service_started
@@ -551,9 +613,9 @@ services:
     depends_on:
       consul:
         condition: service_started
-      data:
+      core-data:
         condition: service_started
-      metadata:
+      core-metadata:
         condition: service_started
       security-bootstrapper:
         condition: service_started
@@ -600,68 +662,6 @@ services:
     - type: bind
       source: /tmp/edgex/secrets/device-virtual
       target: /tmp/edgex/secrets/device-virtual
-      read_only: true
-      bind:
-        selinux: z
-        create_host_path: true
-  metadata:
-    command:
-    - /core-metadata
-    - -cp=consul.http://edgex-core-consul:8500
-    - --registry
-    container_name: edgex-core-metadata
-    depends_on:
-      consul:
-        condition: service_started
-      database:
-        condition: service_started
-      secretstore-setup:
-        condition: service_started
-      security-bootstrapper:
-        condition: service_started
-    entrypoint:
-    - /edgex-init/ready_to_run_wait_install.sh
-    environment:
-      EDGEX_SECURITY_SECRET_STORE: "true"
-      PROXY_SETUP_HOST: edgex-security-proxy-setup
-      SECRETSTORE_HOST: edgex-vault
-      SERVICE_HOST: edgex-core-metadata
-      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
-      STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: "6379"
-      STAGEGATE_DATABASE_READYPORT: "6379"
-      STAGEGATE_READY_TORUNPORT: "54329"
-      STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: "8500"
-      STAGEGATE_REGISTRY_READYPORT: "54324"
-      STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
-      STAGEGATE_WAITFOR_TIMEOUT: 60s
-    hostname: edgex-core-metadata
-    image: nexus3.edgexfoundry.org:10004/core-metadata-arm64:latest
-    networks:
-      edgex-network: null
-    ports:
-    - mode: ingress
-      host_ip: 127.0.0.1
-      target: 59881
-      published: "59881"
-      protocol: tcp
-    read_only: true
-    restart: always
-    security_opt:
-    - no-new-privileges:true
-    user: 2002:2001
-    volumes:
-    - type: volume
-      source: edgex-init
-      target: /edgex-init
-      read_only: true
-      volume: {}
-    - type: bind
-      source: /tmp/edgex/secrets/core-metadata
-      target: /tmp/edgex/secrets/core-metadata
       read_only: true
       bind:
         selinux: z
@@ -716,7 +716,7 @@ services:
     - daemon off;
     container_name: edgex-nginx
     depends_on:
-      secretstore-setup:
+      security-secretstore-setup:
         condition: service_started
     entrypoint:
     - /bin/sh
@@ -769,206 +769,14 @@ services:
       source: nginx-tls
       target: /etc/ssl/nginx
       volume: {}
-  notifications:
-    command:
-    - /support-notifications
-    - -cp=consul.http://edgex-core-consul:8500
-    - --registry
-    container_name: edgex-support-notifications
-    depends_on:
-      consul:
-        condition: service_started
-      database:
-        condition: service_started
-      secretstore-setup:
-        condition: service_started
-      security-bootstrapper:
-        condition: service_started
-    entrypoint:
-    - /edgex-init/ready_to_run_wait_install.sh
-    environment:
-      EDGEX_SECURITY_SECRET_STORE: "true"
-      PROXY_SETUP_HOST: edgex-security-proxy-setup
-      SECRETSTORE_HOST: edgex-vault
-      SERVICE_HOST: edgex-support-notifications
-      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
-      STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: "6379"
-      STAGEGATE_DATABASE_READYPORT: "6379"
-      STAGEGATE_READY_TORUNPORT: "54329"
-      STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: "8500"
-      STAGEGATE_REGISTRY_READYPORT: "54324"
-      STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
-      STAGEGATE_WAITFOR_TIMEOUT: 60s
-    hostname: edgex-support-notifications
-    image: nexus3.edgexfoundry.org:10004/support-notifications-arm64:latest
-    networks:
-      edgex-network: null
-    ports:
-    - mode: ingress
-      host_ip: 127.0.0.1
-      target: 59860
-      published: "59860"
-      protocol: tcp
-    read_only: true
-    restart: always
-    security_opt:
-    - no-new-privileges:true
-    user: 2002:2001
-    volumes:
-    - type: volume
-      source: edgex-init
-      target: /edgex-init
-      read_only: true
-      volume: {}
-    - type: bind
-      source: /tmp/edgex/secrets/support-notifications
-      target: /tmp/edgex/secrets/support-notifications
-      read_only: true
-      bind:
-        selinux: z
-        create_host_path: true
-  proxy-auth:
-    command:
-    - entrypoint.sh
-    - /security-proxy-auth
-    - -cp=consul.http://edgex-core-consul:8500
-    - --registry
-    container_name: edgex-proxy-auth
-    depends_on:
-      secretstore-setup:
-        condition: service_started
-    entrypoint:
-    - /bin/sh
-    - /edgex-init/ready_to_run_wait_install.sh
-    environment:
-      EDGEX_SECURITY_SECRET_STORE: "true"
-      PROXY_SETUP_HOST: edgex-security-proxy-setup
-      SECRETSTORE_HOST: edgex-vault
-      SERVICE_HOST: edgex-proxy-auth
-      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
-      STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: "6379"
-      STAGEGATE_DATABASE_READYPORT: "6379"
-      STAGEGATE_READY_TORUNPORT: "54329"
-      STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: "8500"
-      STAGEGATE_REGISTRY_READYPORT: "54324"
-      STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
-      STAGEGATE_WAITFOR_TIMEOUT: 60s
-    hostname: edgex-proxy-auth
-    image: nexus3.edgexfoundry.org:10004/security-proxy-auth-arm64:latest
-    networks:
-      edgex-network: null
-    ports:
-    - mode: ingress
-      host_ip: 127.0.0.1
-      target: 59842
-      published: "59842"
-      protocol: tcp
-    read_only: true
-    restart: always
-    security_opt:
-    - no-new-privileges:true
-    volumes:
-    - type: volume
-      source: edgex-init
-      target: /edgex-init
-      read_only: true
-      volume: {}
-    - type: bind
-      source: /tmp/edgex/secrets/security-proxy-auth
-      target: /tmp/edgex/secrets/security-proxy-auth
-      read_only: true
-      bind:
-        selinux: z
-        create_host_path: true
-  proxy-setup:
-    container_name: edgex-security-proxy-setup
-    depends_on:
-      secretstore-setup:
-        condition: service_started
-      security-bootstrapper:
-        condition: service_started
-    entrypoint:
-    - /edgex-init/proxy_setup_wait_install.sh
-    environment:
-      ADD_PROXY_ROUTE: device-modbus.http://edgex-device-modbus:59901
-      EDGEX_SECURITY_SECRET_STORE: "true"
-      PROXY_SETUP_HOST: edgex-security-proxy-setup
-      ROUTES_CORE_COMMAND_HOST: edgex-core-command
-      ROUTES_CORE_CONSUL_HOST: edgex-core-consul
-      ROUTES_CORE_DATA_HOST: edgex-core-data
-      ROUTES_CORE_METADATA_HOST: edgex-core-metadata
-      ROUTES_DEVICE_VIRTUAL_HOST: device-virtual
-      ROUTES_RULES_ENGINE_HOST: edgex-kuiper
-      ROUTES_SUPPORT_NOTIFICATIONS_HOST: edgex-support-notifications
-      ROUTES_SUPPORT_SCHEDULER_HOST: edgex-support-scheduler
-      ROUTES_SYS_MGMT_AGENT_HOST: edgex-sys-mgmt-agent
-      SECRETSTORE_HOST: edgex-vault
-      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
-      STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: "6379"
-      STAGEGATE_DATABASE_READYPORT: "6379"
-      STAGEGATE_READY_TORUNPORT: "54329"
-      STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: "8500"
-      STAGEGATE_REGISTRY_READYPORT: "54324"
-      STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
-      STAGEGATE_WAITFOR_TIMEOUT: 60s
-    hostname: edgex-security-proxy-setup
-    image: nexus3.edgexfoundry.org:10004/security-proxy-setup-arm64:latest
-    networks:
-      edgex-network: null
-    read_only: true
-    security_opt:
-    - no-new-privileges:true
-    user: root:root
-    volumes:
-    - type: volume
-      source: edgex-init
-      target: /edgex-init
-      read_only: true
-      volume: {}
-    - type: volume
-      source: nginx-templates
-      target: /etc/nginx/templates
-      volume: {}
-    - type: volume
-      source: nginx-tls
-      target: /etc/ssl/nginx
-      volume: {}
-    - type: volume
-      source: consul-acl-token
-      target: /tmp/edgex/secrets/consul-acl-token
-      read_only: true
-      volume: {}
-    - type: bind
-      source: /tmp/edgex/secrets/security-proxy-setup
-      target: /tmp/edgex/secrets/security-proxy-setup
-      read_only: true
-      bind:
-        selinux: z
-        create_host_path: true
-    - type: volume
-      source: vault-config
-      target: /vault/config
-      volume: {}
-  rulesengine:
+  rules-engine:
     container_name: edgex-kuiper
     depends_on:
       database:
         condition: service_started
-      secretstore-setup:
-        condition: service_started
       security-bootstrapper:
+        condition: service_started
+      security-secretstore-setup:
         condition: service_started
     entrypoint:
     - /edgex-init/kuiper_wait_install.sh
@@ -1042,30 +850,12 @@ services:
       source: kuiper-plugins
       target: /kuiper/plugins
       volume: {}
-  scheduler:
-    command:
-    - /support-scheduler
-    - -cp=consul.http://edgex-core-consul:8500
-    - --registry
-    container_name: edgex-support-scheduler
-    depends_on:
-      consul:
-        condition: service_started
-      database:
-        condition: service_started
-      secretstore-setup:
-        condition: service_started
-      security-bootstrapper:
-        condition: service_started
-    entrypoint:
-    - /edgex-init/ready_to_run_wait_install.sh
+  security-bootstrapper:
+    container_name: edgex-security-bootstrapper
     environment:
-      EDGEX_SECURITY_SECRET_STORE: "true"
-      INTERVALACTIONS_SCRUBAGED_HOST: edgex-core-data
-      INTERVALACTIONS_SCRUBPUSHED_HOST: edgex-core-data
+      EDGEX_GROUP: "2001"
+      EDGEX_USER: "2002"
       PROXY_SETUP_HOST: edgex-security-proxy-setup
-      SECRETSTORE_HOST: edgex-vault
-      SERVICE_HOST: edgex-support-scheduler
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
       STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
@@ -1078,21 +868,64 @@ services:
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
       STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
-    hostname: edgex-support-scheduler
-    image: nexus3.edgexfoundry.org:10004/support-scheduler-arm64:latest
+    hostname: edgex-security-bootstrapper
+    image: nexus3.edgexfoundry.org:10004/security-bootstrapper-arm64:latest
+    networks:
+      edgex-network: null
+    read_only: true
+    restart: always
+    security_opt:
+    - no-new-privileges:true
+    user: root:root
+    volumes:
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      volume: {}
+  security-proxy-auth:
+    command:
+    - entrypoint.sh
+    - /security-proxy-auth
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
+    container_name: edgex-proxy-auth
+    depends_on:
+      security-secretstore-setup:
+        condition: service_started
+    entrypoint:
+    - /bin/sh
+    - /edgex-init/ready_to_run_wait_install.sh
+    environment:
+      EDGEX_SECURITY_SECRET_STORE: "true"
+      PROXY_SETUP_HOST: edgex-security-proxy-setup
+      SECRETSTORE_HOST: edgex-vault
+      SERVICE_HOST: edgex-proxy-auth
+      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
+      STAGEGATE_DATABASE_HOST: edgex-redis
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
+      STAGEGATE_READY_TORUNPORT: "54329"
+      STAGEGATE_REGISTRY_HOST: edgex-core-consul
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
+      STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
+      STAGEGATE_WAITFOR_TIMEOUT: 60s
+    hostname: edgex-proxy-auth
+    image: nexus3.edgexfoundry.org:10004/security-proxy-auth-arm64:latest
     networks:
       edgex-network: null
     ports:
     - mode: ingress
       host_ip: 127.0.0.1
-      target: 59861
-      published: "59861"
+      target: 59842
+      published: "59842"
       protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
-    user: 2002:2001
     volumes:
     - type: volume
       source: edgex-init
@@ -1100,13 +933,86 @@ services:
       read_only: true
       volume: {}
     - type: bind
-      source: /tmp/edgex/secrets/support-scheduler
-      target: /tmp/edgex/secrets/support-scheduler
+      source: /tmp/edgex/secrets/security-proxy-auth
+      target: /tmp/edgex/secrets/security-proxy-auth
       read_only: true
       bind:
         selinux: z
         create_host_path: true
-  secretstore-setup:
+  security-proxy-setup:
+    container_name: edgex-security-proxy-setup
+    depends_on:
+      security-bootstrapper:
+        condition: service_started
+      security-secretstore-setup:
+        condition: service_started
+    entrypoint:
+    - /edgex-init/proxy_setup_wait_install.sh
+    environment:
+      ADD_PROXY_ROUTE: device-modbus.http://edgex-device-modbus:59901
+      EDGEX_SECURITY_SECRET_STORE: "true"
+      PROXY_SETUP_HOST: edgex-security-proxy-setup
+      ROUTES_CORE_COMMAND_HOST: edgex-core-command
+      ROUTES_CORE_CONSUL_HOST: edgex-core-consul
+      ROUTES_CORE_DATA_HOST: edgex-core-data
+      ROUTES_CORE_METADATA_HOST: edgex-core-metadata
+      ROUTES_DEVICE_VIRTUAL_HOST: device-virtual
+      ROUTES_RULES_ENGINE_HOST: edgex-kuiper
+      ROUTES_SUPPORT_NOTIFICATIONS_HOST: edgex-support-notifications
+      ROUTES_SUPPORT_SCHEDULER_HOST: edgex-support-scheduler
+      ROUTES_SYS_MGMT_AGENT_HOST: edgex-sys-mgmt-agent
+      SECRETSTORE_HOST: edgex-vault
+      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
+      STAGEGATE_DATABASE_HOST: edgex-redis
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
+      STAGEGATE_READY_TORUNPORT: "54329"
+      STAGEGATE_REGISTRY_HOST: edgex-core-consul
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
+      STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
+      STAGEGATE_WAITFOR_TIMEOUT: 60s
+    hostname: edgex-security-proxy-setup
+    image: nexus3.edgexfoundry.org:10004/security-proxy-setup-arm64:latest
+    networks:
+      edgex-network: null
+    read_only: true
+    security_opt:
+    - no-new-privileges:true
+    user: root:root
+    volumes:
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      volume: {}
+    - type: volume
+      source: nginx-templates
+      target: /etc/nginx/templates
+      volume: {}
+    - type: volume
+      source: nginx-tls
+      target: /etc/ssl/nginx
+      volume: {}
+    - type: volume
+      source: consul-acl-token
+      target: /tmp/edgex/secrets/consul-acl-token
+      read_only: true
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/security-proxy-setup
+      target: /tmp/edgex/secrets/security-proxy-setup
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
+    - type: volume
+      source: vault-config
+      target: /vault/config
+      volume: {}
+  security-secretstore-setup:
     container_name: edgex-security-secretstore-setup
     depends_on:
       security-bootstrapper:
@@ -1169,38 +1075,6 @@ services:
     - type: volume
       source: vault-config
       target: /vault/config
-      volume: {}
-  security-bootstrapper:
-    container_name: edgex-security-bootstrapper
-    environment:
-      EDGEX_GROUP: "2001"
-      EDGEX_USER: "2002"
-      PROXY_SETUP_HOST: edgex-security-proxy-setup
-      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
-      STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: "6379"
-      STAGEGATE_DATABASE_READYPORT: "6379"
-      STAGEGATE_READY_TORUNPORT: "54329"
-      STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: "8500"
-      STAGEGATE_REGISTRY_READYPORT: "54324"
-      STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
-      STAGEGATE_WAITFOR_TIMEOUT: 60s
-    hostname: edgex-security-bootstrapper
-    image: nexus3.edgexfoundry.org:10004/security-bootstrapper-arm64:latest
-    networks:
-      edgex-network: null
-    read_only: true
-    restart: always
-    security_opt:
-    - no-new-privileges:true
-    user: root:root
-    volumes:
-    - type: volume
-      source: edgex-init
-      target: /edgex-init
       volume: {}
   security-spiffe-token-provider:
     command:
@@ -1436,6 +1310,132 @@ services:
     - type: bind
       source: /tmp/edgex/secrets/spiffe
       target: /tmp/edgex/secrets/spiffe
+      bind:
+        selinux: z
+        create_host_path: true
+  support-notifications:
+    command:
+    - /support-notifications
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
+    container_name: edgex-support-notifications
+    depends_on:
+      consul:
+        condition: service_started
+      database:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
+      security-secretstore-setup:
+        condition: service_started
+    entrypoint:
+    - /edgex-init/ready_to_run_wait_install.sh
+    environment:
+      EDGEX_SECURITY_SECRET_STORE: "true"
+      PROXY_SETUP_HOST: edgex-security-proxy-setup
+      SECRETSTORE_HOST: edgex-vault
+      SERVICE_HOST: edgex-support-notifications
+      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
+      STAGEGATE_DATABASE_HOST: edgex-redis
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
+      STAGEGATE_READY_TORUNPORT: "54329"
+      STAGEGATE_REGISTRY_HOST: edgex-core-consul
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
+      STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
+      STAGEGATE_WAITFOR_TIMEOUT: 60s
+    hostname: edgex-support-notifications
+    image: nexus3.edgexfoundry.org:10004/support-notifications-arm64:latest
+    networks:
+      edgex-network: null
+    ports:
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59860
+      published: "59860"
+      protocol: tcp
+    read_only: true
+    restart: always
+    security_opt:
+    - no-new-privileges:true
+    user: 2002:2001
+    volumes:
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/support-notifications
+      target: /tmp/edgex/secrets/support-notifications
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
+  support-scheduler:
+    command:
+    - /support-scheduler
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
+    container_name: edgex-support-scheduler
+    depends_on:
+      consul:
+        condition: service_started
+      database:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
+      security-secretstore-setup:
+        condition: service_started
+    entrypoint:
+    - /edgex-init/ready_to_run_wait_install.sh
+    environment:
+      EDGEX_SECURITY_SECRET_STORE: "true"
+      INTERVALACTIONS_SCRUBAGED_HOST: edgex-core-data
+      INTERVALACTIONS_SCRUBPUSHED_HOST: edgex-core-data
+      PROXY_SETUP_HOST: edgex-security-proxy-setup
+      SECRETSTORE_HOST: edgex-vault
+      SERVICE_HOST: edgex-support-scheduler
+      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
+      STAGEGATE_DATABASE_HOST: edgex-redis
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
+      STAGEGATE_READY_TORUNPORT: "54329"
+      STAGEGATE_REGISTRY_HOST: edgex-core-consul
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
+      STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
+      STAGEGATE_WAITFOR_TIMEOUT: 60s
+    hostname: edgex-support-scheduler
+    image: nexus3.edgexfoundry.org:10004/support-scheduler-arm64:latest
+    networks:
+      edgex-network: null
+    ports:
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59861
+      published: "59861"
+      protocol: tcp
+    read_only: true
+    restart: always
+    security_opt:
+    - no-new-privileges:true
+    user: 2002:2001
+    volumes:
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/support-scheduler
+      target: /tmp/edgex/secrets/support-scheduler
+      read_only: true
       bind:
         selinux: z
         create_host_path: true

--- a/taf/docker-compose-taf-perf-no-secty-arm64.yml
+++ b/taf/docker-compose-taf-perf-no-secty-arm64.yml
@@ -26,12 +26,12 @@
 #
 name: edgex
 services:
-  app-service-mqtt-export:
+  app-mqtt-export:
     container_name: edgex-app-mqtt-export
     depends_on:
       consul:
         condition: service_started
-      data:
+      core-data:
         condition: service_started
     environment:
       EDGEX_PROFILE: mqtt-export
@@ -55,12 +55,12 @@ services:
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
-  app-service-rules:
+  app-rules-engine:
     container_name: edgex-app-rules-engine
     depends_on:
       consul:
         condition: service_started
-      data:
+      core-data:
         condition: service_started
     environment:
       EDGEX_PROFILE: rules-engine
@@ -78,54 +78,6 @@ services:
       protocol: tcp
     read_only: true
     restart: always
-    security_opt:
-    - no-new-privileges:true
-    user: 2002:2001
-  command:
-    container_name: edgex-core-command
-    depends_on:
-      consul:
-        condition: service_started
-      database:
-        condition: service_started
-      metadata:
-        condition: service_started
-    environment:
-      EDGEX_SECURITY_SECRET_STORE: "false"
-      EXTERNALMQTT_URL: tcp://edgex-mqtt-broker:1883
-      SERVICE_HOST: edgex-core-command
-    hostname: edgex-core-command
-    image: nexus3.edgexfoundry.org:10004/core-command-arm64:latest
-    networks:
-      edgex-network: null
-    ports:
-    - mode: ingress
-      host_ip: 127.0.0.1
-      target: 59882
-      published: "59882"
-      protocol: tcp
-    read_only: true
-    restart: always
-    security_opt:
-    - no-new-privileges:true
-    user: 2002:2001
-  common-config:
-    container_name: edgex-core-common-config-bootstrapper
-    depends_on:
-      consul:
-        condition: service_started
-    environment:
-      ALL_SERVICES_DATABASE_HOST: edgex-redis
-      ALL_SERVICES_MESSAGEBUS_HOST: edgex-redis
-      ALL_SERVICES_REGISTRY_HOST: edgex-core-consul
-      APP_SERVICES_CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
-      DEVICE_SERVICES_CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
-      EDGEX_SECURITY_SECRET_STORE: "false"
-    hostname: edgex-core-common-config-bootstrapper
-    image: nexus3.edgexfoundry.org:10004/core-common-config-bootstrapper-arm64:latest
-    networks:
-      edgex-network: null
-    read_only: true
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -162,14 +114,62 @@ services:
       source: consul-data
       target: /consul/data
       volume: {}
-  data:
+  core-command:
+    container_name: edgex-core-command
+    depends_on:
+      consul:
+        condition: service_started
+      core-metadata:
+        condition: service_started
+      database:
+        condition: service_started
+    environment:
+      EDGEX_SECURITY_SECRET_STORE: "false"
+      EXTERNALMQTT_URL: tcp://edgex-mqtt-broker:1883
+      SERVICE_HOST: edgex-core-command
+    hostname: edgex-core-command
+    image: nexus3.edgexfoundry.org:10004/core-command-arm64:latest
+    networks:
+      edgex-network: null
+    ports:
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59882
+      published: "59882"
+      protocol: tcp
+    read_only: true
+    restart: always
+    security_opt:
+    - no-new-privileges:true
+    user: 2002:2001
+  core-common-config-bootstrapper:
+    container_name: edgex-core-common-config-bootstrapper
+    depends_on:
+      consul:
+        condition: service_started
+    environment:
+      ALL_SERVICES_DATABASE_HOST: edgex-redis
+      ALL_SERVICES_MESSAGEBUS_HOST: edgex-redis
+      ALL_SERVICES_REGISTRY_HOST: edgex-core-consul
+      APP_SERVICES_CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
+      DEVICE_SERVICES_CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
+      EDGEX_SECURITY_SECRET_STORE: "false"
+    hostname: edgex-core-common-config-bootstrapper
+    image: nexus3.edgexfoundry.org:10004/core-common-config-bootstrapper-arm64:latest
+    networks:
+      edgex-network: null
+    read_only: true
+    security_opt:
+    - no-new-privileges:true
+    user: 2002:2001
+  core-data:
     container_name: edgex-core-data
     depends_on:
       consul:
         condition: service_started
-      database:
+      core-metadata:
         condition: service_started
-      metadata:
+      database:
         condition: service_started
     environment:
       EDGEX_SECURITY_SECRET_STORE: "false"
@@ -183,6 +183,31 @@ services:
       host_ip: 127.0.0.1
       target: 59880
       published: "59880"
+      protocol: tcp
+    read_only: true
+    restart: always
+    security_opt:
+    - no-new-privileges:true
+    user: 2002:2001
+  core-metadata:
+    container_name: edgex-core-metadata
+    depends_on:
+      consul:
+        condition: service_started
+      database:
+        condition: service_started
+    environment:
+      EDGEX_SECURITY_SECRET_STORE: "false"
+      SERVICE_HOST: edgex-core-metadata
+    hostname: edgex-core-metadata
+    image: nexus3.edgexfoundry.org:10004/core-metadata-arm64:latest
+    networks:
+      edgex-network: null
+    ports:
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59881
+      published: "59881"
       protocol: tcp
     read_only: true
     restart: always
@@ -216,9 +241,9 @@ services:
     depends_on:
       consul:
         condition: service_started
-      data:
+      core-data:
         condition: service_started
-      metadata:
+      core-metadata:
         condition: service_started
     environment:
       EDGEX_SECURITY_SECRET_STORE: "false"
@@ -243,9 +268,9 @@ services:
     depends_on:
       consul:
         condition: service_started
-      data:
+      core-data:
         condition: service_started
-      metadata:
+      core-metadata:
         condition: service_started
     environment:
       EDGEX_SECURITY_SECRET_STORE: "false"
@@ -259,31 +284,6 @@ services:
       host_ip: 127.0.0.1
       target: 59900
       published: "59900"
-      protocol: tcp
-    read_only: true
-    restart: always
-    security_opt:
-    - no-new-privileges:true
-    user: 2002:2001
-  metadata:
-    container_name: edgex-core-metadata
-    depends_on:
-      consul:
-        condition: service_started
-      database:
-        condition: service_started
-    environment:
-      EDGEX_SECURITY_SECRET_STORE: "false"
-      SERVICE_HOST: edgex-core-metadata
-    hostname: edgex-core-metadata
-    image: nexus3.edgexfoundry.org:10004/core-metadata-arm64:latest
-    networks:
-      edgex-network: null
-    ports:
-    - mode: ingress
-      host_ip: 127.0.0.1
-      target: 59881
-      published: "59881"
       protocol: tcp
     read_only: true
     restart: always
@@ -332,32 +332,7 @@ services:
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
-  notifications:
-    container_name: edgex-support-notifications
-    depends_on:
-      consul:
-        condition: service_started
-      database:
-        condition: service_started
-    environment:
-      EDGEX_SECURITY_SECRET_STORE: "false"
-      SERVICE_HOST: edgex-support-notifications
-    hostname: edgex-support-notifications
-    image: nexus3.edgexfoundry.org:10004/support-notifications-arm64:latest
-    networks:
-      edgex-network: null
-    ports:
-    - mode: ingress
-      host_ip: 127.0.0.1
-      target: 59860
-      published: "59860"
-      protocol: tcp
-    read_only: true
-    restart: always
-    security_opt:
-    - no-new-privileges:true
-    user: 2002:2001
-  rulesengine:
+  rules-engine:
     container_name: edgex-kuiper
     depends_on:
       database:
@@ -406,7 +381,32 @@ services:
       source: kuiper-plugins
       target: /kuiper/plugins
       volume: {}
-  scheduler:
+  support-notifications:
+    container_name: edgex-support-notifications
+    depends_on:
+      consul:
+        condition: service_started
+      database:
+        condition: service_started
+    environment:
+      EDGEX_SECURITY_SECRET_STORE: "false"
+      SERVICE_HOST: edgex-support-notifications
+    hostname: edgex-support-notifications
+    image: nexus3.edgexfoundry.org:10004/support-notifications-arm64:latest
+    networks:
+      edgex-network: null
+    ports:
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59860
+      published: "59860"
+      protocol: tcp
+    read_only: true
+    restart: always
+    security_opt:
+    - no-new-privileges:true
+    user: 2002:2001
+  support-scheduler:
     container_name: edgex-support-scheduler
     depends_on:
       consul:

--- a/taf/docker-compose-taf-perf-no-secty.yml
+++ b/taf/docker-compose-taf-perf-no-secty.yml
@@ -26,12 +26,12 @@
 #
 name: edgex
 services:
-  app-service-mqtt-export:
+  app-mqtt-export:
     container_name: edgex-app-mqtt-export
     depends_on:
       consul:
         condition: service_started
-      data:
+      core-data:
         condition: service_started
     environment:
       EDGEX_PROFILE: mqtt-export
@@ -55,12 +55,12 @@ services:
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
-  app-service-rules:
+  app-rules-engine:
     container_name: edgex-app-rules-engine
     depends_on:
       consul:
         condition: service_started
-      data:
+      core-data:
         condition: service_started
     environment:
       EDGEX_PROFILE: rules-engine
@@ -78,54 +78,6 @@ services:
       protocol: tcp
     read_only: true
     restart: always
-    security_opt:
-    - no-new-privileges:true
-    user: 2002:2001
-  command:
-    container_name: edgex-core-command
-    depends_on:
-      consul:
-        condition: service_started
-      database:
-        condition: service_started
-      metadata:
-        condition: service_started
-    environment:
-      EDGEX_SECURITY_SECRET_STORE: "false"
-      EXTERNALMQTT_URL: tcp://edgex-mqtt-broker:1883
-      SERVICE_HOST: edgex-core-command
-    hostname: edgex-core-command
-    image: nexus3.edgexfoundry.org:10004/core-command:latest
-    networks:
-      edgex-network: null
-    ports:
-    - mode: ingress
-      host_ip: 127.0.0.1
-      target: 59882
-      published: "59882"
-      protocol: tcp
-    read_only: true
-    restart: always
-    security_opt:
-    - no-new-privileges:true
-    user: 2002:2001
-  common-config:
-    container_name: edgex-core-common-config-bootstrapper
-    depends_on:
-      consul:
-        condition: service_started
-    environment:
-      ALL_SERVICES_DATABASE_HOST: edgex-redis
-      ALL_SERVICES_MESSAGEBUS_HOST: edgex-redis
-      ALL_SERVICES_REGISTRY_HOST: edgex-core-consul
-      APP_SERVICES_CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
-      DEVICE_SERVICES_CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
-      EDGEX_SECURITY_SECRET_STORE: "false"
-    hostname: edgex-core-common-config-bootstrapper
-    image: nexus3.edgexfoundry.org:10004/core-common-config-bootstrapper:latest
-    networks:
-      edgex-network: null
-    read_only: true
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -162,14 +114,62 @@ services:
       source: consul-data
       target: /consul/data
       volume: {}
-  data:
+  core-command:
+    container_name: edgex-core-command
+    depends_on:
+      consul:
+        condition: service_started
+      core-metadata:
+        condition: service_started
+      database:
+        condition: service_started
+    environment:
+      EDGEX_SECURITY_SECRET_STORE: "false"
+      EXTERNALMQTT_URL: tcp://edgex-mqtt-broker:1883
+      SERVICE_HOST: edgex-core-command
+    hostname: edgex-core-command
+    image: nexus3.edgexfoundry.org:10004/core-command:latest
+    networks:
+      edgex-network: null
+    ports:
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59882
+      published: "59882"
+      protocol: tcp
+    read_only: true
+    restart: always
+    security_opt:
+    - no-new-privileges:true
+    user: 2002:2001
+  core-common-config-bootstrapper:
+    container_name: edgex-core-common-config-bootstrapper
+    depends_on:
+      consul:
+        condition: service_started
+    environment:
+      ALL_SERVICES_DATABASE_HOST: edgex-redis
+      ALL_SERVICES_MESSAGEBUS_HOST: edgex-redis
+      ALL_SERVICES_REGISTRY_HOST: edgex-core-consul
+      APP_SERVICES_CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
+      DEVICE_SERVICES_CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
+      EDGEX_SECURITY_SECRET_STORE: "false"
+    hostname: edgex-core-common-config-bootstrapper
+    image: nexus3.edgexfoundry.org:10004/core-common-config-bootstrapper:latest
+    networks:
+      edgex-network: null
+    read_only: true
+    security_opt:
+    - no-new-privileges:true
+    user: 2002:2001
+  core-data:
     container_name: edgex-core-data
     depends_on:
       consul:
         condition: service_started
-      database:
+      core-metadata:
         condition: service_started
-      metadata:
+      database:
         condition: service_started
     environment:
       EDGEX_SECURITY_SECRET_STORE: "false"
@@ -183,6 +183,31 @@ services:
       host_ip: 127.0.0.1
       target: 59880
       published: "59880"
+      protocol: tcp
+    read_only: true
+    restart: always
+    security_opt:
+    - no-new-privileges:true
+    user: 2002:2001
+  core-metadata:
+    container_name: edgex-core-metadata
+    depends_on:
+      consul:
+        condition: service_started
+      database:
+        condition: service_started
+    environment:
+      EDGEX_SECURITY_SECRET_STORE: "false"
+      SERVICE_HOST: edgex-core-metadata
+    hostname: edgex-core-metadata
+    image: nexus3.edgexfoundry.org:10004/core-metadata:latest
+    networks:
+      edgex-network: null
+    ports:
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59881
+      published: "59881"
       protocol: tcp
     read_only: true
     restart: always
@@ -216,9 +241,9 @@ services:
     depends_on:
       consul:
         condition: service_started
-      data:
+      core-data:
         condition: service_started
-      metadata:
+      core-metadata:
         condition: service_started
     environment:
       EDGEX_SECURITY_SECRET_STORE: "false"
@@ -243,9 +268,9 @@ services:
     depends_on:
       consul:
         condition: service_started
-      data:
+      core-data:
         condition: service_started
-      metadata:
+      core-metadata:
         condition: service_started
     environment:
       EDGEX_SECURITY_SECRET_STORE: "false"
@@ -259,31 +284,6 @@ services:
       host_ip: 127.0.0.1
       target: 59900
       published: "59900"
-      protocol: tcp
-    read_only: true
-    restart: always
-    security_opt:
-    - no-new-privileges:true
-    user: 2002:2001
-  metadata:
-    container_name: edgex-core-metadata
-    depends_on:
-      consul:
-        condition: service_started
-      database:
-        condition: service_started
-    environment:
-      EDGEX_SECURITY_SECRET_STORE: "false"
-      SERVICE_HOST: edgex-core-metadata
-    hostname: edgex-core-metadata
-    image: nexus3.edgexfoundry.org:10004/core-metadata:latest
-    networks:
-      edgex-network: null
-    ports:
-    - mode: ingress
-      host_ip: 127.0.0.1
-      target: 59881
-      published: "59881"
       protocol: tcp
     read_only: true
     restart: always
@@ -332,32 +332,7 @@ services:
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
-  notifications:
-    container_name: edgex-support-notifications
-    depends_on:
-      consul:
-        condition: service_started
-      database:
-        condition: service_started
-    environment:
-      EDGEX_SECURITY_SECRET_STORE: "false"
-      SERVICE_HOST: edgex-support-notifications
-    hostname: edgex-support-notifications
-    image: nexus3.edgexfoundry.org:10004/support-notifications:latest
-    networks:
-      edgex-network: null
-    ports:
-    - mode: ingress
-      host_ip: 127.0.0.1
-      target: 59860
-      published: "59860"
-      protocol: tcp
-    read_only: true
-    restart: always
-    security_opt:
-    - no-new-privileges:true
-    user: 2002:2001
-  rulesengine:
+  rules-engine:
     container_name: edgex-kuiper
     depends_on:
       database:
@@ -406,7 +381,32 @@ services:
       source: kuiper-plugins
       target: /kuiper/plugins
       volume: {}
-  scheduler:
+  support-notifications:
+    container_name: edgex-support-notifications
+    depends_on:
+      consul:
+        condition: service_started
+      database:
+        condition: service_started
+    environment:
+      EDGEX_SECURITY_SECRET_STORE: "false"
+      SERVICE_HOST: edgex-support-notifications
+    hostname: edgex-support-notifications
+    image: nexus3.edgexfoundry.org:10004/support-notifications:latest
+    networks:
+      edgex-network: null
+    ports:
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59860
+      published: "59860"
+      protocol: tcp
+    read_only: true
+    restart: always
+    security_opt:
+    - no-new-privileges:true
+    user: 2002:2001
+  support-scheduler:
     container_name: edgex-support-scheduler
     depends_on:
       consul:

--- a/taf/docker-compose-taf-perf.yml
+++ b/taf/docker-compose-taf-perf.yml
@@ -26,7 +26,7 @@
 #
 name: edgex
 services:
-  app-service-mqtt-export:
+  app-mqtt-export:
     command:
     - /app-service-configurable
     - -cp=consul.http://edgex-core-consul:8500
@@ -35,7 +35,7 @@ services:
     depends_on:
       consul:
         condition: service_started
-      data:
+      core-data:
         condition: service_started
       security-bootstrapper:
         condition: service_started
@@ -90,7 +90,7 @@ services:
       bind:
         selinux: z
         create_host_path: true
-  app-service-rules:
+  app-rules-engine:
     command:
     - /app-service-configurable
     - -cp=consul.http://edgex-core-consul:8500
@@ -99,7 +99,7 @@ services:
     depends_on:
       consul:
         condition: service_started
-      data:
+      core-data:
         condition: service_started
       security-bootstrapper:
         condition: service_started
@@ -147,128 +147,6 @@ services:
     - type: bind
       source: /tmp/edgex/secrets/app-rules-engine
       target: /tmp/edgex/secrets/app-rules-engine
-      read_only: true
-      bind:
-        selinux: z
-        create_host_path: true
-  command:
-    command:
-    - /core-command
-    - -cp=consul.http://edgex-core-consul:8500
-    - --registry
-    container_name: edgex-core-command
-    depends_on:
-      consul:
-        condition: service_started
-      database:
-        condition: service_started
-      metadata:
-        condition: service_started
-      secretstore-setup:
-        condition: service_started
-      security-bootstrapper:
-        condition: service_started
-    entrypoint:
-    - /edgex-init/ready_to_run_wait_install.sh
-    environment:
-      EDGEX_SECURITY_SECRET_STORE: "true"
-      EXTERNALMQTT_URL: tcp://edgex-mqtt-broker:1883
-      PROXY_SETUP_HOST: edgex-security-proxy-setup
-      SECRETSTORE_HOST: edgex-vault
-      SERVICE_HOST: edgex-core-command
-      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
-      STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: "6379"
-      STAGEGATE_DATABASE_READYPORT: "6379"
-      STAGEGATE_READY_TORUNPORT: "54329"
-      STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: "8500"
-      STAGEGATE_REGISTRY_READYPORT: "54324"
-      STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
-      STAGEGATE_WAITFOR_TIMEOUT: 60s
-    hostname: edgex-core-command
-    image: nexus3.edgexfoundry.org:10004/core-command:latest
-    networks:
-      edgex-network: null
-    ports:
-    - mode: ingress
-      host_ip: 127.0.0.1
-      target: 59882
-      published: "59882"
-      protocol: tcp
-    read_only: true
-    restart: always
-    security_opt:
-    - no-new-privileges:true
-    user: 2002:2001
-    volumes:
-    - type: volume
-      source: edgex-init
-      target: /edgex-init
-      read_only: true
-      volume: {}
-    - type: bind
-      source: /tmp/edgex/secrets/core-command
-      target: /tmp/edgex/secrets/core-command
-      read_only: true
-      bind:
-        selinux: z
-        create_host_path: true
-  common-config:
-    command:
-    - /entrypoint.sh
-    - /core-common-config-bootstrapper
-    - -cp=consul.http://edgex-core-consul:8500
-    container_name: edgex-core-common-config-bootstrapper
-    depends_on:
-      consul:
-        condition: service_started
-      secretstore-setup:
-        condition: service_started
-      security-bootstrapper:
-        condition: service_started
-    entrypoint:
-    - /edgex-init/ready_to_run_wait_install.sh
-    environment:
-      ALL_SERVICES_DATABASE_HOST: edgex-redis
-      ALL_SERVICES_MESSAGEBUS_HOST: edgex-redis
-      ALL_SERVICES_REGISTRY_HOST: edgex-core-consul
-      APP_SERVICES_CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
-      DEVICE_SERVICES_CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
-      EDGEX_SECURITY_SECRET_STORE: "true"
-      PROXY_SETUP_HOST: edgex-security-proxy-setup
-      SECRETSTORE_HOST: edgex-vault
-      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
-      STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: "6379"
-      STAGEGATE_DATABASE_READYPORT: "6379"
-      STAGEGATE_READY_TORUNPORT: "54329"
-      STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: "8500"
-      STAGEGATE_REGISTRY_READYPORT: "54324"
-      STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
-      STAGEGATE_WAITFOR_TIMEOUT: 60s
-    hostname: edgex-core-common-config-bootstrapper
-    image: nexus3.edgexfoundry.org:10004/core-common-config-bootstrapper:latest
-    networks:
-      edgex-network: null
-    read_only: true
-    security_opt:
-    - no-new-privileges:true
-    user: 2002:2001
-    volumes:
-    - type: volume
-      source: edgex-init
-      target: /edgex-init
-      read_only: true
-      volume: {}
-    - type: bind
-      source: /tmp/edgex/secrets/core-common-config-bootstrapper
-      target: /tmp/edgex/secrets/core-common-config-bootstrapper
       read_only: true
       bind:
         selinux: z
@@ -351,7 +229,129 @@ services:
       bind:
         selinux: z
         create_host_path: true
-  data:
+  core-command:
+    command:
+    - /core-command
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
+    container_name: edgex-core-command
+    depends_on:
+      consul:
+        condition: service_started
+      core-metadata:
+        condition: service_started
+      database:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
+      security-secretstore-setup:
+        condition: service_started
+    entrypoint:
+    - /edgex-init/ready_to_run_wait_install.sh
+    environment:
+      EDGEX_SECURITY_SECRET_STORE: "true"
+      EXTERNALMQTT_URL: tcp://edgex-mqtt-broker:1883
+      PROXY_SETUP_HOST: edgex-security-proxy-setup
+      SECRETSTORE_HOST: edgex-vault
+      SERVICE_HOST: edgex-core-command
+      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
+      STAGEGATE_DATABASE_HOST: edgex-redis
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
+      STAGEGATE_READY_TORUNPORT: "54329"
+      STAGEGATE_REGISTRY_HOST: edgex-core-consul
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
+      STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
+      STAGEGATE_WAITFOR_TIMEOUT: 60s
+    hostname: edgex-core-command
+    image: nexus3.edgexfoundry.org:10004/core-command:latest
+    networks:
+      edgex-network: null
+    ports:
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59882
+      published: "59882"
+      protocol: tcp
+    read_only: true
+    restart: always
+    security_opt:
+    - no-new-privileges:true
+    user: 2002:2001
+    volumes:
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/core-command
+      target: /tmp/edgex/secrets/core-command
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
+  core-common-config-bootstrapper:
+    command:
+    - /entrypoint.sh
+    - /core-common-config-bootstrapper
+    - -cp=consul.http://edgex-core-consul:8500
+    container_name: edgex-core-common-config-bootstrapper
+    depends_on:
+      consul:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
+      security-secretstore-setup:
+        condition: service_started
+    entrypoint:
+    - /edgex-init/ready_to_run_wait_install.sh
+    environment:
+      ALL_SERVICES_DATABASE_HOST: edgex-redis
+      ALL_SERVICES_MESSAGEBUS_HOST: edgex-redis
+      ALL_SERVICES_REGISTRY_HOST: edgex-core-consul
+      APP_SERVICES_CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
+      DEVICE_SERVICES_CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
+      EDGEX_SECURITY_SECRET_STORE: "true"
+      PROXY_SETUP_HOST: edgex-security-proxy-setup
+      SECRETSTORE_HOST: edgex-vault
+      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
+      STAGEGATE_DATABASE_HOST: edgex-redis
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
+      STAGEGATE_READY_TORUNPORT: "54329"
+      STAGEGATE_REGISTRY_HOST: edgex-core-consul
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
+      STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
+      STAGEGATE_WAITFOR_TIMEOUT: 60s
+    hostname: edgex-core-common-config-bootstrapper
+    image: nexus3.edgexfoundry.org:10004/core-common-config-bootstrapper:latest
+    networks:
+      edgex-network: null
+    read_only: true
+    security_opt:
+    - no-new-privileges:true
+    user: 2002:2001
+    volumes:
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/core-common-config-bootstrapper
+      target: /tmp/edgex/secrets/core-common-config-bootstrapper
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
+  core-data:
     command:
     - /core-data
     - -cp=consul.http://edgex-core-consul:8500
@@ -360,13 +360,13 @@ services:
     depends_on:
       consul:
         condition: service_started
+      core-metadata:
+        condition: service_started
       database:
         condition: service_started
-      metadata:
-        condition: service_started
-      secretstore-setup:
-        condition: service_started
       security-bootstrapper:
+        condition: service_started
+      security-secretstore-setup:
         condition: service_started
     entrypoint:
     - /edgex-init/ready_to_run_wait_install.sh
@@ -415,12 +415,74 @@ services:
       bind:
         selinux: z
         create_host_path: true
+  core-metadata:
+    command:
+    - /core-metadata
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
+    container_name: edgex-core-metadata
+    depends_on:
+      consul:
+        condition: service_started
+      database:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
+      security-secretstore-setup:
+        condition: service_started
+    entrypoint:
+    - /edgex-init/ready_to_run_wait_install.sh
+    environment:
+      EDGEX_SECURITY_SECRET_STORE: "true"
+      PROXY_SETUP_HOST: edgex-security-proxy-setup
+      SECRETSTORE_HOST: edgex-vault
+      SERVICE_HOST: edgex-core-metadata
+      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
+      STAGEGATE_DATABASE_HOST: edgex-redis
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
+      STAGEGATE_READY_TORUNPORT: "54329"
+      STAGEGATE_REGISTRY_HOST: edgex-core-consul
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
+      STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
+      STAGEGATE_WAITFOR_TIMEOUT: 60s
+    hostname: edgex-core-metadata
+    image: nexus3.edgexfoundry.org:10004/core-metadata:latest
+    networks:
+      edgex-network: null
+    ports:
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59881
+      published: "59881"
+      protocol: tcp
+    read_only: true
+    restart: always
+    security_opt:
+    - no-new-privileges:true
+    user: 2002:2001
+    volumes:
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/core-metadata
+      target: /tmp/edgex/secrets/core-metadata
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   database:
     container_name: edgex-redis
     depends_on:
-      secretstore-setup:
-        condition: service_started
       security-bootstrapper:
+        condition: service_started
+      security-secretstore-setup:
         condition: service_started
     entrypoint:
     - /edgex-init/redis_wait_install.sh
@@ -489,9 +551,9 @@ services:
     depends_on:
       consul:
         condition: service_started
-      data:
+      core-data:
         condition: service_started
-      metadata:
+      core-metadata:
         condition: service_started
       security-bootstrapper:
         condition: service_started
@@ -551,9 +613,9 @@ services:
     depends_on:
       consul:
         condition: service_started
-      data:
+      core-data:
         condition: service_started
-      metadata:
+      core-metadata:
         condition: service_started
       security-bootstrapper:
         condition: service_started
@@ -600,68 +662,6 @@ services:
     - type: bind
       source: /tmp/edgex/secrets/device-virtual
       target: /tmp/edgex/secrets/device-virtual
-      read_only: true
-      bind:
-        selinux: z
-        create_host_path: true
-  metadata:
-    command:
-    - /core-metadata
-    - -cp=consul.http://edgex-core-consul:8500
-    - --registry
-    container_name: edgex-core-metadata
-    depends_on:
-      consul:
-        condition: service_started
-      database:
-        condition: service_started
-      secretstore-setup:
-        condition: service_started
-      security-bootstrapper:
-        condition: service_started
-    entrypoint:
-    - /edgex-init/ready_to_run_wait_install.sh
-    environment:
-      EDGEX_SECURITY_SECRET_STORE: "true"
-      PROXY_SETUP_HOST: edgex-security-proxy-setup
-      SECRETSTORE_HOST: edgex-vault
-      SERVICE_HOST: edgex-core-metadata
-      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
-      STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: "6379"
-      STAGEGATE_DATABASE_READYPORT: "6379"
-      STAGEGATE_READY_TORUNPORT: "54329"
-      STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: "8500"
-      STAGEGATE_REGISTRY_READYPORT: "54324"
-      STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
-      STAGEGATE_WAITFOR_TIMEOUT: 60s
-    hostname: edgex-core-metadata
-    image: nexus3.edgexfoundry.org:10004/core-metadata:latest
-    networks:
-      edgex-network: null
-    ports:
-    - mode: ingress
-      host_ip: 127.0.0.1
-      target: 59881
-      published: "59881"
-      protocol: tcp
-    read_only: true
-    restart: always
-    security_opt:
-    - no-new-privileges:true
-    user: 2002:2001
-    volumes:
-    - type: volume
-      source: edgex-init
-      target: /edgex-init
-      read_only: true
-      volume: {}
-    - type: bind
-      source: /tmp/edgex/secrets/core-metadata
-      target: /tmp/edgex/secrets/core-metadata
       read_only: true
       bind:
         selinux: z
@@ -716,7 +716,7 @@ services:
     - daemon off;
     container_name: edgex-nginx
     depends_on:
-      secretstore-setup:
+      security-secretstore-setup:
         condition: service_started
     entrypoint:
     - /bin/sh
@@ -769,206 +769,14 @@ services:
       source: nginx-tls
       target: /etc/ssl/nginx
       volume: {}
-  notifications:
-    command:
-    - /support-notifications
-    - -cp=consul.http://edgex-core-consul:8500
-    - --registry
-    container_name: edgex-support-notifications
-    depends_on:
-      consul:
-        condition: service_started
-      database:
-        condition: service_started
-      secretstore-setup:
-        condition: service_started
-      security-bootstrapper:
-        condition: service_started
-    entrypoint:
-    - /edgex-init/ready_to_run_wait_install.sh
-    environment:
-      EDGEX_SECURITY_SECRET_STORE: "true"
-      PROXY_SETUP_HOST: edgex-security-proxy-setup
-      SECRETSTORE_HOST: edgex-vault
-      SERVICE_HOST: edgex-support-notifications
-      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
-      STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: "6379"
-      STAGEGATE_DATABASE_READYPORT: "6379"
-      STAGEGATE_READY_TORUNPORT: "54329"
-      STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: "8500"
-      STAGEGATE_REGISTRY_READYPORT: "54324"
-      STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
-      STAGEGATE_WAITFOR_TIMEOUT: 60s
-    hostname: edgex-support-notifications
-    image: nexus3.edgexfoundry.org:10004/support-notifications:latest
-    networks:
-      edgex-network: null
-    ports:
-    - mode: ingress
-      host_ip: 127.0.0.1
-      target: 59860
-      published: "59860"
-      protocol: tcp
-    read_only: true
-    restart: always
-    security_opt:
-    - no-new-privileges:true
-    user: 2002:2001
-    volumes:
-    - type: volume
-      source: edgex-init
-      target: /edgex-init
-      read_only: true
-      volume: {}
-    - type: bind
-      source: /tmp/edgex/secrets/support-notifications
-      target: /tmp/edgex/secrets/support-notifications
-      read_only: true
-      bind:
-        selinux: z
-        create_host_path: true
-  proxy-auth:
-    command:
-    - entrypoint.sh
-    - /security-proxy-auth
-    - -cp=consul.http://edgex-core-consul:8500
-    - --registry
-    container_name: edgex-proxy-auth
-    depends_on:
-      secretstore-setup:
-        condition: service_started
-    entrypoint:
-    - /bin/sh
-    - /edgex-init/ready_to_run_wait_install.sh
-    environment:
-      EDGEX_SECURITY_SECRET_STORE: "true"
-      PROXY_SETUP_HOST: edgex-security-proxy-setup
-      SECRETSTORE_HOST: edgex-vault
-      SERVICE_HOST: edgex-proxy-auth
-      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
-      STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: "6379"
-      STAGEGATE_DATABASE_READYPORT: "6379"
-      STAGEGATE_READY_TORUNPORT: "54329"
-      STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: "8500"
-      STAGEGATE_REGISTRY_READYPORT: "54324"
-      STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
-      STAGEGATE_WAITFOR_TIMEOUT: 60s
-    hostname: edgex-proxy-auth
-    image: nexus3.edgexfoundry.org:10004/security-proxy-auth:latest
-    networks:
-      edgex-network: null
-    ports:
-    - mode: ingress
-      host_ip: 127.0.0.1
-      target: 59842
-      published: "59842"
-      protocol: tcp
-    read_only: true
-    restart: always
-    security_opt:
-    - no-new-privileges:true
-    volumes:
-    - type: volume
-      source: edgex-init
-      target: /edgex-init
-      read_only: true
-      volume: {}
-    - type: bind
-      source: /tmp/edgex/secrets/security-proxy-auth
-      target: /tmp/edgex/secrets/security-proxy-auth
-      read_only: true
-      bind:
-        selinux: z
-        create_host_path: true
-  proxy-setup:
-    container_name: edgex-security-proxy-setup
-    depends_on:
-      secretstore-setup:
-        condition: service_started
-      security-bootstrapper:
-        condition: service_started
-    entrypoint:
-    - /edgex-init/proxy_setup_wait_install.sh
-    environment:
-      ADD_PROXY_ROUTE: device-modbus.http://edgex-device-modbus:59901
-      EDGEX_SECURITY_SECRET_STORE: "true"
-      PROXY_SETUP_HOST: edgex-security-proxy-setup
-      ROUTES_CORE_COMMAND_HOST: edgex-core-command
-      ROUTES_CORE_CONSUL_HOST: edgex-core-consul
-      ROUTES_CORE_DATA_HOST: edgex-core-data
-      ROUTES_CORE_METADATA_HOST: edgex-core-metadata
-      ROUTES_DEVICE_VIRTUAL_HOST: device-virtual
-      ROUTES_RULES_ENGINE_HOST: edgex-kuiper
-      ROUTES_SUPPORT_NOTIFICATIONS_HOST: edgex-support-notifications
-      ROUTES_SUPPORT_SCHEDULER_HOST: edgex-support-scheduler
-      ROUTES_SYS_MGMT_AGENT_HOST: edgex-sys-mgmt-agent
-      SECRETSTORE_HOST: edgex-vault
-      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
-      STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: "6379"
-      STAGEGATE_DATABASE_READYPORT: "6379"
-      STAGEGATE_READY_TORUNPORT: "54329"
-      STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: "8500"
-      STAGEGATE_REGISTRY_READYPORT: "54324"
-      STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
-      STAGEGATE_WAITFOR_TIMEOUT: 60s
-    hostname: edgex-security-proxy-setup
-    image: nexus3.edgexfoundry.org:10004/security-proxy-setup:latest
-    networks:
-      edgex-network: null
-    read_only: true
-    security_opt:
-    - no-new-privileges:true
-    user: root:root
-    volumes:
-    - type: volume
-      source: edgex-init
-      target: /edgex-init
-      read_only: true
-      volume: {}
-    - type: volume
-      source: nginx-templates
-      target: /etc/nginx/templates
-      volume: {}
-    - type: volume
-      source: nginx-tls
-      target: /etc/ssl/nginx
-      volume: {}
-    - type: volume
-      source: consul-acl-token
-      target: /tmp/edgex/secrets/consul-acl-token
-      read_only: true
-      volume: {}
-    - type: bind
-      source: /tmp/edgex/secrets/security-proxy-setup
-      target: /tmp/edgex/secrets/security-proxy-setup
-      read_only: true
-      bind:
-        selinux: z
-        create_host_path: true
-    - type: volume
-      source: vault-config
-      target: /vault/config
-      volume: {}
-  rulesengine:
+  rules-engine:
     container_name: edgex-kuiper
     depends_on:
       database:
         condition: service_started
-      secretstore-setup:
-        condition: service_started
       security-bootstrapper:
+        condition: service_started
+      security-secretstore-setup:
         condition: service_started
     entrypoint:
     - /edgex-init/kuiper_wait_install.sh
@@ -1042,30 +850,12 @@ services:
       source: kuiper-plugins
       target: /kuiper/plugins
       volume: {}
-  scheduler:
-    command:
-    - /support-scheduler
-    - -cp=consul.http://edgex-core-consul:8500
-    - --registry
-    container_name: edgex-support-scheduler
-    depends_on:
-      consul:
-        condition: service_started
-      database:
-        condition: service_started
-      secretstore-setup:
-        condition: service_started
-      security-bootstrapper:
-        condition: service_started
-    entrypoint:
-    - /edgex-init/ready_to_run_wait_install.sh
+  security-bootstrapper:
+    container_name: edgex-security-bootstrapper
     environment:
-      EDGEX_SECURITY_SECRET_STORE: "true"
-      INTERVALACTIONS_SCRUBAGED_HOST: edgex-core-data
-      INTERVALACTIONS_SCRUBPUSHED_HOST: edgex-core-data
+      EDGEX_GROUP: "2001"
+      EDGEX_USER: "2002"
       PROXY_SETUP_HOST: edgex-security-proxy-setup
-      SECRETSTORE_HOST: edgex-vault
-      SERVICE_HOST: edgex-support-scheduler
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
       STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
@@ -1078,21 +868,64 @@ services:
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
       STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
-    hostname: edgex-support-scheduler
-    image: nexus3.edgexfoundry.org:10004/support-scheduler:latest
+    hostname: edgex-security-bootstrapper
+    image: nexus3.edgexfoundry.org:10004/security-bootstrapper:latest
+    networks:
+      edgex-network: null
+    read_only: true
+    restart: always
+    security_opt:
+    - no-new-privileges:true
+    user: root:root
+    volumes:
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      volume: {}
+  security-proxy-auth:
+    command:
+    - entrypoint.sh
+    - /security-proxy-auth
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
+    container_name: edgex-proxy-auth
+    depends_on:
+      security-secretstore-setup:
+        condition: service_started
+    entrypoint:
+    - /bin/sh
+    - /edgex-init/ready_to_run_wait_install.sh
+    environment:
+      EDGEX_SECURITY_SECRET_STORE: "true"
+      PROXY_SETUP_HOST: edgex-security-proxy-setup
+      SECRETSTORE_HOST: edgex-vault
+      SERVICE_HOST: edgex-proxy-auth
+      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
+      STAGEGATE_DATABASE_HOST: edgex-redis
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
+      STAGEGATE_READY_TORUNPORT: "54329"
+      STAGEGATE_REGISTRY_HOST: edgex-core-consul
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
+      STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
+      STAGEGATE_WAITFOR_TIMEOUT: 60s
+    hostname: edgex-proxy-auth
+    image: nexus3.edgexfoundry.org:10004/security-proxy-auth:latest
     networks:
       edgex-network: null
     ports:
     - mode: ingress
       host_ip: 127.0.0.1
-      target: 59861
-      published: "59861"
+      target: 59842
+      published: "59842"
       protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
-    user: 2002:2001
     volumes:
     - type: volume
       source: edgex-init
@@ -1100,13 +933,86 @@ services:
       read_only: true
       volume: {}
     - type: bind
-      source: /tmp/edgex/secrets/support-scheduler
-      target: /tmp/edgex/secrets/support-scheduler
+      source: /tmp/edgex/secrets/security-proxy-auth
+      target: /tmp/edgex/secrets/security-proxy-auth
       read_only: true
       bind:
         selinux: z
         create_host_path: true
-  secretstore-setup:
+  security-proxy-setup:
+    container_name: edgex-security-proxy-setup
+    depends_on:
+      security-bootstrapper:
+        condition: service_started
+      security-secretstore-setup:
+        condition: service_started
+    entrypoint:
+    - /edgex-init/proxy_setup_wait_install.sh
+    environment:
+      ADD_PROXY_ROUTE: device-modbus.http://edgex-device-modbus:59901
+      EDGEX_SECURITY_SECRET_STORE: "true"
+      PROXY_SETUP_HOST: edgex-security-proxy-setup
+      ROUTES_CORE_COMMAND_HOST: edgex-core-command
+      ROUTES_CORE_CONSUL_HOST: edgex-core-consul
+      ROUTES_CORE_DATA_HOST: edgex-core-data
+      ROUTES_CORE_METADATA_HOST: edgex-core-metadata
+      ROUTES_DEVICE_VIRTUAL_HOST: device-virtual
+      ROUTES_RULES_ENGINE_HOST: edgex-kuiper
+      ROUTES_SUPPORT_NOTIFICATIONS_HOST: edgex-support-notifications
+      ROUTES_SUPPORT_SCHEDULER_HOST: edgex-support-scheduler
+      ROUTES_SYS_MGMT_AGENT_HOST: edgex-sys-mgmt-agent
+      SECRETSTORE_HOST: edgex-vault
+      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
+      STAGEGATE_DATABASE_HOST: edgex-redis
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
+      STAGEGATE_READY_TORUNPORT: "54329"
+      STAGEGATE_REGISTRY_HOST: edgex-core-consul
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
+      STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
+      STAGEGATE_WAITFOR_TIMEOUT: 60s
+    hostname: edgex-security-proxy-setup
+    image: nexus3.edgexfoundry.org:10004/security-proxy-setup:latest
+    networks:
+      edgex-network: null
+    read_only: true
+    security_opt:
+    - no-new-privileges:true
+    user: root:root
+    volumes:
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      volume: {}
+    - type: volume
+      source: nginx-templates
+      target: /etc/nginx/templates
+      volume: {}
+    - type: volume
+      source: nginx-tls
+      target: /etc/ssl/nginx
+      volume: {}
+    - type: volume
+      source: consul-acl-token
+      target: /tmp/edgex/secrets/consul-acl-token
+      read_only: true
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/security-proxy-setup
+      target: /tmp/edgex/secrets/security-proxy-setup
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
+    - type: volume
+      source: vault-config
+      target: /vault/config
+      volume: {}
+  security-secretstore-setup:
     container_name: edgex-security-secretstore-setup
     depends_on:
       security-bootstrapper:
@@ -1169,38 +1075,6 @@ services:
     - type: volume
       source: vault-config
       target: /vault/config
-      volume: {}
-  security-bootstrapper:
-    container_name: edgex-security-bootstrapper
-    environment:
-      EDGEX_GROUP: "2001"
-      EDGEX_USER: "2002"
-      PROXY_SETUP_HOST: edgex-security-proxy-setup
-      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
-      STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: "6379"
-      STAGEGATE_DATABASE_READYPORT: "6379"
-      STAGEGATE_READY_TORUNPORT: "54329"
-      STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: "8500"
-      STAGEGATE_REGISTRY_READYPORT: "54324"
-      STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
-      STAGEGATE_WAITFOR_TIMEOUT: 60s
-    hostname: edgex-security-bootstrapper
-    image: nexus3.edgexfoundry.org:10004/security-bootstrapper:latest
-    networks:
-      edgex-network: null
-    read_only: true
-    restart: always
-    security_opt:
-    - no-new-privileges:true
-    user: root:root
-    volumes:
-    - type: volume
-      source: edgex-init
-      target: /edgex-init
       volume: {}
   security-spiffe-token-provider:
     command:
@@ -1436,6 +1310,132 @@ services:
     - type: bind
       source: /tmp/edgex/secrets/spiffe
       target: /tmp/edgex/secrets/spiffe
+      bind:
+        selinux: z
+        create_host_path: true
+  support-notifications:
+    command:
+    - /support-notifications
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
+    container_name: edgex-support-notifications
+    depends_on:
+      consul:
+        condition: service_started
+      database:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
+      security-secretstore-setup:
+        condition: service_started
+    entrypoint:
+    - /edgex-init/ready_to_run_wait_install.sh
+    environment:
+      EDGEX_SECURITY_SECRET_STORE: "true"
+      PROXY_SETUP_HOST: edgex-security-proxy-setup
+      SECRETSTORE_HOST: edgex-vault
+      SERVICE_HOST: edgex-support-notifications
+      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
+      STAGEGATE_DATABASE_HOST: edgex-redis
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
+      STAGEGATE_READY_TORUNPORT: "54329"
+      STAGEGATE_REGISTRY_HOST: edgex-core-consul
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
+      STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
+      STAGEGATE_WAITFOR_TIMEOUT: 60s
+    hostname: edgex-support-notifications
+    image: nexus3.edgexfoundry.org:10004/support-notifications:latest
+    networks:
+      edgex-network: null
+    ports:
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59860
+      published: "59860"
+      protocol: tcp
+    read_only: true
+    restart: always
+    security_opt:
+    - no-new-privileges:true
+    user: 2002:2001
+    volumes:
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/support-notifications
+      target: /tmp/edgex/secrets/support-notifications
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
+  support-scheduler:
+    command:
+    - /support-scheduler
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
+    container_name: edgex-support-scheduler
+    depends_on:
+      consul:
+        condition: service_started
+      database:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
+      security-secretstore-setup:
+        condition: service_started
+    entrypoint:
+    - /edgex-init/ready_to_run_wait_install.sh
+    environment:
+      EDGEX_SECURITY_SECRET_STORE: "true"
+      INTERVALACTIONS_SCRUBAGED_HOST: edgex-core-data
+      INTERVALACTIONS_SCRUBPUSHED_HOST: edgex-core-data
+      PROXY_SETUP_HOST: edgex-security-proxy-setup
+      SECRETSTORE_HOST: edgex-vault
+      SERVICE_HOST: edgex-support-scheduler
+      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
+      STAGEGATE_DATABASE_HOST: edgex-redis
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
+      STAGEGATE_READY_TORUNPORT: "54329"
+      STAGEGATE_REGISTRY_HOST: edgex-core-consul
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
+      STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
+      STAGEGATE_WAITFOR_TIMEOUT: 60s
+    hostname: edgex-support-scheduler
+    image: nexus3.edgexfoundry.org:10004/support-scheduler:latest
+    networks:
+      edgex-network: null
+    ports:
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59861
+      published: "59861"
+      protocol: tcp
+    read_only: true
+    restart: always
+    security_opt:
+    - no-new-privileges:true
+    user: 2002:2001
+    volumes:
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/support-scheduler
+      target: /tmp/edgex/secrets/support-scheduler
+      read_only: true
       bind:
         selinux: z
         create_host_path: true

--- a/taf/docker-compose-taf.yml
+++ b/taf/docker-compose-taf.yml
@@ -26,7 +26,7 @@
 #
 name: edgex
 services:
-  app-service-external-mqtt-trigger:
+  app-external-mqtt-trigger:
     command:
     - /app-service-configurable
     - -cp=consul.http://edgex-core-consul:8500
@@ -35,7 +35,7 @@ services:
     depends_on:
       consul:
         condition: service_started
-      data:
+      core-data:
         condition: service_started
       security-bootstrapper:
         condition: service_started
@@ -91,16 +91,16 @@ services:
       bind:
         selinux: z
         create_host_path: true
-  app-service-functional-tests:
+  app-functional-tests:
     command:
     - /app-service-configurable
     - -cp=consul.http://edgex-core-consul:8500
     - --registry
-    container_name: app-functional-tests
+    container_name: edgex-app-functional-tests
     depends_on:
       consul:
         condition: service_started
-      data:
+      core-data:
         condition: service_started
       security-bootstrapper:
         condition: service_started
@@ -111,7 +111,7 @@ services:
       EDGEX_SECURITY_SECRET_STORE: "true"
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       SECRETSTORE_HOST: edgex-vault
-      SERVICE_HOST: app-functional-tests
+      SERVICE_HOST: edgex-app-functional-tests
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
       STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
@@ -124,7 +124,7 @@ services:
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
       STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
-    hostname: app-functional-tests
+    hostname: edgex-app-functional-tests
     image: nexus3.edgexfoundry.org:10004/app-service-configurable:latest
     networks:
       edgex-network: null
@@ -150,7 +150,7 @@ services:
       bind:
         selinux: z
         create_host_path: true
-  app-service-http-export:
+  app-http-export:
     command:
     - /app-service-configurable
     - -cp=consul.http://edgex-core-consul:8500
@@ -159,7 +159,7 @@ services:
     depends_on:
       consul:
         condition: service_started
-      data:
+      core-data:
         condition: service_started
       security-bootstrapper:
         condition: service_started
@@ -213,7 +213,7 @@ services:
       bind:
         selinux: z
         create_host_path: true
-  app-service-mqtt-export:
+  app-mqtt-export:
     command:
     - /app-service-configurable
     - -cp=consul.http://edgex-core-consul:8500
@@ -222,7 +222,7 @@ services:
     depends_on:
       consul:
         condition: service_started
-      data:
+      core-data:
         condition: service_started
       security-bootstrapper:
         condition: service_started
@@ -277,7 +277,7 @@ services:
       bind:
         selinux: z
         create_host_path: true
-  app-service-rules:
+  app-rules-engine:
     command:
     - /app-service-configurable
     - -cp=consul.http://edgex-core-consul:8500
@@ -286,7 +286,7 @@ services:
     depends_on:
       consul:
         condition: service_started
-      data:
+      core-data:
         condition: service_started
       security-bootstrapper:
         condition: service_started
@@ -338,7 +338,7 @@ services:
       bind:
         selinux: z
         create_host_path: true
-  app-service-sample:
+  app-sample:
     command:
     - /app-service-configurable
     - -cp=consul.http://edgex-core-consul:8500
@@ -347,7 +347,7 @@ services:
     depends_on:
       consul:
         condition: service_started
-      data:
+      core-data:
         condition: service_started
       security-bootstrapper:
         condition: service_started
@@ -402,31 +402,29 @@ services:
       bind:
         selinux: z
         create_host_path: true
-  command:
+  app-scalability-test-mqtt-export:
     command:
-    - /core-command
+    - /app-service-configurable
     - -cp=consul.http://edgex-core-consul:8500
     - --registry
-    container_name: edgex-core-command
+    container_name: edgex-app-scalability-test-mqtt-export
     depends_on:
       consul:
         condition: service_started
-      database:
-        condition: service_started
-      metadata:
-        condition: service_started
-      secretstore-setup:
+      core-data:
         condition: service_started
       security-bootstrapper:
         condition: service_started
     entrypoint:
     - /edgex-init/ready_to_run_wait_install.sh
     environment:
+      EDGEX_PROFILE: mqtt-export
       EDGEX_SECURITY_SECRET_STORE: "true"
-      EXTERNALMQTT_URL: tcp://edgex-mqtt-broker:1883
+      EDGEX_SERVICE_KEY: app-scalability-test-mqtt-export
+      MESSAGEBUS_OPTIONAL_CLIENTID: app-scalability-test-mqtt-export
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       SECRETSTORE_HOST: edgex-vault
-      SERVICE_HOST: edgex-core-command
+      SERVICE_HOST: edgex-app-scalability-test-mqtt-export
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
       STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
@@ -439,18 +437,20 @@ services:
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
       STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
-    hostname: edgex-core-command
-    image: nexus3.edgexfoundry.org:10004/core-command:latest
+      WRITABLE_LOGLEVEL: DEBUG
+      WRITABLE_PIPELINE_FUNCTIONS_MQTTEXPORT_PARAMETERS_BROKERADDRESS: MQTT_BROKER_ADDRESS_PLACE_HOLDER
+      WRITABLE_PIPELINE_FUNCTIONS_MQTTEXPORT_PARAMETERS_CLIENTID: app-scalability-test-mqtt-export
+      WRITABLE_PIPELINE_FUNCTIONS_MQTTEXPORT_PARAMETERS_TOPIC: edgex-events
+    hostname: edgex-app-scalability-test-mqtt-export
+    image: nexus3.edgexfoundry.org:10004/app-service-configurable:latest
     networks:
       edgex-network: null
     ports:
     - mode: ingress
-      host_ip: 127.0.0.1
-      target: 59882
-      published: "59882"
+      target: 59703
+      published: "59710"
       protocol: tcp
     read_only: true
-    restart: always
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
@@ -461,65 +461,8 @@ services:
       read_only: true
       volume: {}
     - type: bind
-      source: /tmp/edgex/secrets/core-command
-      target: /tmp/edgex/secrets/core-command
-      read_only: true
-      bind:
-        selinux: z
-        create_host_path: true
-  common-config:
-    command:
-    - /entrypoint.sh
-    - /core-common-config-bootstrapper
-    - -cp=consul.http://edgex-core-consul:8500
-    container_name: edgex-core-common-config-bootstrapper
-    depends_on:
-      consul:
-        condition: service_started
-      secretstore-setup:
-        condition: service_started
-      security-bootstrapper:
-        condition: service_started
-    entrypoint:
-    - /edgex-init/ready_to_run_wait_install.sh
-    environment:
-      ALL_SERVICES_DATABASE_HOST: edgex-redis
-      ALL_SERVICES_MESSAGEBUS_HOST: edgex-redis
-      ALL_SERVICES_REGISTRY_HOST: edgex-core-consul
-      APP_SERVICES_CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
-      DEVICE_SERVICES_CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
-      EDGEX_SECURITY_SECRET_STORE: "true"
-      PROXY_SETUP_HOST: edgex-security-proxy-setup
-      SECRETSTORE_HOST: edgex-vault
-      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
-      STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: "6379"
-      STAGEGATE_DATABASE_READYPORT: "6379"
-      STAGEGATE_READY_TORUNPORT: "54329"
-      STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: "8500"
-      STAGEGATE_REGISTRY_READYPORT: "54324"
-      STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
-      STAGEGATE_WAITFOR_TIMEOUT: 60s
-    hostname: edgex-core-common-config-bootstrapper
-    image: nexus3.edgexfoundry.org:10004/core-common-config-bootstrapper:latest
-    networks:
-      edgex-network: null
-    read_only: true
-    security_opt:
-    - no-new-privileges:true
-    user: 2002:2001
-    volumes:
-    - type: volume
-      source: edgex-init
-      target: /edgex-init
-      read_only: true
-      volume: {}
-    - type: bind
-      source: /tmp/edgex/secrets/core-common-config-bootstrapper
-      target: /tmp/edgex/secrets/core-common-config-bootstrapper
+      source: /tmp/edgex/secrets/app-scalability-test-mqtt-export
+      target: /tmp/edgex/secrets/app-scalability-test-mqtt-export
       read_only: true
       bind:
         selinux: z
@@ -602,7 +545,129 @@ services:
       bind:
         selinux: z
         create_host_path: true
-  data:
+  core-command:
+    command:
+    - /core-command
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
+    container_name: edgex-core-command
+    depends_on:
+      consul:
+        condition: service_started
+      core-metadata:
+        condition: service_started
+      database:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
+      security-secretstore-setup:
+        condition: service_started
+    entrypoint:
+    - /edgex-init/ready_to_run_wait_install.sh
+    environment:
+      EDGEX_SECURITY_SECRET_STORE: "true"
+      EXTERNALMQTT_URL: tcp://edgex-mqtt-broker:1883
+      PROXY_SETUP_HOST: edgex-security-proxy-setup
+      SECRETSTORE_HOST: edgex-vault
+      SERVICE_HOST: edgex-core-command
+      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
+      STAGEGATE_DATABASE_HOST: edgex-redis
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
+      STAGEGATE_READY_TORUNPORT: "54329"
+      STAGEGATE_REGISTRY_HOST: edgex-core-consul
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
+      STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
+      STAGEGATE_WAITFOR_TIMEOUT: 60s
+    hostname: edgex-core-command
+    image: nexus3.edgexfoundry.org:10004/core-command:latest
+    networks:
+      edgex-network: null
+    ports:
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59882
+      published: "59882"
+      protocol: tcp
+    read_only: true
+    restart: always
+    security_opt:
+    - no-new-privileges:true
+    user: 2002:2001
+    volumes:
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/core-command
+      target: /tmp/edgex/secrets/core-command
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
+  core-common-config-bootstrapper:
+    command:
+    - /entrypoint.sh
+    - /core-common-config-bootstrapper
+    - -cp=consul.http://edgex-core-consul:8500
+    container_name: edgex-core-common-config-bootstrapper
+    depends_on:
+      consul:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
+      security-secretstore-setup:
+        condition: service_started
+    entrypoint:
+    - /edgex-init/ready_to_run_wait_install.sh
+    environment:
+      ALL_SERVICES_DATABASE_HOST: edgex-redis
+      ALL_SERVICES_MESSAGEBUS_HOST: edgex-redis
+      ALL_SERVICES_REGISTRY_HOST: edgex-core-consul
+      APP_SERVICES_CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
+      DEVICE_SERVICES_CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
+      EDGEX_SECURITY_SECRET_STORE: "true"
+      PROXY_SETUP_HOST: edgex-security-proxy-setup
+      SECRETSTORE_HOST: edgex-vault
+      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
+      STAGEGATE_DATABASE_HOST: edgex-redis
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
+      STAGEGATE_READY_TORUNPORT: "54329"
+      STAGEGATE_REGISTRY_HOST: edgex-core-consul
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
+      STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
+      STAGEGATE_WAITFOR_TIMEOUT: 60s
+    hostname: edgex-core-common-config-bootstrapper
+    image: nexus3.edgexfoundry.org:10004/core-common-config-bootstrapper:latest
+    networks:
+      edgex-network: null
+    read_only: true
+    security_opt:
+    - no-new-privileges:true
+    user: 2002:2001
+    volumes:
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/core-common-config-bootstrapper
+      target: /tmp/edgex/secrets/core-common-config-bootstrapper
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
+  core-data:
     command:
     - /core-data
     - -cp=consul.http://edgex-core-consul:8500
@@ -611,13 +676,13 @@ services:
     depends_on:
       consul:
         condition: service_started
+      core-metadata:
+        condition: service_started
       database:
         condition: service_started
-      metadata:
-        condition: service_started
-      secretstore-setup:
-        condition: service_started
       security-bootstrapper:
+        condition: service_started
+      security-secretstore-setup:
         condition: service_started
     entrypoint:
     - /edgex-init/ready_to_run_wait_install.sh
@@ -666,12 +731,74 @@ services:
       bind:
         selinux: z
         create_host_path: true
+  core-metadata:
+    command:
+    - /core-metadata
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
+    container_name: edgex-core-metadata
+    depends_on:
+      consul:
+        condition: service_started
+      database:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
+      security-secretstore-setup:
+        condition: service_started
+    entrypoint:
+    - /edgex-init/ready_to_run_wait_install.sh
+    environment:
+      EDGEX_SECURITY_SECRET_STORE: "true"
+      PROXY_SETUP_HOST: edgex-security-proxy-setup
+      SECRETSTORE_HOST: edgex-vault
+      SERVICE_HOST: edgex-core-metadata
+      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
+      STAGEGATE_DATABASE_HOST: edgex-redis
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
+      STAGEGATE_READY_TORUNPORT: "54329"
+      STAGEGATE_REGISTRY_HOST: edgex-core-consul
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
+      STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
+      STAGEGATE_WAITFOR_TIMEOUT: 60s
+    hostname: edgex-core-metadata
+    image: nexus3.edgexfoundry.org:10004/core-metadata:latest
+    networks:
+      edgex-network: null
+    ports:
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59881
+      published: "59881"
+      protocol: tcp
+    read_only: true
+    restart: always
+    security_opt:
+    - no-new-privileges:true
+    user: 2002:2001
+    volumes:
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/core-metadata
+      target: /tmp/edgex/secrets/core-metadata
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
   database:
     container_name: edgex-redis
     depends_on:
-      secretstore-setup:
-        condition: service_started
       security-bootstrapper:
+        condition: service_started
+      security-secretstore-setup:
         condition: service_started
     entrypoint:
     - /edgex-init/redis_wait_install.sh
@@ -741,9 +868,9 @@ services:
     depends_on:
       consul:
         condition: service_started
-      data:
+      core-data:
         condition: service_started
-      metadata:
+      core-metadata:
         condition: service_started
       modbus-simulator:
         condition: service_started
@@ -811,9 +938,9 @@ services:
     depends_on:
       consul:
         condition: service_started
-      data:
+      core-data:
         condition: service_started
-      metadata:
+      core-metadata:
         condition: service_started
       security-bootstrapper:
         condition: service_started
@@ -873,9 +1000,9 @@ services:
     depends_on:
       consul:
         condition: service_started
-      data:
+      core-data:
         condition: service_started
-      metadata:
+      core-metadata:
         condition: service_started
       security-bootstrapper:
         condition: service_started
@@ -936,9 +1063,9 @@ services:
     depends_on:
       consul:
         condition: service_started
-      data:
+      core-data:
         condition: service_started
-      metadata:
+      core-metadata:
         condition: service_started
       security-bootstrapper:
         condition: service_started
@@ -992,68 +1119,6 @@ services:
     - type: bind
       source: /PROFILE_VOLUME_PLACE_HOLDER
       target: CONFIG_DIR_PLACE_HOLDER
-      bind:
-        selinux: z
-        create_host_path: true
-  metadata:
-    command:
-    - /core-metadata
-    - -cp=consul.http://edgex-core-consul:8500
-    - --registry
-    container_name: edgex-core-metadata
-    depends_on:
-      consul:
-        condition: service_started
-      database:
-        condition: service_started
-      secretstore-setup:
-        condition: service_started
-      security-bootstrapper:
-        condition: service_started
-    entrypoint:
-    - /edgex-init/ready_to_run_wait_install.sh
-    environment:
-      EDGEX_SECURITY_SECRET_STORE: "true"
-      PROXY_SETUP_HOST: edgex-security-proxy-setup
-      SECRETSTORE_HOST: edgex-vault
-      SERVICE_HOST: edgex-core-metadata
-      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
-      STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: "6379"
-      STAGEGATE_DATABASE_READYPORT: "6379"
-      STAGEGATE_READY_TORUNPORT: "54329"
-      STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: "8500"
-      STAGEGATE_REGISTRY_READYPORT: "54324"
-      STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
-      STAGEGATE_WAITFOR_TIMEOUT: 60s
-    hostname: edgex-core-metadata
-    image: nexus3.edgexfoundry.org:10004/core-metadata:latest
-    networks:
-      edgex-network: null
-    ports:
-    - mode: ingress
-      host_ip: 127.0.0.1
-      target: 59881
-      published: "59881"
-      protocol: tcp
-    read_only: true
-    restart: always
-    security_opt:
-    - no-new-privileges:true
-    user: 2002:2001
-    volumes:
-    - type: volume
-      source: edgex-init
-      target: /edgex-init
-      read_only: true
-      volume: {}
-    - type: bind
-      source: /tmp/edgex/secrets/core-metadata
-      target: /tmp/edgex/secrets/core-metadata
-      read_only: true
       bind:
         selinux: z
         create_host_path: true
@@ -1124,7 +1189,7 @@ services:
     - daemon off;
     container_name: edgex-nginx
     depends_on:
-      secretstore-setup:
+      security-secretstore-setup:
         condition: service_started
     entrypoint:
     - /bin/sh
@@ -1177,206 +1242,14 @@ services:
       source: nginx-tls
       target: /etc/ssl/nginx
       volume: {}
-  notifications:
-    command:
-    - /support-notifications
-    - -cp=consul.http://edgex-core-consul:8500
-    - --registry
-    container_name: edgex-support-notifications
-    depends_on:
-      consul:
-        condition: service_started
-      database:
-        condition: service_started
-      secretstore-setup:
-        condition: service_started
-      security-bootstrapper:
-        condition: service_started
-    entrypoint:
-    - /edgex-init/ready_to_run_wait_install.sh
-    environment:
-      EDGEX_SECURITY_SECRET_STORE: "true"
-      PROXY_SETUP_HOST: edgex-security-proxy-setup
-      SECRETSTORE_HOST: edgex-vault
-      SERVICE_HOST: edgex-support-notifications
-      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
-      STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: "6379"
-      STAGEGATE_DATABASE_READYPORT: "6379"
-      STAGEGATE_READY_TORUNPORT: "54329"
-      STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: "8500"
-      STAGEGATE_REGISTRY_READYPORT: "54324"
-      STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
-      STAGEGATE_WAITFOR_TIMEOUT: 60s
-    hostname: edgex-support-notifications
-    image: nexus3.edgexfoundry.org:10004/support-notifications:latest
-    networks:
-      edgex-network: null
-    ports:
-    - mode: ingress
-      host_ip: 127.0.0.1
-      target: 59860
-      published: "59860"
-      protocol: tcp
-    read_only: true
-    restart: always
-    security_opt:
-    - no-new-privileges:true
-    user: 2002:2001
-    volumes:
-    - type: volume
-      source: edgex-init
-      target: /edgex-init
-      read_only: true
-      volume: {}
-    - type: bind
-      source: /tmp/edgex/secrets/support-notifications
-      target: /tmp/edgex/secrets/support-notifications
-      read_only: true
-      bind:
-        selinux: z
-        create_host_path: true
-  proxy-auth:
-    command:
-    - entrypoint.sh
-    - /security-proxy-auth
-    - -cp=consul.http://edgex-core-consul:8500
-    - --registry
-    container_name: edgex-proxy-auth
-    depends_on:
-      secretstore-setup:
-        condition: service_started
-    entrypoint:
-    - /bin/sh
-    - /edgex-init/ready_to_run_wait_install.sh
-    environment:
-      EDGEX_SECURITY_SECRET_STORE: "true"
-      PROXY_SETUP_HOST: edgex-security-proxy-setup
-      SECRETSTORE_HOST: edgex-vault
-      SERVICE_HOST: edgex-proxy-auth
-      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
-      STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: "6379"
-      STAGEGATE_DATABASE_READYPORT: "6379"
-      STAGEGATE_READY_TORUNPORT: "54329"
-      STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: "8500"
-      STAGEGATE_REGISTRY_READYPORT: "54324"
-      STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
-      STAGEGATE_WAITFOR_TIMEOUT: 60s
-    hostname: edgex-proxy-auth
-    image: nexus3.edgexfoundry.org:10004/security-proxy-auth:latest
-    networks:
-      edgex-network: null
-    ports:
-    - mode: ingress
-      host_ip: 127.0.0.1
-      target: 59842
-      published: "59842"
-      protocol: tcp
-    read_only: true
-    restart: always
-    security_opt:
-    - no-new-privileges:true
-    volumes:
-    - type: volume
-      source: edgex-init
-      target: /edgex-init
-      read_only: true
-      volume: {}
-    - type: bind
-      source: /tmp/edgex/secrets/security-proxy-auth
-      target: /tmp/edgex/secrets/security-proxy-auth
-      read_only: true
-      bind:
-        selinux: z
-        create_host_path: true
-  proxy-setup:
-    container_name: edgex-security-proxy-setup
-    depends_on:
-      secretstore-setup:
-        condition: service_started
-      security-bootstrapper:
-        condition: service_started
-    entrypoint:
-    - /edgex-init/proxy_setup_wait_install.sh
-    environment:
-      ADD_PROXY_ROUTE: device-modbus.http://edgex-device-modbus:59901
-      EDGEX_SECURITY_SECRET_STORE: "true"
-      PROXY_SETUP_HOST: edgex-security-proxy-setup
-      ROUTES_CORE_COMMAND_HOST: edgex-core-command
-      ROUTES_CORE_CONSUL_HOST: edgex-core-consul
-      ROUTES_CORE_DATA_HOST: edgex-core-data
-      ROUTES_CORE_METADATA_HOST: edgex-core-metadata
-      ROUTES_DEVICE_VIRTUAL_HOST: device-virtual
-      ROUTES_RULES_ENGINE_HOST: edgex-kuiper
-      ROUTES_SUPPORT_NOTIFICATIONS_HOST: edgex-support-notifications
-      ROUTES_SUPPORT_SCHEDULER_HOST: edgex-support-scheduler
-      ROUTES_SYS_MGMT_AGENT_HOST: edgex-sys-mgmt-agent
-      SECRETSTORE_HOST: edgex-vault
-      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
-      STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: "6379"
-      STAGEGATE_DATABASE_READYPORT: "6379"
-      STAGEGATE_READY_TORUNPORT: "54329"
-      STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: "8500"
-      STAGEGATE_REGISTRY_READYPORT: "54324"
-      STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
-      STAGEGATE_WAITFOR_TIMEOUT: 60s
-    hostname: edgex-security-proxy-setup
-    image: nexus3.edgexfoundry.org:10004/security-proxy-setup:latest
-    networks:
-      edgex-network: null
-    read_only: true
-    security_opt:
-    - no-new-privileges:true
-    user: root:root
-    volumes:
-    - type: volume
-      source: edgex-init
-      target: /edgex-init
-      read_only: true
-      volume: {}
-    - type: volume
-      source: nginx-templates
-      target: /etc/nginx/templates
-      volume: {}
-    - type: volume
-      source: nginx-tls
-      target: /etc/ssl/nginx
-      volume: {}
-    - type: volume
-      source: consul-acl-token
-      target: /tmp/edgex/secrets/consul-acl-token
-      read_only: true
-      volume: {}
-    - type: bind
-      source: /tmp/edgex/secrets/security-proxy-setup
-      target: /tmp/edgex/secrets/security-proxy-setup
-      read_only: true
-      bind:
-        selinux: z
-        create_host_path: true
-    - type: volume
-      source: vault-config
-      target: /vault/config
-      volume: {}
-  rulesengine:
+  rules-engine:
     container_name: edgex-kuiper
     depends_on:
       database:
         condition: service_started
-      secretstore-setup:
-        condition: service_started
       security-bootstrapper:
+        condition: service_started
+      security-secretstore-setup:
         condition: service_started
     entrypoint:
     - /edgex-init/kuiper_wait_install.sh
@@ -1450,29 +1323,12 @@ services:
       source: kuiper-plugins
       target: /kuiper/plugins
       volume: {}
-  scalability-test-mqtt-export:
-    command:
-    - /app-service-configurable
-    - -cp=consul.http://edgex-core-consul:8500
-    - --registry
-    container_name: edgex-scalability-test-mqtt-export
-    depends_on:
-      consul:
-        condition: service_started
-      data:
-        condition: service_started
-      security-bootstrapper:
-        condition: service_started
-    entrypoint:
-    - /edgex-init/ready_to_run_wait_install.sh
+  security-bootstrapper:
+    container_name: edgex-security-bootstrapper
     environment:
-      EDGEX_PROFILE: mqtt-export
-      EDGEX_SECURITY_SECRET_STORE: "true"
-      EDGEX_SERVICE_KEY: app-scalability-test-mqtt-export
-      MESSAGEBUS_OPTIONAL_CLIENTID: app-scalability-test-mqtt-export
+      EDGEX_GROUP: "2001"
+      EDGEX_USER: "2002"
       PROXY_SETUP_HOST: edgex-security-proxy-setup
-      SECRETSTORE_HOST: edgex-vault
-      SERVICE_HOST: edgex-scalability-test-mqtt-export
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
       STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
@@ -1485,60 +1341,38 @@ services:
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
       STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
-      WRITABLE_LOGLEVEL: DEBUG
-      WRITABLE_PIPELINE_FUNCTIONS_MQTTEXPORT_PARAMETERS_BROKERADDRESS: MQTT_BROKER_ADDRESS_PLACE_HOLDER
-      WRITABLE_PIPELINE_FUNCTIONS_MQTTEXPORT_PARAMETERS_CLIENTID: scalability-test-mqtt-export
-      WRITABLE_PIPELINE_FUNCTIONS_MQTTEXPORT_PARAMETERS_TOPIC: edgex-events
-    hostname: edgex-scalability-test-mqtt-export
-    image: nexus3.edgexfoundry.org:10004/app-service-configurable:latest
+    hostname: edgex-security-bootstrapper
+    image: nexus3.edgexfoundry.org:10004/security-bootstrapper:latest
     networks:
       edgex-network: null
-    ports:
-    - mode: ingress
-      target: 59703
-      published: "59710"
-      protocol: tcp
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
-    user: 2002:2001
+    user: root:root
     volumes:
     - type: volume
       source: edgex-init
       target: /edgex-init
-      read_only: true
       volume: {}
-    - type: bind
-      source: /tmp/edgex/secrets/app-scalability-test-mqtt-export
-      target: /tmp/edgex/secrets/app-scalability-test-mqtt-export
-      read_only: true
-      bind:
-        selinux: z
-        create_host_path: true
-  scheduler:
+  security-proxy-auth:
     command:
-    - /support-scheduler
+    - entrypoint.sh
+    - /security-proxy-auth
     - -cp=consul.http://edgex-core-consul:8500
     - --registry
-    container_name: edgex-support-scheduler
+    container_name: edgex-proxy-auth
     depends_on:
-      consul:
-        condition: service_started
-      database:
-        condition: service_started
-      secretstore-setup:
-        condition: service_started
-      security-bootstrapper:
+      security-secretstore-setup:
         condition: service_started
     entrypoint:
+    - /bin/sh
     - /edgex-init/ready_to_run_wait_install.sh
     environment:
       EDGEX_SECURITY_SECRET_STORE: "true"
-      INTERVALACTIONS_SCRUBAGED_HOST: edgex-core-data
-      INTERVALACTIONS_SCRUBPUSHED_HOST: edgex-core-data
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       SECRETSTORE_HOST: edgex-vault
-      SERVICE_HOST: edgex-support-scheduler
+      SERVICE_HOST: edgex-proxy-auth
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
       STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
@@ -1551,21 +1385,20 @@ services:
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
       STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
-    hostname: edgex-support-scheduler
-    image: nexus3.edgexfoundry.org:10004/support-scheduler:latest
+    hostname: edgex-proxy-auth
+    image: nexus3.edgexfoundry.org:10004/security-proxy-auth:latest
     networks:
       edgex-network: null
     ports:
     - mode: ingress
       host_ip: 127.0.0.1
-      target: 59861
-      published: "59861"
+      target: 59842
+      published: "59842"
       protocol: tcp
     read_only: true
     restart: always
     security_opt:
     - no-new-privileges:true
-    user: 2002:2001
     volumes:
     - type: volume
       source: edgex-init
@@ -1573,13 +1406,86 @@ services:
       read_only: true
       volume: {}
     - type: bind
-      source: /tmp/edgex/secrets/support-scheduler
-      target: /tmp/edgex/secrets/support-scheduler
+      source: /tmp/edgex/secrets/security-proxy-auth
+      target: /tmp/edgex/secrets/security-proxy-auth
       read_only: true
       bind:
         selinux: z
         create_host_path: true
-  secretstore-setup:
+  security-proxy-setup:
+    container_name: edgex-security-proxy-setup
+    depends_on:
+      security-bootstrapper:
+        condition: service_started
+      security-secretstore-setup:
+        condition: service_started
+    entrypoint:
+    - /edgex-init/proxy_setup_wait_install.sh
+    environment:
+      ADD_PROXY_ROUTE: device-modbus.http://edgex-device-modbus:59901
+      EDGEX_SECURITY_SECRET_STORE: "true"
+      PROXY_SETUP_HOST: edgex-security-proxy-setup
+      ROUTES_CORE_COMMAND_HOST: edgex-core-command
+      ROUTES_CORE_CONSUL_HOST: edgex-core-consul
+      ROUTES_CORE_DATA_HOST: edgex-core-data
+      ROUTES_CORE_METADATA_HOST: edgex-core-metadata
+      ROUTES_DEVICE_VIRTUAL_HOST: device-virtual
+      ROUTES_RULES_ENGINE_HOST: edgex-kuiper
+      ROUTES_SUPPORT_NOTIFICATIONS_HOST: edgex-support-notifications
+      ROUTES_SUPPORT_SCHEDULER_HOST: edgex-support-scheduler
+      ROUTES_SYS_MGMT_AGENT_HOST: edgex-sys-mgmt-agent
+      SECRETSTORE_HOST: edgex-vault
+      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
+      STAGEGATE_DATABASE_HOST: edgex-redis
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
+      STAGEGATE_READY_TORUNPORT: "54329"
+      STAGEGATE_REGISTRY_HOST: edgex-core-consul
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
+      STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
+      STAGEGATE_WAITFOR_TIMEOUT: 60s
+    hostname: edgex-security-proxy-setup
+    image: nexus3.edgexfoundry.org:10004/security-proxy-setup:latest
+    networks:
+      edgex-network: null
+    read_only: true
+    security_opt:
+    - no-new-privileges:true
+    user: root:root
+    volumes:
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      volume: {}
+    - type: volume
+      source: nginx-templates
+      target: /etc/nginx/templates
+      volume: {}
+    - type: volume
+      source: nginx-tls
+      target: /etc/ssl/nginx
+      volume: {}
+    - type: volume
+      source: consul-acl-token
+      target: /tmp/edgex/secrets/consul-acl-token
+      read_only: true
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/security-proxy-setup
+      target: /tmp/edgex/secrets/security-proxy-setup
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
+    - type: volume
+      source: vault-config
+      target: /vault/config
+      volume: {}
+  security-secretstore-setup:
     container_name: edgex-security-secretstore-setup
     depends_on:
       security-bootstrapper:
@@ -1642,38 +1548,6 @@ services:
     - type: volume
       source: vault-config
       target: /vault/config
-      volume: {}
-  security-bootstrapper:
-    container_name: edgex-security-bootstrapper
-    environment:
-      EDGEX_GROUP: "2001"
-      EDGEX_USER: "2002"
-      PROXY_SETUP_HOST: edgex-security-proxy-setup
-      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
-      STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: "6379"
-      STAGEGATE_DATABASE_READYPORT: "6379"
-      STAGEGATE_READY_TORUNPORT: "54329"
-      STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: "8500"
-      STAGEGATE_REGISTRY_READYPORT: "54324"
-      STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
-      STAGEGATE_WAITFOR_TIMEOUT: 60s
-    hostname: edgex-security-bootstrapper
-    image: nexus3.edgexfoundry.org:10004/security-bootstrapper:latest
-    networks:
-      edgex-network: null
-    read_only: true
-    restart: always
-    security_opt:
-    - no-new-privileges:true
-    user: root:root
-    volumes:
-    - type: volume
-      source: edgex-init
-      target: /edgex-init
       volume: {}
   security-spiffe-token-provider:
     command:
@@ -1909,6 +1783,132 @@ services:
     - type: bind
       source: /tmp/edgex/secrets/spiffe
       target: /tmp/edgex/secrets/spiffe
+      bind:
+        selinux: z
+        create_host_path: true
+  support-notifications:
+    command:
+    - /support-notifications
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
+    container_name: edgex-support-notifications
+    depends_on:
+      consul:
+        condition: service_started
+      database:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
+      security-secretstore-setup:
+        condition: service_started
+    entrypoint:
+    - /edgex-init/ready_to_run_wait_install.sh
+    environment:
+      EDGEX_SECURITY_SECRET_STORE: "true"
+      PROXY_SETUP_HOST: edgex-security-proxy-setup
+      SECRETSTORE_HOST: edgex-vault
+      SERVICE_HOST: edgex-support-notifications
+      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
+      STAGEGATE_DATABASE_HOST: edgex-redis
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
+      STAGEGATE_READY_TORUNPORT: "54329"
+      STAGEGATE_REGISTRY_HOST: edgex-core-consul
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
+      STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
+      STAGEGATE_WAITFOR_TIMEOUT: 60s
+    hostname: edgex-support-notifications
+    image: nexus3.edgexfoundry.org:10004/support-notifications:latest
+    networks:
+      edgex-network: null
+    ports:
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59860
+      published: "59860"
+      protocol: tcp
+    read_only: true
+    restart: always
+    security_opt:
+    - no-new-privileges:true
+    user: 2002:2001
+    volumes:
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/support-notifications
+      target: /tmp/edgex/secrets/support-notifications
+      read_only: true
+      bind:
+        selinux: z
+        create_host_path: true
+  support-scheduler:
+    command:
+    - /support-scheduler
+    - -cp=consul.http://edgex-core-consul:8500
+    - --registry
+    container_name: edgex-support-scheduler
+    depends_on:
+      consul:
+        condition: service_started
+      database:
+        condition: service_started
+      security-bootstrapper:
+        condition: service_started
+      security-secretstore-setup:
+        condition: service_started
+    entrypoint:
+    - /edgex-init/ready_to_run_wait_install.sh
+    environment:
+      EDGEX_SECURITY_SECRET_STORE: "true"
+      INTERVALACTIONS_SCRUBAGED_HOST: edgex-core-data
+      INTERVALACTIONS_SCRUBPUSHED_HOST: edgex-core-data
+      PROXY_SETUP_HOST: edgex-security-proxy-setup
+      SECRETSTORE_HOST: edgex-vault
+      SERVICE_HOST: edgex-support-scheduler
+      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
+      STAGEGATE_DATABASE_HOST: edgex-redis
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
+      STAGEGATE_READY_TORUNPORT: "54329"
+      STAGEGATE_REGISTRY_HOST: edgex-core-consul
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
+      STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
+      STAGEGATE_WAITFOR_TIMEOUT: 60s
+    hostname: edgex-support-scheduler
+    image: nexus3.edgexfoundry.org:10004/support-scheduler:latest
+    networks:
+      edgex-network: null
+    ports:
+    - mode: ingress
+      host_ip: 127.0.0.1
+      target: 59861
+      published: "59861"
+      protocol: tcp
+    read_only: true
+    restart: always
+    security_opt:
+    - no-new-privileges:true
+    user: 2002:2001
+    volumes:
+    - type: volume
+      source: edgex-init
+      target: /edgex-init
+      read_only: true
+      volume: {}
+    - type: bind
+      source: /tmp/edgex/secrets/support-scheduler
+      target: /tmp/edgex/secrets/support-scheduler
+      read_only: true
       bind:
         selinux: z
         create_host_path: true


### PR DESCRIPTION
BREAKING CHANGE: Many sevice names have changed in order to conform with core-, support-, app- and device- naming standard. Impact should be minimal unless scripts have references to the old service names, rather than container names. Container name havent chnaged except for app-functional-tests' which is now edgex-app-functional-tests

closes #231
Signed-off-by: Leonard Goodell <leonard.goodell@intel.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-compose/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-compose/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>


## Testing Instructions
run `make run ds-virtual` 
Verify all service bootstrap and data is flowing from Device Virtual to App Rules Engine