### PR TITLE
fix: CREDENTIALSPATH changed to CREDENTIALSNAME

### DIFF
--- a/compose-builder/add-secure-device-mqtt.yml
+++ b/compose-builder/add-secure-device-mqtt.yml
@@ -19,4 +19,4 @@ services:
   device-mqtt:
     environment:
       MQTTBROKERINFO_AUTHMODE: usernamepassword
-      MQTTBROKERINFO_CREDENTIALSPATH: message-bus
+      MQTTBROKERINFO_CREDENTIALSNAME: message-bus


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [X] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>


## Testing Instructions
```
make run ds-mqtt mqtt-bus
```

Without this fix, device-mqtt will fail trying to cred "credentials" secret instead of "message-bus" secret.
