### PR TITLE
fix: [minnesota] Correct GPIO Port to be same as documented

### DIFF
--- a/compose-builder/add-device-gpio.yml
+++ b/compose-builder/add-device-gpio.yml
@@ -19,7 +19,7 @@ services:
   device-gpio:
     image: ${DEVICE_SVC_REPOSITORY}/device-gpio${ARCH}:${DEVICE_GPIO_VERSION}
     ports:
-    - "127.0.0.1:59994:59994"
+    - "127.0.0.1:59910:59910"
     container_name: edgex-device-gpio
     hostname: edgex-device-gpio
     read_only: true


### PR DESCRIPTION
<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-compose/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-compose/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [ ] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>


## Testing Instructions
<!-- How can the reviewers test your change? -->
