### PR TITLE
fix: Add "restart: always" in security-proxy-setup service

### DIFF
--- a/compose-builder/Makefile
+++ b/compose-builder/Makefile
@@ -813,7 +813,6 @@ ifeq (taf-secty, $(filter taf-secty,$(ARGS)))
 		-f add-device-rest.yml \
 		-f add-device-modbus.yml \
 		-f add-device-onvif-camera.yml \
-		-f add-device-s7.yml \
 		-f add-taf-device-services-mods.yml \
 		-f add-mqtt-broker-mosquitto.yml \
 		-f add-modbus-simulator.yml \
@@ -869,7 +868,6 @@ else
 			-f add-device-rest.yml \
 			-f add-device-modbus.yml \
             -f add-device-onvif-camera.yml \
-			-f add-device-s7.yml \
 			-f add-taf-device-services-mods.yml \
 			-f ${BROKER_YAML} \
 			-f add-modbus-simulator.yml \
@@ -897,7 +895,6 @@ else
     			-f add-asc-mqtt-export.yml \
     			-f add-device-virtual.yml \
     			-f add-device-rest.yml \
-				-f add-device-s7.yml \
     			-f add-mqtt-broker-mosquitto.yml \
 				-f add-taf-mqtt-broker-mosquitto.yml \
 			-f add-delayed-start-services.yml
@@ -914,7 +911,6 @@ else
 					-f add-asc-mqtt-export.yml \
 					-f add-device-virtual.yml \
 					-f add-device-rest.yml \
-					-f add-device-s7.yml \
 					-f ${BROKER_YAML} \
 					-f ${TAF_BROKER_YAML}
 

--- a/compose-builder/add-security.yml
+++ b/compose-builder/add-security.yml
@@ -195,6 +195,7 @@ services:
     hostname: edgex-security-proxy-setup
     entrypoint: ["/edgex-init/proxy_setup_wait_install.sh"]
     read_only: true
+    restart: always
     networks:
       - edgex-network
     env_file:

--- a/docker-compose-arm64.yml
+++ b/docker-compose-arm64.yml
@@ -955,6 +955,7 @@ services:
     networks:
       edgex-network: null
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: root:root

--- a/docker-compose-with-app-sample-arm64.yml
+++ b/docker-compose-with-app-sample-arm64.yml
@@ -1028,6 +1028,7 @@ services:
     networks:
       edgex-network: null
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: root:root

--- a/docker-compose-with-app-sample.yml
+++ b/docker-compose-with-app-sample.yml
@@ -1028,6 +1028,7 @@ services:
     networks:
       edgex-network: null
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: root:root

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -955,6 +955,7 @@ services:
     networks:
       edgex-network: null
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: root:root

--- a/taf/docker-compose-taf-arm64.yml
+++ b/taf/docker-compose-taf-arm64.yml
@@ -1617,6 +1617,7 @@ services:
     networks:
       edgex-network: null
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: root:root

--- a/taf/docker-compose-taf-mqtt-bus-arm64.yml
+++ b/taf/docker-compose-taf-mqtt-bus-arm64.yml
@@ -1679,6 +1679,7 @@ services:
     networks:
       edgex-network: null
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: root:root

--- a/taf/docker-compose-taf-mqtt-bus.yml
+++ b/taf/docker-compose-taf-mqtt-bus.yml
@@ -1679,6 +1679,7 @@ services:
     networks:
       edgex-network: null
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: root:root

--- a/taf/docker-compose-taf-perf-arm64.yml
+++ b/taf/docker-compose-taf-perf-arm64.yml
@@ -1070,6 +1070,7 @@ services:
     networks:
       edgex-network: null
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: root:root

--- a/taf/docker-compose-taf-perf.yml
+++ b/taf/docker-compose-taf-perf.yml
@@ -1070,6 +1070,7 @@ services:
     networks:
       edgex-network: null
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: root:root

--- a/taf/docker-compose-taf.yml
+++ b/taf/docker-compose-taf.yml
@@ -1617,6 +1617,7 @@ services:
     networks:
       edgex-network: null
     read_only: true
+    restart: always
     security_opt:
     - no-new-privileges:true
     user: root:root


### PR DESCRIPTION
Closes #434
`make build` by `Docker Compose version v2.15.1`


<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-compose/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-compose/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [X] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>


## Testing Instructions
<!-- How can the reviewers test your change? -->
