### PR TITLE
fix: added missing delayed started spiffe volume for support services

### DIFF
--- a/compose-builder/Makefile
+++ b/compose-builder/Makefile
@@ -100,6 +100,13 @@ else
     export MQTT_VERBOSE=
 endif
 
+# When in delay-start mode, we have to make sure support serivces be delayed-start-compliant: i.e. the runtime-token configuration be added etc..
+ifeq (delayed-start, $(filter delayed-start,$(ARGS)))
+	ext_file_sup_notif:= $(shell GEN_EXT_DIR="$(GEN_EXT_DIR)" ./gen_runtime_token_config_compose_ext.sh support-notifications)
+	ext_file_sup_sch:= $(shell GEN_EXT_DIR="$(GEN_EXT_DIR)" ./gen_runtime_token_config_compose_ext.sh support-scheduler)
+	COMPOSE_FILES:=$(COMPOSE_FILES) -f $(ext_file_sup_notif) -f $(ext_file_sup_sch)
+endif
+
 # Add Device Services
 ifeq (ds-onvif-camera, $(filter ds-onvif-camera,$(ARGS)))
 	COMPOSE_FILES:=$(COMPOSE_FILES) -f add-device-onvif-camera.yml


### PR DESCRIPTION
  Updated Makefile to run delayed-started generation script for support services to make sure these serivces are delayed-startable

  Fixes: #364

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-compose/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-compose/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x ] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x ] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>


## Testing Instructions
<!-- How can the reviewers test your change? -->
- docker build the latest edgex-go and ensure the fix in this PR is in there: https://github.com/edgexfoundry/edgex-go/pull/4509 
- use compose_builder to run it with delay-started mode: `make run dev delayed-start ds-virtual ds-modbus` 
- wait for a few minutes to let everything start up and settle down
- verify that both `support-notifications` and `support-scheduler` are now received tokens from spiffe token provider
