### PR TITLE
fix: Some device service containers dont' have dumb-init

### DIFF
--- a/compose-builder/add-service-secure-template.yml
+++ b/compose-builder/add-service-secure-template.yml
@@ -30,7 +30,7 @@ services:
       ADD_PROXY_ROUTE: ${EXTRA_PROXY_ROUTE_LIST}
 
   ${SERVICE_NAME}:
-    entrypoint: ["/edgex-init/ready_to_run_wait_install.sh"]
+    entrypoint: [${SHELL_OVERRIDE} "/edgex-init/ready_to_run_wait_install.sh"]
     command: "/${EXECUTABLE} ${DEFAULT_EDGEX_RUN_CMD_PARMS}"
     env_file:
       - common-security.env

--- a/compose-builder/gen_secure_compose_ext.sh
+++ b/compose-builder/gen_secure_compose_ext.sh
@@ -51,6 +51,15 @@ SERVICE_EXT_COMPOSE_PATH=./"$GEN_EXT_DIR"/add-"$service_name"-secure.yml
 sed 's/${SERVICE_NAME}:/'"$service_name"':/g' "$ADD_SERVICE_SECURE_FILE_TEMPLATE" > "$SERVICE_EXT_COMPOSE_PATH"
 sed -i 's/${SERVICE_KEY}/'"$service_key"'/g' "$SERVICE_EXT_COMPOSE_PATH"
 sed -i 's/${EXECUTABLE}/'"$executable"'/g' "$SERVICE_EXT_COMPOSE_PATH"
+case "${service_name}" in
+  device-bacnet | device-coap | device-gpio)
+    # These services don't have dumb-init in their containers, causing an issue for the wait script, use sh instead
+    sed -i 's/${SHELL_OVERRIDE}/"\/bin\/sh", /g' "$SERVICE_EXT_COMPOSE_PATH"
+    ;;
+  *)
+    sed -i 's/${SHELL_OVERRIDE}//g' "$SERVICE_EXT_COMPOSE_PATH"
+    ;;
+esac
 # optional with default value
 if [ "$num_of_args" -eq 4 ]; then
     sed -i 's/ ${DEFAULT_EDGEX_RUN_CMD_PARMS}/'"$params"'/g' "$SERVICE_EXT_COMPOSE_PATH"


### PR DESCRIPTION
Fixes issue where some device service containers don't have the dumb-init tool, which us used as the shell intepreter for the wait_install.sh secure bootstrapping script.  The override forces use of /bin/sh.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [X] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>


## Testing Instructions
Run make run with all device services.  Note that device-bacnet container has a missing file that is causing nested startup issues.
