### PR TITLE
fix: Don't register spiffe token provider service

### DIFF
--- a/compose-builder/add-delayed-start-services.yml
+++ b/compose-builder/add-delayed-start-services.yml
@@ -110,7 +110,7 @@ services:
     image: ${CORE_EDGEX_REPOSITORY}/security-spiffe-token-provider${ARCH}:${CORE_EDGEX_VERSION}
     entrypoint:
       - /edgex-init/ready_to_run_wait_install.sh
-    command: /security-spiffe-token-provider -cp=consul.http://edgex-core-consul:8500 --registry
+    command: /security-spiffe-token-provider -cp=consul.http://edgex-core-consul:8500
     user: "root:root"
     container_name: edgex-security-spiffe-token-provider
     hostname: edgex-security-spiffe-token-provider


### PR DESCRIPTION
go-mod-bootstrap only allows registration of HTTP healtchecks with consul, which will not work for this service, as it requires clients have a client TLS certificate

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-compose/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [X] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>


## Testing Instructions
<!-- How can the reviewers test your change? -->
```
make delayed-start ds-virtual
```


Thence, go to http://localhost:8500/ui/dc1/services and verify no failing health check for edgex-security-spiffe-token-provider
