### PR TITLE
fix: Repair startup argumetns for device-bacnet in secure mode

### DIFF
--- a/compose-builder/Makefile
+++ b/compose-builder/Makefile
@@ -165,7 +165,8 @@ ifeq (ds-bacnet, $(filter ds-bacnet,$(ARGS)))
 		else
 			KNOWN_SECRETS_LIST:=$(KNOWN_SECRETS_LIST),redisdb[device-bacnet],message-bus[device-bacnet]
 		endif
-		extension_file:= $(shell GEN_EXT_DIR="$(GEN_EXT_DIR)" ./gen_secure_compose_ext.sh device-bacnet device-bacnet startup.sh "")
+		extension_file:= $(shell GEN_EXT_DIR="$(GEN_EXT_DIR)" ./gen_secure_compose_ext.sh device-bacnet device-bacnet device-bacnet-ip/device-bacnet-c " -cp=consul://edgex-core-consul:8500 --registry --confdir=/res")
+
 		COMPOSE_FILES:=$(COMPOSE_FILES) -f $(extension_file)
 		# add runtime token config for delayed-start if specified
 		ifeq (delayed-start, $(filter delayed-start,$(ARGS)))

--- a/compose-builder/gen_secure_compose_ext.sh
+++ b/compose-builder/gen_secure_compose_ext.sh
@@ -50,7 +50,7 @@ ADD_SERVICE_SECURE_FILE_TEMPLATE="add-service-secure-template.yml"
 SERVICE_EXT_COMPOSE_PATH=./"$GEN_EXT_DIR"/add-"$service_name"-secure.yml
 sed 's/${SERVICE_NAME}:/'"$service_name"':/g' "$ADD_SERVICE_SECURE_FILE_TEMPLATE" > "$SERVICE_EXT_COMPOSE_PATH"
 sed -i 's/${SERVICE_KEY}/'"$service_key"'/g' "$SERVICE_EXT_COMPOSE_PATH"
-sed -i 's/${EXECUTABLE}/'"$executable"'/g' "$SERVICE_EXT_COMPOSE_PATH"
+sed -i 's,${EXECUTABLE},'"$executable"',g' "$SERVICE_EXT_COMPOSE_PATH"
 case "${service_name}" in
   device-bacnet | device-coap | device-gpio)
     # These services don't have dumb-init in their containers, causing an issue for the wait script, use sh instead
@@ -62,7 +62,7 @@ case "${service_name}" in
 esac
 # optional with default value
 if [ "$num_of_args" -eq 4 ]; then
-    sed -i 's/ ${DEFAULT_EDGEX_RUN_CMD_PARMS}/'"$params"'/g' "$SERVICE_EXT_COMPOSE_PATH"
+    sed -i 's, ${DEFAULT_EDGEX_RUN_CMD_PARMS},'"$params"',g' "$SERVICE_EXT_COMPOSE_PATH"
 fi
 
 # app-service-mqtt-export has non-empty env section


### PR DESCRIPTION
device-bacnet container does not contain a startup.sh. Replace with appropriate command based on what is in the default ENTRYPOINT and CMD for no-security container.

Modify gen_secure_compose_ext.sh script to use comma delimeter in case executable to be launched uses
slash as part of its path.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [ ] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>


## Testing Instructions
```
make run ds-bacnet
```

Note that `docker logs edgex-device-bacnet` will terminate with

```
level=INFO ts=2023-04-18T20:53:15Z app=device-coap msg="Uploading configuration to registry."
level=ERROR ts=2023-04-18T20:53:15Z app=device-coap msg="Unable to upload config: HTTP 409 Conflict"
Error: 17: HTTP 409 Conflict
```

However, the current scenario is that the container does not run at all, so this is an improvement.