### PR TITLE
fix: [napa] Use correct value for MQTTBROKERINFO_AUTHMODE for Device MQTT

### DIFF
--- a/compose-builder/Makefile
+++ b/compose-builder/Makefile
@@ -278,7 +278,12 @@ ifeq (ds-mqtt, $(filter ds-mqtt,$(ARGS)))
 		else
 			EXTRA_PROXY_ROUTE_LIST:=$(EXTRA_PROXY_ROUTE_LIST),$(PROXY_ROUTE)
 		endif
-		extension_file:= $(shell GEN_EXT_DIR="$(GEN_EXT_DIR)" ./gen_secure_compose_ext.sh device-mqtt)
+		ifeq (mqtt-bus, $(filter mqtt-bus,$(ARGS)))
+			IS_MQTT_BUS:=1
+		else
+			IS_MQTT_BUS:=0
+		endif
+		extension_file:= $(shell GEN_EXT_DIR="$(GEN_EXT_DIR)" IS_MQTT_BUS="$(IS_MQTT_BUS)" ./gen_secure_compose_ext.sh device-mqtt)
 		COMPOSE_FILES:=$(COMPOSE_FILES) -f $(extension_file)
 		# add runtime token config for delayed-start if specified
 		ifeq (delayed-start, $(filter delayed-start,$(ARGS)))

--- a/compose-builder/add-secure-device-mqtt.yml
+++ b/compose-builder/add-secure-device-mqtt.yml
@@ -18,5 +18,5 @@ version: '3.7'
 services:
   device-mqtt:
     environment:
-      MQTTBROKERINFO_AUTHMODE: usernamepassword
+      MQTTBROKERINFO_AUTHMODE: none
       MQTTBROKERINFO_CREDENTIALSNAME: message-bus

--- a/compose-builder/gen_secure_compose_ext.sh
+++ b/compose-builder/gen_secure_compose_ext.sh
@@ -65,13 +65,17 @@ if [ "$num_of_args" -eq 4 ]; then
     sed -i 's, ${DEFAULT_EDGEX_RUN_CMD_PARMS},'"$params"',g' "$SERVICE_EXT_COMPOSE_PATH"
 fi
 
-# app-service-mqtt-export has non-empty env section
 if [ "$IS_MQTT_BUS" = "1" ]; then
   if [ "$service_name" = "app-service-mqtt-export" ] || [ "$service_name" = "app-scalability-test-mqtt-export" ]; then
     ENV_SECTION='environment:\r      WRITABLE_INSECURESECRETS_MQTT_SECRETS_USERNAME: USERNAME_PLACEH_OLDER\r      WRITABLE_INSECURESECRETS_MQTT_SECRETS_PASSWORD: PASSWORD_PLACE_HOLDER'
     sed -i 's/##${ENVIRONMENT_SECTION}/'"$ENV_SECTION"'/g' "$SERVICE_EXT_COMPOSE_PATH"
   fi
+  if [ "$service_name" = "device-mqtt" ]; then
+    ENV_SECTION='environment:\r      MQTTBROKERINFO_AUTHMODE: usernamepassword'
+    sed -i 's/##${ENVIRONMENT_SECTION}/'"$ENV_SECTION"'/g' "$SERVICE_EXT_COMPOSE_PATH"
+  fi
 fi
+
 
 # return the extension compose file path
 echo "$SERVICE_EXT_COMPOSE_PATH"


### PR DESCRIPTION
closes #395

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-compose/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-compose/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?) **N/A**
  <link to docs PR>


## Testing Instructions
run `make gen ds-mqtt mqtt-broker`
Verify Device MQTT has `MQTTBROKERINFO_AUTHMODE: none`
run `make gen ds-mqtt mqtt-bus`
Verify Device MQTT has `MQTTBROKERINFO_AUTHMODE: usernamepassword`