### PR TITLE
feat: Docker rootless

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,9 @@ DOCKER_COMPOSE=docker compose
 # Resolve user ID for rootless docker port mapping
 export USERID:=$(shell id -u)
 
+# Set default rootful docker socket path
+export DOCKER_SOCKET_PATH=/var/run/docker.sock
+
 ifeq (arm64, $(filter arm64,$(ARGS)))
 	ARM64=-arm64
 	ARM64_OPTION=arm64
@@ -55,10 +58,8 @@ endef
 .PHONY: $(OPTIONS)
 
 portainer:
-	@if [ ! -e /run/user/${USERID}/docker.sock ]; then \
-    	echo "Error: Docker socket not found at /run/user/${USERID}/docker.sock"; \
-    	echo "Please ensure Docker is running rootless."; \
-    	exit 1; \
+	@if [ -e /run/user/${USERID}/docker.sock ]; then \
+    	export DOCKER_SOCKET_PATH=/run/user/${USERID}/docker.sock; \
     fi
 	${DOCKER_COMPOSE} -p portainer -f docker-compose-portainer.yml up -d
 

--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,11 @@ endef
 .PHONY: $(OPTIONS)
 
 portainer:
-	echo "user ID: ${USERID}"
+	@if [ ! -e /run/user/${USERID}/docker.sock ]; then \
+    	echo "Error: Docker socket not found at /run/user/${USERID}/docker.sock"; \
+    	echo "Please ensure Docker is running rootless."; \
+    	exit 1; \
+    fi
 	${DOCKER_COMPOSE} -p portainer -f docker-compose-portainer.yml up -d
 
 portainer-down:

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,11 @@ OPTIONS:=" arm64 no-secty app-sample zero-trust " # Must have spaces around word
 # This tool now only supports compose V2, aka "docker compose" as it has replaced to old docker-compose tool.
 DOCKER_COMPOSE=docker compose
 
+# Resolve user ID for rootless docker port mapping
+
+# Resolve user ID for rootless docker port mapping
+export USERID:=$(shell id -u)
+
 ifeq (arm64, $(filter arm64,$(ARGS)))
 	ARM64=-arm64
 	ARM64_OPTION=arm64
@@ -52,6 +57,7 @@ endef
 .PHONY: $(OPTIONS)
 
 portainer:
+	echo "user ID: ${USERID}"
 	${DOCKER_COMPOSE} -p portainer -f docker-compose-portainer.yml up -d
 
 portainer-down:

--- a/Makefile
+++ b/Makefile
@@ -28,8 +28,6 @@ OPTIONS:=" arm64 no-secty app-sample zero-trust " # Must have spaces around word
 DOCKER_COMPOSE=docker compose
 
 # Resolve user ID for rootless docker port mapping
-
-# Resolve user ID for rootless docker port mapping
 export USERID:=$(shell id -u)
 
 ifeq (arm64, $(filter arm64,$(ARGS)))

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ The compose files under the `taf` subfolder are used for the automated TAF tests
 
 - **docker-compose-portainer.yml**
     Stand-alone compose file for running Portainer which is a  Docker container management tool. Visit here https://www.portainer.io/ for more details on Portianer.
-    Use `make portainer`and `make portainer-down` to start and stop Portainer.
+    Use `make portainer`and `make portainer-down` to start and stop Portainer. This feature has been configured to run only in a rootless docker environment.
 
 ### Use PostgreSQL as the persistence layer in EdgeX
 - **docker-compose-postgres-no-secty.yml** Contains just the services needed to run in non-secure configuration. Includes Postgres, Redis, Device Virtual and MQTT Broker services using a mix of Postgres and Redis as the databases and MQTT as the message bus.

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ The compose files under the `taf` subfolder are used for the automated TAF tests
 
 - **docker-compose-portainer.yml**
     Stand-alone compose file for running Portainer which is a  Docker container management tool. Visit here https://www.portainer.io/ for more details on Portianer.
-    Use `make portainer`and `make portainer-down` to start and stop Portainer. This feature has been configured to run only in a rootless docker environment.
+    Use `make portainer`and `make portainer-down` to start and stop Portainer.
 
 ### Use PostgreSQL as the persistence layer in EdgeX
 - **docker-compose-postgres-no-secty.yml** Contains just the services needed to run in non-secure configuration. Includes Postgres, Redis, Device Virtual and MQTT Broker services using a mix of Postgres and Redis as the databases and MQTT as the message bus.

--- a/compose-builder/Makefile
+++ b/compose-builder/Makefile
@@ -37,7 +37,8 @@ NANOMQ=
 REGISTRY=
 
 # Resolve user ID for rootless docker port mapping
-export USERID=$(id -u)
+# Resolve user ID for rootless docker port mapping
+export USERID:=$(shell id -u)
 
 BROKER_YAML=add-mqtt-broker-mosquitto.yml
 TAF_BROKER_YAML=add-taf-mqtt-broker-mosquitto.yml

--- a/compose-builder/Makefile
+++ b/compose-builder/Makefile
@@ -149,10 +149,8 @@ ifeq (delayed-start,$(filter delayed-start,$(ARGS)))
     endif
 
     # Generate runtime token config for support services
-    ext_file_sup_notif := $(shell ZERO_TRUST="$(MAKE_ZERO_TRUST)" GEN_EXT_DIR="$(GEN_EXT_DIR)" \
-        ./gen_runtime_token_config_compose_ext.sh support-notifications)
-    ext_file_sup_sch := $(shell ZERO_TRUST="$(MAKE_ZERO_TRUST)" GEN_EXT_DIR="$(GEN_EXT_DIR)" \
-        ./gen_runtime_token_config_compose_ext.sh support-scheduler)
+    ext_file_sup_notif := $(shell ZERO_TRUST="$(MAKE_ZERO_TRUST)" GEN_EXT_DIR="$(GEN_EXT_DIR)" ./gen_runtime_token_config_compose_ext.sh support-notifications)
+    ext_file_sup_sch := $(shell ZERO_TRUST="$(MAKE_ZERO_TRUST)" GEN_EXT_DIR="$(GEN_EXT_DIR)"  ./gen_runtime_token_config_compose_ext.sh support-scheduler)
 
     # Add generated config files to COMPOSE_FILES
     COMPOSE_FILES += -f $(ext_file_sup_notif) -f $(ext_file_sup_sch)

--- a/compose-builder/Makefile
+++ b/compose-builder/Makefile
@@ -141,15 +141,21 @@ ifeq (keeper, $(filter keeper,$(ARGS)))
 	endif
 endif
 
-# When in delay-start mode, we have to make sure support serivces be delayed-start-compliant: i.e. the runtime-token configuration be added etc..
-ifeq (delayed-start, $(filter delayed-start,$(ARGS)))
-    # Make sure docker is running rootless as security-spire-agent runs only in docker rootless mode
-	@if [ -e /run/user/${USERID}/docker.sock ]; then \
-		export DOCKER_SOCKET_PATH=/run/user/${USERID}/docker.sock; \
-    fi
-	ext_file_sup_notif:= $(shell ZERO_TRUST="$(MAKE_ZERO_TRUST)" GEN_EXT_DIR="$(GEN_EXT_DIR)" ./gen_runtime_token_config_compose_ext.sh support-notifications)
-	ext_file_sup_sch:= $(shell ZERO_TRUST="$(MAKE_ZERO_TRUST)" GEN_EXT_DIR="$(GEN_EXT_DIR)" ./gen_runtime_token_config_compose_ext.sh support-scheduler)
-	COMPOSE_FILES:=$(COMPOSE_FILES) -f $(ext_file_sup_notif) -f $(ext_file_sup_sch)
+# When in delay-start mode, ensure support services are delay-start-compliant by adding runtime-token configuration
+ifeq (delayed-start,$(filter delayed-start,$(ARGS)))
+    # Ensure Docker is running rootless, as security-spire-agent runs only in Docker rootless mode
+    ifneq (,$(wildcard /run/user/$(USERID)/docker.sock))
+        export DOCKER_SOCKET_PATH := /run/user/$(USERID)/docker.sock
+    endif
+
+    # Generate runtime token config for support services
+    ext_file_sup_notif := $(shell ZERO_TRUST="$(MAKE_ZERO_TRUST)" GEN_EXT_DIR="$(GEN_EXT_DIR)" \
+        ./gen_runtime_token_config_compose_ext.sh support-notifications)
+    ext_file_sup_sch := $(shell ZERO_TRUST="$(MAKE_ZERO_TRUST)" GEN_EXT_DIR="$(GEN_EXT_DIR)" \
+        ./gen_runtime_token_config_compose_ext.sh support-scheduler)
+
+    # Add generated config files to COMPOSE_FILES
+    COMPOSE_FILES += -f $(ext_file_sup_notif) -f $(ext_file_sup_sch)
 endif
 
 # Add Device Services

--- a/compose-builder/Makefile
+++ b/compose-builder/Makefile
@@ -138,6 +138,12 @@ endif
 
 # When in delay-start mode, we have to make sure support serivces be delayed-start-compliant: i.e. the runtime-token configuration be added etc..
 ifeq (delayed-start, $(filter delayed-start,$(ARGS)))
+    # Make sure docker is running rootless as security-spire-agent runs only in docker rootless mode
+	@if [ ! -e /run/user/${USERID}/docker.sock ]; then \
+    	echo "Error: Docker socket not found at /run/user/${USERID}/docker.sock"; \
+    	echo "Please ensure Docker is running rootless."; \
+    	exit 1; \
+    fi
 	ext_file_sup_notif:= $(shell ZERO_TRUST="$(MAKE_ZERO_TRUST)" GEN_EXT_DIR="$(GEN_EXT_DIR)" ./gen_runtime_token_config_compose_ext.sh support-notifications)
 	ext_file_sup_sch:= $(shell ZERO_TRUST="$(MAKE_ZERO_TRUST)" GEN_EXT_DIR="$(GEN_EXT_DIR)" ./gen_runtime_token_config_compose_ext.sh support-scheduler)
 	COMPOSE_FILES:=$(COMPOSE_FILES) -f $(ext_file_sup_notif) -f $(ext_file_sup_sch)
@@ -1064,6 +1070,11 @@ help:
 	echo "See README.md in this folder"
 
 portainer:
+	@if [ ! -e /run/user/${USERID}/docker.sock ]; then \
+    	echo "Error: Docker socket not found at /run/user/${USERID}/docker.sock"; \
+    	echo "Please ensure Docker is running rootless."; \
+    	exit 1; \
+    fi
 	make -C ${RELEASE_FOLDER} portainer
 
 portainer-down:

--- a/compose-builder/Makefile
+++ b/compose-builder/Makefile
@@ -1135,7 +1135,6 @@ taf-compose-perf: gen
 	cat gen-header docker-compose.yml > $(RELEASE_FOLDER)taf/docker-compose-taf-perf$(NO_SECURITY)$(BUS)$(NANOMQ)$(ARCH).yml
 
 run: gen
-	echo mem = ${TOTAL_SYSTEM_MEMORY}
 	${DOCKER_COMPOSE}  -p edgex up -d $(SERVICES)
 
 pull: gen

--- a/compose-builder/Makefile
+++ b/compose-builder/Makefile
@@ -36,6 +36,9 @@ BUS=
 NANOMQ=
 REGISTRY=
 
+# Resolve user ID for rootless docker port mapping
+export USERID=$(id -u)
+
 BROKER_YAML=add-mqtt-broker-mosquitto.yml
 TAF_BROKER_YAML=add-taf-mqtt-broker-mosquitto.yml
 

--- a/compose-builder/Makefile
+++ b/compose-builder/Makefile
@@ -42,6 +42,9 @@ export USERID:=$(shell id -u)
 # Set default rootful docker socket path
 export DOCKER_SOCKET_PATH=/var/run/docker.sock
 
+# Get total system memory in megabytes for vault config
+export TOTAL_SYSTEM_MEMORY:=$(shell grep MemTotal /proc/meminfo | awk '{print $$2}')m
+
 BROKER_YAML=add-mqtt-broker-mosquitto.yml
 TAF_BROKER_YAML=add-taf-mqtt-broker-mosquitto.yml
 
@@ -1132,6 +1135,7 @@ taf-compose-perf: gen
 	cat gen-header docker-compose.yml > $(RELEASE_FOLDER)taf/docker-compose-taf-perf$(NO_SECURITY)$(BUS)$(NANOMQ)$(ARCH).yml
 
 run: gen
+	echo mem = ${TOTAL_SYSTEM_MEMORY}
 	${DOCKER_COMPOSE}  -p edgex up -d $(SERVICES)
 
 pull: gen

--- a/compose-builder/Makefile
+++ b/compose-builder/Makefile
@@ -37,7 +37,6 @@ NANOMQ=
 REGISTRY=
 
 # Resolve user ID for rootless docker port mapping
-# Resolve user ID for rootless docker port mapping
 export USERID:=$(shell id -u)
 
 BROKER_YAML=add-mqtt-broker-mosquitto.yml

--- a/compose-builder/Makefile
+++ b/compose-builder/Makefile
@@ -39,6 +39,9 @@ REGISTRY=
 # Resolve user ID for rootless docker port mapping
 export USERID:=$(shell id -u)
 
+# Set default rootful docker socket path
+export DOCKER_SOCKET_PATH=/var/run/docker.sock
+
 BROKER_YAML=add-mqtt-broker-mosquitto.yml
 TAF_BROKER_YAML=add-taf-mqtt-broker-mosquitto.yml
 
@@ -138,10 +141,8 @@ endif
 # When in delay-start mode, we have to make sure support serivces be delayed-start-compliant: i.e. the runtime-token configuration be added etc..
 ifeq (delayed-start, $(filter delayed-start,$(ARGS)))
     # Make sure docker is running rootless as security-spire-agent runs only in docker rootless mode
-	@if [ ! -e /run/user/${USERID}/docker.sock ]; then \
-    	echo "Error: Docker socket not found at /run/user/${USERID}/docker.sock"; \
-    	echo "Please ensure Docker is running rootless."; \
-    	exit 1; \
+	@if [ -e /run/user/${USERID}/docker.sock ]; then \
+		export DOCKER_SOCKET_PATH=/run/user/${USERID}/docker.sock; \
     fi
 	ext_file_sup_notif:= $(shell ZERO_TRUST="$(MAKE_ZERO_TRUST)" GEN_EXT_DIR="$(GEN_EXT_DIR)" ./gen_runtime_token_config_compose_ext.sh support-notifications)
 	ext_file_sup_sch:= $(shell ZERO_TRUST="$(MAKE_ZERO_TRUST)" GEN_EXT_DIR="$(GEN_EXT_DIR)" ./gen_runtime_token_config_compose_ext.sh support-scheduler)

--- a/compose-builder/README.md
+++ b/compose-builder/README.md
@@ -163,7 +163,7 @@ Usage: make <target> where target is:
 #### Portainer
 
 ```
-portainer       Runs Portainer independent of the EdgeX services
+portainer       Runs Portainer independent of the EdgeX services and requires a rootless docker environment.
 portainer-down	Stops Portainer independent of the EdgeX services
 ```
 #### Build

--- a/compose-builder/README.md
+++ b/compose-builder/README.md
@@ -163,7 +163,7 @@ Usage: make <target> where target is:
 #### Portainer
 
 ```
-portainer       Runs Portainer independent of the EdgeX services and requires a rootless docker environment.
+portainer       Runs Portainer independent of the EdgeX services.
 portainer-down	Stops Portainer independent of the EdgeX services
 ```
 #### Build

--- a/compose-builder/add-delayed-start-services.yml
+++ b/compose-builder/add-delayed-start-services.yml
@@ -75,7 +75,7 @@ services:
       - spire-ca:/srv/spiffe/ca
       - spire-agent:/srv/spiffe/agent
       - /tmp/edgex/secrets/spiffe:/tmp/edgex/secrets/spiffe:z
-      - /run/user/${USERID}/docker.sock:/var/run/docker.sock
+      - ${DOCKER_SOCKET_PATH}:/var/run/docker.sock
     depends_on:
       - security-spire-server
     pid: host

--- a/compose-builder/add-delayed-start-services.yml
+++ b/compose-builder/add-delayed-start-services.yml
@@ -75,7 +75,7 @@ services:
       - spire-ca:/srv/spiffe/ca
       - spire-agent:/srv/spiffe/agent
       - /tmp/edgex/secrets/spiffe:/tmp/edgex/secrets/spiffe:z
-      - /var/run/docker.sock:/var/run/docker.sock
+      - /run/user/${USERID}/docker.sock:/var/run/docker.sock
     depends_on:
       - security-spire-server
     pid: host

--- a/compose-builder/add-security.yml
+++ b/compose-builder/add-security.yml
@@ -120,6 +120,9 @@ services:
       VAULT_CONFIG_DIR: /vault/config
       VAULT_UI: "true"
       VAULT_LOCAL_CONFIG: >
+        backend "file" {
+            path = "/vault/file"
+        }
         disable_mlock = true
     volumes:
       - edgex-init:/edgex-init:ro

--- a/compose-builder/add-security.yml
+++ b/compose-builder/add-security.yml
@@ -104,11 +104,14 @@ services:
       - edgex-network
     ports:
       - "127.0.0.1:8200:8200"
-    cap_add:
-      - "IPC_LOCK"
+    deploy:
+      resources:
+        limits:
+          memory: "1024m"
+    memswap_limit: "1024m"
     tmpfs:
       - /vault/config
-    entrypoint: ["/edgex-init/vault_wait_install.sh"]
+    entrypoint: [ "/edgex-init/vault_wait_install.sh" ]
     env_file:
       - common-sec-stage-gate.env
     command: server
@@ -116,6 +119,18 @@ services:
       VAULT_ADDR: http://edgex-vault:8200
       VAULT_CONFIG_DIR: /vault/config
       VAULT_UI: "true"
+      VAULT_LOCAL_CONFIG: >
+        listener "tcp" { 
+            address = "edgex-vault:8200" 
+            tls_disable = "1" 
+            cluster_address = "edgex-vault:8201" 
+        }
+        backend "file" {
+            path = "/vault/file"
+        }
+        default_lease_ttl = "168h" 
+        max_lease_ttl = "720h"
+        disable_mlock = true
     volumes:
       - edgex-init:/edgex-init:ro
       - vault-file:/vault/file

--- a/compose-builder/add-security.yml
+++ b/compose-builder/add-security.yml
@@ -107,8 +107,8 @@ services:
     deploy:
       resources:
         limits:
-          memory: "1024m"
-    memswap_limit: "1024m"
+          memory: "${TOTAL_SYSTEM_MEMORY}"
+    memswap_limit: "${TOTAL_SYSTEM_MEMORY}"
     tmpfs:
       - /vault/config
     entrypoint: [ "/edgex-init/vault_wait_install.sh" ]
@@ -120,16 +120,6 @@ services:
       VAULT_CONFIG_DIR: /vault/config
       VAULT_UI: "true"
       VAULT_LOCAL_CONFIG: >
-        listener "tcp" { 
-            address = "edgex-vault:8200" 
-            tls_disable = "1" 
-            cluster_address = "edgex-vault:8201" 
-        }
-        backend "file" {
-            path = "/vault/file"
-        }
-        default_lease_ttl = "168h" 
-        max_lease_ttl = "720h"
         disable_mlock = true
     volumes:
       - edgex-init:/edgex-init:ro

--- a/compose-builder/add-security.yml
+++ b/compose-builder/add-security.yml
@@ -121,9 +121,16 @@ services:
       VAULT_UI: "true"
       SKIP_SETCAP: "true"
       VAULT_LOCAL_CONFIG: |
+        listener "tcp" { 
+          address = "edgex-vault:8200" 
+          tls_disable = "1" 
+          cluster_address = "edgex-vault:8201" 
+        } 
         backend "file" {
-            path = "/vault/file"
+          path = "/vault/file"
         }
+        default_lease_ttl = "168h" 
+        max_lease_ttl = "720h"
         disable_mlock = true
     volumes:
       - edgex-init:/edgex-init:ro

--- a/compose-builder/add-security.yml
+++ b/compose-builder/add-security.yml
@@ -119,7 +119,8 @@ services:
       VAULT_ADDR: http://edgex-vault:8200
       VAULT_CONFIG_DIR: /vault/config
       VAULT_UI: "true"
-      VAULT_LOCAL_CONFIG: >
+      SKIP_SETCAP: "true"
+      VAULT_LOCAL_CONFIG: |
         backend "file" {
             path = "/vault/file"
         }

--- a/docker-compose-arm64.yml
+++ b/docker-compose-arm64.yml
@@ -1308,6 +1308,7 @@ services:
       - /edgex-init/vault_wait_install.sh
     environment:
       PROXY_SETUP_HOST: edgex-security-proxy-setup
+      SKIP_SETCAP: "true"
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
       STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
@@ -1326,7 +1327,8 @@ services:
       VAULT_LOCAL_CONFIG: |
         backend "file" {
             path = "/vault/file"
-        } disable_mlock = true
+        }
+        disable_mlock = true
       VAULT_UI: "true"
     hostname: edgex-vault
     image: hashicorp/vault:1.14

--- a/docker-compose-arm64.yml
+++ b/docker-compose-arm64.yml
@@ -1293,49 +1293,67 @@ services:
         bind:
           create_host_path: true
   vault:
-    image: hashicorp/vault:${VAULT_VERSION}
-    user: "root:root" # Note that Vault is run under the 'vault' user, but entry point scripts need to first run as root
+    command:
+      - server
     container_name: edgex-vault
-    hostname: edgex-vault
-    networks:
-      - edgex-network
-    ports:
-      - "127.0.0.1:8200:8200"
+    depends_on:
+      security-bootstrapper:
+        condition: service_started
+        required: true
     deploy:
       resources:
         limits:
-          memory: "1024m"
-    memswap_limit: "1024m"
-    tmpfs:
-      - /vault/config
-    entrypoint: [ "/edgex-init/vault_wait_install.sh" ]
-    env_file:
-      - common-sec-stage-gate.env
-    command: server
+          memory: "1073741824"
+    entrypoint:
+      - /edgex-init/vault_wait_install.sh
     environment:
+      PROXY_SETUP_HOST: edgex-security-proxy-setup
+      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
+      STAGEGATE_DATABASE_HOST: edgex-redis
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
+      STAGEGATE_PROXYSETUP_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
+      STAGEGATE_REGISTRY_HOST: edgex-core-consul
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
+      STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
+      STAGEGATE_WAITFOR_TIMEOUT: 60s
       VAULT_ADDR: http://edgex-vault:8200
       VAULT_CONFIG_DIR: /vault/config
+      VAULT_LOCAL_CONFIG: "listener \"tcp\" { \n    address = \"edgex-vault:8200\" \n    tls_disable = \"1\" \n    cluster_address = \"edgex-vault:8201\" \n} backend \"file\" {\n    path = \"/vault/file\"\n} default_lease_ttl = \"168h\"  max_lease_ttl = \"720h\" disable_mlock = true\n"
       VAULT_UI: "true"
-      VAULT_LOCAL_CONFIG: >
-        listener "tcp" { 
-            address = "edgex-vault:8200" 
-            tls_disable = "1" 
-            cluster_address = "edgex-vault:8201" 
-        }
-        backend "file" {
-            path = "/vault/file"
-        }
-        default_lease_ttl = "168h" 
-        max_lease_ttl = "720h"
-        disable_mlock = true
-    volumes:
-      - edgex-init:/edgex-init:ro
-      - vault-file:/vault/file
-      - vault-logs:/vault/logs
-    depends_on:
-      - security-bootstrapper
+    hostname: edgex-vault
+    image: hashicorp/vault:1.14
+    memswap_limit: "1073741824"
+    networks:
+      edgex-network: null
+    ports:
+      - mode: ingress
+        host_ip: 127.0.0.1
+        target: 8200
+        published: "8200"
+        protocol: tcp
     restart: always
-
+    tmpfs:
+      - /vault/config
+    user: root:root
+    volumes:
+      - type: volume
+        source: edgex-init
+        target: /edgex-init
+        read_only: true
+        volume: {}
+      - type: volume
+        source: vault-file
+        target: /vault/file
+        volume: {}
+      - type: volume
+        source: vault-logs
+        target: /vault/logs
+        volume: {}
 networks:
   edgex-network:
     name: edgex_edgex-network

--- a/docker-compose-arm64.yml
+++ b/docker-compose-arm64.yml
@@ -1293,63 +1293,49 @@ services:
         bind:
           create_host_path: true
   vault:
-    cap_add:
-      - IPC_LOCK
-    command:
-      - server
+    image: hashicorp/vault:${VAULT_VERSION}
+    user: "root:root" # Note that Vault is run under the 'vault' user, but entry point scripts need to first run as root
     container_name: edgex-vault
-    depends_on:
-      security-bootstrapper:
-        condition: service_started
-        required: true
-    entrypoint:
-      - /edgex-init/vault_wait_install.sh
+    hostname: edgex-vault
+    networks:
+      - edgex-network
+    ports:
+      - "127.0.0.1:8200:8200"
+    deploy:
+      resources:
+        limits:
+          memory: "1024m"
+    memswap_limit: "1024m"
+    tmpfs:
+      - /vault/config
+    entrypoint: [ "/edgex-init/vault_wait_install.sh" ]
+    env_file:
+      - common-sec-stage-gate.env
+    command: server
     environment:
-      PROXY_SETUP_HOST: edgex-security-proxy-setup
-      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
-      STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: "6379"
-      STAGEGATE_DATABASE_READYPORT: "6379"
-      STAGEGATE_PROXYSETUP_READYPORT: "54325"
-      STAGEGATE_READY_TORUNPORT: "54329"
-      STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: "8500"
-      STAGEGATE_REGISTRY_READYPORT: "54324"
-      STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
-      STAGEGATE_WAITFOR_TIMEOUT: 60s
       VAULT_ADDR: http://edgex-vault:8200
       VAULT_CONFIG_DIR: /vault/config
       VAULT_UI: "true"
-    hostname: edgex-vault
-    image: hashicorp/vault:1.14
-    networks:
-      edgex-network: null
-    ports:
-      - mode: ingress
-        host_ip: 127.0.0.1
-        target: 8200
-        published: "8200"
-        protocol: tcp
-    restart: always
-    tmpfs:
-      - /vault/config
-    user: root:root
+      VAULT_LOCAL_CONFIG: >
+        listener "tcp" { 
+            address = "edgex-vault:8200" 
+            tls_disable = "1" 
+            cluster_address = "edgex-vault:8201" 
+        }
+        backend "file" {
+            path = "/vault/file"
+        }
+        default_lease_ttl = "168h" 
+        max_lease_ttl = "720h"
+        disable_mlock = true
     volumes:
-      - type: volume
-        source: edgex-init
-        target: /edgex-init
-        read_only: true
-        volume: {}
-      - type: volume
-        source: vault-file
-        target: /vault/file
-        volume: {}
-      - type: volume
-        source: vault-logs
-        target: /vault/logs
-        volume: {}
+      - edgex-init:/edgex-init:ro
+      - vault-file:/vault/file
+      - vault-logs:/vault/logs
+    depends_on:
+      - security-bootstrapper
+    restart: always
+
 networks:
   edgex-network:
     name: edgex_edgex-network

--- a/docker-compose-arm64.yml
+++ b/docker-compose-arm64.yml
@@ -1303,7 +1303,7 @@ services:
     deploy:
       resources:
         limits:
-          memory: "34032712679424"
+          memory: "34032716873728"
     entrypoint:
       - /edgex-init/vault_wait_install.sh
     environment:
@@ -1324,11 +1324,13 @@ services:
       VAULT_ADDR: http://edgex-vault:8200
       VAULT_CONFIG_DIR: /vault/config
       VAULT_LOCAL_CONFIG: |
-        disable_mlock = true
+        backend "file" {
+            path = "/vault/file"
+        } disable_mlock = true
       VAULT_UI: "true"
     hostname: edgex-vault
     image: hashicorp/vault:1.14
-    memswap_limit: "34032712679424"
+    memswap_limit: "34032716873728"
     networks:
       edgex-network: null
     ports:

--- a/docker-compose-arm64.yml
+++ b/docker-compose-arm64.yml
@@ -1324,11 +1324,7 @@ services:
       STAGEGATE_WAITFOR_TIMEOUT: 60s
       VAULT_ADDR: http://edgex-vault:8200
       VAULT_CONFIG_DIR: /vault/config
-      VAULT_LOCAL_CONFIG: |
-        backend "file" {
-            path = "/vault/file"
-        }
-        disable_mlock = true
+      VAULT_LOCAL_CONFIG: "listener \"tcp\" { \n  address = \"edgex-vault:8200\" \n  tls_disable = \"1\" \n  cluster_address = \"edgex-vault:8201\" \n} \nbackend \"file\" {\n  path = \"/vault/file\"\n}\ndefault_lease_ttl = \"168h\" \nmax_lease_ttl = \"720h\"\ndisable_mlock = true\n"
       VAULT_UI: "true"
     hostname: edgex-vault
     image: hashicorp/vault:1.14

--- a/docker-compose-arm64.yml
+++ b/docker-compose-arm64.yml
@@ -1303,7 +1303,7 @@ services:
     deploy:
       resources:
         limits:
-          memory: "1073741824"
+          memory: "34032712679424"
     entrypoint:
       - /edgex-init/vault_wait_install.sh
     environment:
@@ -1323,11 +1323,12 @@ services:
       STAGEGATE_WAITFOR_TIMEOUT: 60s
       VAULT_ADDR: http://edgex-vault:8200
       VAULT_CONFIG_DIR: /vault/config
-      VAULT_LOCAL_CONFIG: "listener \"tcp\" { \n    address = \"edgex-vault:8200\" \n    tls_disable = \"1\" \n    cluster_address = \"edgex-vault:8201\" \n} backend \"file\" {\n    path = \"/vault/file\"\n} default_lease_ttl = \"168h\"  max_lease_ttl = \"720h\" disable_mlock = true\n"
+      VAULT_LOCAL_CONFIG: |
+        disable_mlock = true
       VAULT_UI: "true"
     hostname: edgex-vault
     image: hashicorp/vault:1.14
-    memswap_limit: "1073741824"
+    memswap_limit: "34032712679424"
     networks:
       edgex-network: null
     ports:

--- a/docker-compose-portainer.yml
+++ b/docker-compose-portainer.yml
@@ -27,6 +27,6 @@ services:
     restart: always
     command: -H unix:///var/run/docker.sock
     volumes:
-      - /var/run/docker.sock:/var/run/docker.sock:z
+      - /run/user/${USERID}/docker.sock:/var/run/docker.sock
       - portainer_data:/data
 

--- a/docker-compose-portainer.yml
+++ b/docker-compose-portainer.yml
@@ -27,6 +27,6 @@ services:
     restart: always
     command: -H unix:///var/run/docker.sock
     volumes:
-      - /run/user/${USERID}/docker.sock:/var/run/docker.sock
+      - ${DOCKER_SOCKET_PATH}:/var/run/docker.sock
       - portainer_data:/data
 

--- a/docker-compose-with-app-sample-arm64.yml
+++ b/docker-compose-with-app-sample-arm64.yml
@@ -1370,63 +1370,48 @@ services:
         bind:
           create_host_path: true
   vault:
-    cap_add:
-      - IPC_LOCK
-    command:
-      - server
+    image: hashicorp/vault:${VAULT_VERSION}
+    user: "root:root" # Note that Vault is run under the 'vault' user, but entry point scripts need to first run as root
     container_name: edgex-vault
-    depends_on:
-      security-bootstrapper:
-        condition: service_started
-        required: true
-    entrypoint:
-      - /edgex-init/vault_wait_install.sh
+    hostname: edgex-vault
+    networks:
+      - edgex-network
+    ports:
+      - "127.0.0.1:8200:8200"
+    deploy:
+      resources:
+        limits:
+          memory: "1024m"
+    memswap_limit: "1024m"
+    tmpfs:
+      - /vault/config
+    entrypoint: [ "/edgex-init/vault_wait_install.sh" ]
+    env_file:
+      - common-sec-stage-gate.env
+    command: server
     environment:
-      PROXY_SETUP_HOST: edgex-security-proxy-setup
-      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
-      STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: "6379"
-      STAGEGATE_DATABASE_READYPORT: "6379"
-      STAGEGATE_PROXYSETUP_READYPORT: "54325"
-      STAGEGATE_READY_TORUNPORT: "54329"
-      STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: "8500"
-      STAGEGATE_REGISTRY_READYPORT: "54324"
-      STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
-      STAGEGATE_WAITFOR_TIMEOUT: 60s
       VAULT_ADDR: http://edgex-vault:8200
       VAULT_CONFIG_DIR: /vault/config
       VAULT_UI: "true"
-    hostname: edgex-vault
-    image: hashicorp/vault:1.14
-    networks:
-      edgex-network: null
-    ports:
-      - mode: ingress
-        host_ip: 127.0.0.1
-        target: 8200
-        published: "8200"
-        protocol: tcp
-    restart: always
-    tmpfs:
-      - /vault/config
-    user: root:root
+      VAULT_LOCAL_CONFIG: >
+        listener "tcp" { 
+            address = "edgex-vault:8200" 
+            tls_disable = "1" 
+            cluster_address = "edgex-vault:8201" 
+        }
+        backend "file" {
+            path = "/vault/file"
+        }
+        default_lease_ttl = "168h" 
+        max_lease_ttl = "720h"
+        disable_mlock = true
     volumes:
-      - type: volume
-        source: edgex-init
-        target: /edgex-init
-        read_only: true
-        volume: {}
-      - type: volume
-        source: vault-file
-        target: /vault/file
-        volume: {}
-      - type: volume
-        source: vault-logs
-        target: /vault/logs
-        volume: {}
+      - edgex-init:/edgex-init:ro
+      - vault-file:/vault/file
+      - vault-logs:/vault/logs
+    depends_on:
+      - security-bootstrapper
+    restart: always
 networks:
   edgex-network:
     name: edgex_edgex-network

--- a/docker-compose-with-app-sample-arm64.yml
+++ b/docker-compose-with-app-sample-arm64.yml
@@ -1380,7 +1380,7 @@ services:
     deploy:
       resources:
         limits:
-          memory: "34032712679424"
+          memory: "34032716873728"
     entrypoint:
       - /edgex-init/vault_wait_install.sh
     environment:
@@ -1401,11 +1401,13 @@ services:
       VAULT_ADDR: http://edgex-vault:8200
       VAULT_CONFIG_DIR: /vault/config
       VAULT_LOCAL_CONFIG: |
-        disable_mlock = true
+        backend "file" {
+            path = "/vault/file"
+        } disable_mlock = true
       VAULT_UI: "true"
     hostname: edgex-vault
     image: hashicorp/vault:1.14
-    memswap_limit: "34032712679424"
+    memswap_limit: "34032716873728"
     networks:
       edgex-network: null
     ports:

--- a/docker-compose-with-app-sample-arm64.yml
+++ b/docker-compose-with-app-sample-arm64.yml
@@ -1401,11 +1401,7 @@ services:
       STAGEGATE_WAITFOR_TIMEOUT: 60s
       VAULT_ADDR: http://edgex-vault:8200
       VAULT_CONFIG_DIR: /vault/config
-      VAULT_LOCAL_CONFIG: |
-        backend "file" {
-            path = "/vault/file"
-        }
-        disable_mlock = true
+      VAULT_LOCAL_CONFIG: "listener \"tcp\" { \n  address = \"edgex-vault:8200\" \n  tls_disable = \"1\" \n  cluster_address = \"edgex-vault:8201\" \n} \nbackend \"file\" {\n  path = \"/vault/file\"\n}\ndefault_lease_ttl = \"168h\" \nmax_lease_ttl = \"720h\"\ndisable_mlock = true\n"
       VAULT_UI: "true"
     hostname: edgex-vault
     image: hashicorp/vault:1.14

--- a/docker-compose-with-app-sample-arm64.yml
+++ b/docker-compose-with-app-sample-arm64.yml
@@ -1370,48 +1370,67 @@ services:
         bind:
           create_host_path: true
   vault:
-    image: hashicorp/vault:${VAULT_VERSION}
-    user: "root:root" # Note that Vault is run under the 'vault' user, but entry point scripts need to first run as root
+    command:
+      - server
     container_name: edgex-vault
-    hostname: edgex-vault
-    networks:
-      - edgex-network
-    ports:
-      - "127.0.0.1:8200:8200"
+    depends_on:
+      security-bootstrapper:
+        condition: service_started
+        required: true
     deploy:
       resources:
         limits:
-          memory: "1024m"
-    memswap_limit: "1024m"
-    tmpfs:
-      - /vault/config
-    entrypoint: [ "/edgex-init/vault_wait_install.sh" ]
-    env_file:
-      - common-sec-stage-gate.env
-    command: server
+          memory: "1073741824"
+    entrypoint:
+      - /edgex-init/vault_wait_install.sh
     environment:
+      PROXY_SETUP_HOST: edgex-security-proxy-setup
+      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
+      STAGEGATE_DATABASE_HOST: edgex-redis
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
+      STAGEGATE_PROXYSETUP_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
+      STAGEGATE_REGISTRY_HOST: edgex-core-consul
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
+      STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
+      STAGEGATE_WAITFOR_TIMEOUT: 60s
       VAULT_ADDR: http://edgex-vault:8200
       VAULT_CONFIG_DIR: /vault/config
+      VAULT_LOCAL_CONFIG: "listener \"tcp\" { \n    address = \"edgex-vault:8200\" \n    tls_disable = \"1\" \n    cluster_address = \"edgex-vault:8201\" \n} backend \"file\" {\n    path = \"/vault/file\"\n} default_lease_ttl = \"168h\"  max_lease_ttl = \"720h\" disable_mlock = true\n"
       VAULT_UI: "true"
-      VAULT_LOCAL_CONFIG: >
-        listener "tcp" { 
-            address = "edgex-vault:8200" 
-            tls_disable = "1" 
-            cluster_address = "edgex-vault:8201" 
-        }
-        backend "file" {
-            path = "/vault/file"
-        }
-        default_lease_ttl = "168h" 
-        max_lease_ttl = "720h"
-        disable_mlock = true
-    volumes:
-      - edgex-init:/edgex-init:ro
-      - vault-file:/vault/file
-      - vault-logs:/vault/logs
-    depends_on:
-      - security-bootstrapper
+    hostname: edgex-vault
+    image: hashicorp/vault:1.14
+    memswap_limit: "1073741824"
+    networks:
+      edgex-network: null
+    ports:
+      - mode: ingress
+        host_ip: 127.0.0.1
+        target: 8200
+        published: "8200"
+        protocol: tcp
     restart: always
+    tmpfs:
+      - /vault/config
+    user: root:root
+    volumes:
+      - type: volume
+        source: edgex-init
+        target: /edgex-init
+        read_only: true
+        volume: {}
+      - type: volume
+        source: vault-file
+        target: /vault/file
+        volume: {}
+      - type: volume
+        source: vault-logs
+        target: /vault/logs
+        volume: {}
 networks:
   edgex-network:
     name: edgex_edgex-network

--- a/docker-compose-with-app-sample-arm64.yml
+++ b/docker-compose-with-app-sample-arm64.yml
@@ -1380,7 +1380,7 @@ services:
     deploy:
       resources:
         limits:
-          memory: "1073741824"
+          memory: "34032712679424"
     entrypoint:
       - /edgex-init/vault_wait_install.sh
     environment:
@@ -1400,11 +1400,12 @@ services:
       STAGEGATE_WAITFOR_TIMEOUT: 60s
       VAULT_ADDR: http://edgex-vault:8200
       VAULT_CONFIG_DIR: /vault/config
-      VAULT_LOCAL_CONFIG: "listener \"tcp\" { \n    address = \"edgex-vault:8200\" \n    tls_disable = \"1\" \n    cluster_address = \"edgex-vault:8201\" \n} backend \"file\" {\n    path = \"/vault/file\"\n} default_lease_ttl = \"168h\"  max_lease_ttl = \"720h\" disable_mlock = true\n"
+      VAULT_LOCAL_CONFIG: |
+        disable_mlock = true
       VAULT_UI: "true"
     hostname: edgex-vault
     image: hashicorp/vault:1.14
-    memswap_limit: "1073741824"
+    memswap_limit: "34032712679424"
     networks:
       edgex-network: null
     ports:

--- a/docker-compose-with-app-sample-arm64.yml
+++ b/docker-compose-with-app-sample-arm64.yml
@@ -1385,6 +1385,7 @@ services:
       - /edgex-init/vault_wait_install.sh
     environment:
       PROXY_SETUP_HOST: edgex-security-proxy-setup
+      SKIP_SETCAP: "true"
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
       STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
@@ -1403,7 +1404,8 @@ services:
       VAULT_LOCAL_CONFIG: |
         backend "file" {
             path = "/vault/file"
-        } disable_mlock = true
+        }
+        disable_mlock = true
       VAULT_UI: "true"
     hostname: edgex-vault
     image: hashicorp/vault:1.14

--- a/docker-compose-with-app-sample.yml
+++ b/docker-compose-with-app-sample.yml
@@ -1370,63 +1370,48 @@ services:
         bind:
           create_host_path: true
   vault:
-    cap_add:
-      - IPC_LOCK
-    command:
-      - server
+    image: hashicorp/vault:${VAULT_VERSION}
+    user: "root:root" # Note that Vault is run under the 'vault' user, but entry point scripts need to first run as root
     container_name: edgex-vault
-    depends_on:
-      security-bootstrapper:
-        condition: service_started
-        required: true
-    entrypoint:
-      - /edgex-init/vault_wait_install.sh
+    hostname: edgex-vault
+    networks:
+      - edgex-network
+    ports:
+      - "127.0.0.1:8200:8200"
+    deploy:
+      resources:
+        limits:
+          memory: "1024m"
+    memswap_limit: "1024m"
+    tmpfs:
+      - /vault/config
+    entrypoint: [ "/edgex-init/vault_wait_install.sh" ]
+    env_file:
+      - common-sec-stage-gate.env
+    command: server
     environment:
-      PROXY_SETUP_HOST: edgex-security-proxy-setup
-      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
-      STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: "6379"
-      STAGEGATE_DATABASE_READYPORT: "6379"
-      STAGEGATE_PROXYSETUP_READYPORT: "54325"
-      STAGEGATE_READY_TORUNPORT: "54329"
-      STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: "8500"
-      STAGEGATE_REGISTRY_READYPORT: "54324"
-      STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
-      STAGEGATE_WAITFOR_TIMEOUT: 60s
       VAULT_ADDR: http://edgex-vault:8200
       VAULT_CONFIG_DIR: /vault/config
       VAULT_UI: "true"
-    hostname: edgex-vault
-    image: hashicorp/vault:1.14
-    networks:
-      edgex-network: null
-    ports:
-      - mode: ingress
-        host_ip: 127.0.0.1
-        target: 8200
-        published: "8200"
-        protocol: tcp
-    restart: always
-    tmpfs:
-      - /vault/config
-    user: root:root
+      VAULT_LOCAL_CONFIG: >
+        listener "tcp" { 
+            address = "edgex-vault:8200" 
+            tls_disable = "1" 
+            cluster_address = "edgex-vault:8201" 
+        }
+        backend "file" {
+            path = "/vault/file"
+        }
+        default_lease_ttl = "168h" 
+        max_lease_ttl = "720h"
+        disable_mlock = true
     volumes:
-      - type: volume
-        source: edgex-init
-        target: /edgex-init
-        read_only: true
-        volume: {}
-      - type: volume
-        source: vault-file
-        target: /vault/file
-        volume: {}
-      - type: volume
-        source: vault-logs
-        target: /vault/logs
-        volume: {}
+      - edgex-init:/edgex-init:ro
+      - vault-file:/vault/file
+      - vault-logs:/vault/logs
+    depends_on:
+      - security-bootstrapper
+    restart: always
 networks:
   edgex-network:
     name: edgex_edgex-network

--- a/docker-compose-with-app-sample.yml
+++ b/docker-compose-with-app-sample.yml
@@ -1380,7 +1380,7 @@ services:
     deploy:
       resources:
         limits:
-          memory: "34032712679424"
+          memory: "34032716873728"
     entrypoint:
       - /edgex-init/vault_wait_install.sh
     environment:
@@ -1401,11 +1401,13 @@ services:
       VAULT_ADDR: http://edgex-vault:8200
       VAULT_CONFIG_DIR: /vault/config
       VAULT_LOCAL_CONFIG: |
-        disable_mlock = true
+        backend "file" {
+            path = "/vault/file"
+        } disable_mlock = true
       VAULT_UI: "true"
     hostname: edgex-vault
     image: hashicorp/vault:1.14
-    memswap_limit: "34032712679424"
+    memswap_limit: "34032716873728"
     networks:
       edgex-network: null
     ports:

--- a/docker-compose-with-app-sample.yml
+++ b/docker-compose-with-app-sample.yml
@@ -1401,11 +1401,7 @@ services:
       STAGEGATE_WAITFOR_TIMEOUT: 60s
       VAULT_ADDR: http://edgex-vault:8200
       VAULT_CONFIG_DIR: /vault/config
-      VAULT_LOCAL_CONFIG: |
-        backend "file" {
-            path = "/vault/file"
-        }
-        disable_mlock = true
+      VAULT_LOCAL_CONFIG: "listener \"tcp\" { \n  address = \"edgex-vault:8200\" \n  tls_disable = \"1\" \n  cluster_address = \"edgex-vault:8201\" \n} \nbackend \"file\" {\n  path = \"/vault/file\"\n}\ndefault_lease_ttl = \"168h\" \nmax_lease_ttl = \"720h\"\ndisable_mlock = true\n"
       VAULT_UI: "true"
     hostname: edgex-vault
     image: hashicorp/vault:1.14

--- a/docker-compose-with-app-sample.yml
+++ b/docker-compose-with-app-sample.yml
@@ -1370,48 +1370,67 @@ services:
         bind:
           create_host_path: true
   vault:
-    image: hashicorp/vault:${VAULT_VERSION}
-    user: "root:root" # Note that Vault is run under the 'vault' user, but entry point scripts need to first run as root
+    command:
+      - server
     container_name: edgex-vault
-    hostname: edgex-vault
-    networks:
-      - edgex-network
-    ports:
-      - "127.0.0.1:8200:8200"
+    depends_on:
+      security-bootstrapper:
+        condition: service_started
+        required: true
     deploy:
       resources:
         limits:
-          memory: "1024m"
-    memswap_limit: "1024m"
-    tmpfs:
-      - /vault/config
-    entrypoint: [ "/edgex-init/vault_wait_install.sh" ]
-    env_file:
-      - common-sec-stage-gate.env
-    command: server
+          memory: "1073741824"
+    entrypoint:
+      - /edgex-init/vault_wait_install.sh
     environment:
+      PROXY_SETUP_HOST: edgex-security-proxy-setup
+      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
+      STAGEGATE_DATABASE_HOST: edgex-redis
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
+      STAGEGATE_PROXYSETUP_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
+      STAGEGATE_REGISTRY_HOST: edgex-core-consul
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
+      STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
+      STAGEGATE_WAITFOR_TIMEOUT: 60s
       VAULT_ADDR: http://edgex-vault:8200
       VAULT_CONFIG_DIR: /vault/config
+      VAULT_LOCAL_CONFIG: "listener \"tcp\" { \n    address = \"edgex-vault:8200\" \n    tls_disable = \"1\" \n    cluster_address = \"edgex-vault:8201\" \n} backend \"file\" {\n    path = \"/vault/file\"\n} default_lease_ttl = \"168h\"  max_lease_ttl = \"720h\" disable_mlock = true\n"
       VAULT_UI: "true"
-      VAULT_LOCAL_CONFIG: >
-        listener "tcp" { 
-            address = "edgex-vault:8200" 
-            tls_disable = "1" 
-            cluster_address = "edgex-vault:8201" 
-        }
-        backend "file" {
-            path = "/vault/file"
-        }
-        default_lease_ttl = "168h" 
-        max_lease_ttl = "720h"
-        disable_mlock = true
-    volumes:
-      - edgex-init:/edgex-init:ro
-      - vault-file:/vault/file
-      - vault-logs:/vault/logs
-    depends_on:
-      - security-bootstrapper
+    hostname: edgex-vault
+    image: hashicorp/vault:1.14
+    memswap_limit: "1073741824"
+    networks:
+      edgex-network: null
+    ports:
+      - mode: ingress
+        host_ip: 127.0.0.1
+        target: 8200
+        published: "8200"
+        protocol: tcp
     restart: always
+    tmpfs:
+      - /vault/config
+    user: root:root
+    volumes:
+      - type: volume
+        source: edgex-init
+        target: /edgex-init
+        read_only: true
+        volume: {}
+      - type: volume
+        source: vault-file
+        target: /vault/file
+        volume: {}
+      - type: volume
+        source: vault-logs
+        target: /vault/logs
+        volume: {}
 networks:
   edgex-network:
     name: edgex_edgex-network

--- a/docker-compose-with-app-sample.yml
+++ b/docker-compose-with-app-sample.yml
@@ -1380,7 +1380,7 @@ services:
     deploy:
       resources:
         limits:
-          memory: "1073741824"
+          memory: "34032712679424"
     entrypoint:
       - /edgex-init/vault_wait_install.sh
     environment:
@@ -1400,11 +1400,12 @@ services:
       STAGEGATE_WAITFOR_TIMEOUT: 60s
       VAULT_ADDR: http://edgex-vault:8200
       VAULT_CONFIG_DIR: /vault/config
-      VAULT_LOCAL_CONFIG: "listener \"tcp\" { \n    address = \"edgex-vault:8200\" \n    tls_disable = \"1\" \n    cluster_address = \"edgex-vault:8201\" \n} backend \"file\" {\n    path = \"/vault/file\"\n} default_lease_ttl = \"168h\"  max_lease_ttl = \"720h\" disable_mlock = true\n"
+      VAULT_LOCAL_CONFIG: |
+        disable_mlock = true
       VAULT_UI: "true"
     hostname: edgex-vault
     image: hashicorp/vault:1.14
-    memswap_limit: "1073741824"
+    memswap_limit: "34032712679424"
     networks:
       edgex-network: null
     ports:

--- a/docker-compose-with-app-sample.yml
+++ b/docker-compose-with-app-sample.yml
@@ -1385,6 +1385,7 @@ services:
       - /edgex-init/vault_wait_install.sh
     environment:
       PROXY_SETUP_HOST: edgex-security-proxy-setup
+      SKIP_SETCAP: "true"
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
       STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
@@ -1403,7 +1404,8 @@ services:
       VAULT_LOCAL_CONFIG: |
         backend "file" {
             path = "/vault/file"
-        } disable_mlock = true
+        }
+        disable_mlock = true
       VAULT_UI: "true"
     hostname: edgex-vault
     image: hashicorp/vault:1.14

--- a/docker-compose-zero-trust-arm64.yml
+++ b/docker-compose-zero-trust-arm64.yml
@@ -1139,6 +1139,7 @@ services:
       - /edgex-init/vault_wait_install.sh
     environment:
       PROXY_SETUP_HOST: edgex-security-proxy-setup
+      SKIP_SETCAP: "true"
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
       STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
@@ -1157,7 +1158,8 @@ services:
       VAULT_LOCAL_CONFIG: |
         backend "file" {
             path = "/vault/file"
-        } disable_mlock = true
+        }
+        disable_mlock = true
       VAULT_UI: "true"
     hostname: edgex-vault
     image: hashicorp/vault:1.14

--- a/docker-compose-zero-trust-arm64.yml
+++ b/docker-compose-zero-trust-arm64.yml
@@ -1134,7 +1134,7 @@ services:
     deploy:
       resources:
         limits:
-          memory: "34032712679424"
+          memory: "34032716873728"
     entrypoint:
       - /edgex-init/vault_wait_install.sh
     environment:
@@ -1155,11 +1155,13 @@ services:
       VAULT_ADDR: http://edgex-vault:8200
       VAULT_CONFIG_DIR: /vault/config
       VAULT_LOCAL_CONFIG: |
-        disable_mlock = true
+        backend "file" {
+            path = "/vault/file"
+        } disable_mlock = true
       VAULT_UI: "true"
     hostname: edgex-vault
     image: hashicorp/vault:1.14
-    memswap_limit: "34032712679424"
+    memswap_limit: "34032716873728"
     networks:
       edgex-network: null
     ports:

--- a/docker-compose-zero-trust-arm64.yml
+++ b/docker-compose-zero-trust-arm64.yml
@@ -1155,11 +1155,7 @@ services:
       STAGEGATE_WAITFOR_TIMEOUT: 60s
       VAULT_ADDR: http://edgex-vault:8200
       VAULT_CONFIG_DIR: /vault/config
-      VAULT_LOCAL_CONFIG: |
-        backend "file" {
-            path = "/vault/file"
-        }
-        disable_mlock = true
+      VAULT_LOCAL_CONFIG: "listener \"tcp\" { \n  address = \"edgex-vault:8200\" \n  tls_disable = \"1\" \n  cluster_address = \"edgex-vault:8201\" \n} \nbackend \"file\" {\n  path = \"/vault/file\"\n}\ndefault_lease_ttl = \"168h\" \nmax_lease_ttl = \"720h\"\ndisable_mlock = true\n"
       VAULT_UI: "true"
     hostname: edgex-vault
     image: hashicorp/vault:1.14

--- a/docker-compose-zero-trust-arm64.yml
+++ b/docker-compose-zero-trust-arm64.yml
@@ -1124,63 +1124,48 @@ services:
           selinux: z
           create_host_path: true
   vault:
-    cap_add:
-      - IPC_LOCK
-    command:
-      - server
+    image: hashicorp/vault:${VAULT_VERSION}
+    user: "root:root" # Note that Vault is run under the 'vault' user, but entry point scripts need to first run as root
     container_name: edgex-vault
-    depends_on:
-      security-bootstrapper:
-        condition: service_started
-        required: true
-    entrypoint:
-      - /edgex-init/vault_wait_install.sh
+    hostname: edgex-vault
+    networks:
+      - edgex-network
+    ports:
+      - "127.0.0.1:8200:8200"
+    deploy:
+      resources:
+        limits:
+          memory: "1024m"
+    memswap_limit: "1024m"
+    tmpfs:
+      - /vault/config
+    entrypoint: [ "/edgex-init/vault_wait_install.sh" ]
+    env_file:
+      - common-sec-stage-gate.env
+    command: server
     environment:
-      PROXY_SETUP_HOST: edgex-security-proxy-setup
-      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
-      STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: "6379"
-      STAGEGATE_DATABASE_READYPORT: "6379"
-      STAGEGATE_PROXYSETUP_READYPORT: "54325"
-      STAGEGATE_READY_TORUNPORT: "54329"
-      STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: "8500"
-      STAGEGATE_REGISTRY_READYPORT: "54324"
-      STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
-      STAGEGATE_WAITFOR_TIMEOUT: 60s
       VAULT_ADDR: http://edgex-vault:8200
       VAULT_CONFIG_DIR: /vault/config
       VAULT_UI: "true"
-    hostname: edgex-vault
-    image: hashicorp/vault:1.14
-    networks:
-      edgex-network: null
-    ports:
-      - mode: ingress
-        host_ip: 127.0.0.1
-        target: 8200
-        published: "8200"
-        protocol: tcp
-    restart: always
-    tmpfs:
-      - /vault/config
-    user: root:root
+      VAULT_LOCAL_CONFIG: >
+        listener "tcp" { 
+            address = "edgex-vault:8200" 
+            tls_disable = "1" 
+            cluster_address = "edgex-vault:8201" 
+        }
+        backend "file" {
+            path = "/vault/file"
+        }
+        default_lease_ttl = "168h" 
+        max_lease_ttl = "720h"
+        disable_mlock = true
     volumes:
-      - type: volume
-        source: edgex-init
-        target: /edgex-init
-        read_only: true
-        volume: {}
-      - type: volume
-        source: vault-file
-        target: /vault/file
-        volume: {}
-      - type: volume
-        source: vault-logs
-        target: /vault/logs
-        volume: {}
+      - edgex-init:/edgex-init:ro
+      - vault-file:/vault/file
+      - vault-logs:/vault/logs
+    depends_on:
+      - security-bootstrapper
+    restart: always
 networks:
   edgex-network:
     name: edgex_edgex-network

--- a/docker-compose-zero-trust-arm64.yml
+++ b/docker-compose-zero-trust-arm64.yml
@@ -1124,48 +1124,67 @@ services:
           selinux: z
           create_host_path: true
   vault:
-    image: hashicorp/vault:${VAULT_VERSION}
-    user: "root:root" # Note that Vault is run under the 'vault' user, but entry point scripts need to first run as root
+    command:
+      - server
     container_name: edgex-vault
-    hostname: edgex-vault
-    networks:
-      - edgex-network
-    ports:
-      - "127.0.0.1:8200:8200"
+    depends_on:
+      security-bootstrapper:
+        condition: service_started
+        required: true
     deploy:
       resources:
         limits:
-          memory: "1024m"
-    memswap_limit: "1024m"
-    tmpfs:
-      - /vault/config
-    entrypoint: [ "/edgex-init/vault_wait_install.sh" ]
-    env_file:
-      - common-sec-stage-gate.env
-    command: server
+          memory: "1073741824"
+    entrypoint:
+      - /edgex-init/vault_wait_install.sh
     environment:
+      PROXY_SETUP_HOST: edgex-security-proxy-setup
+      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
+      STAGEGATE_DATABASE_HOST: edgex-redis
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
+      STAGEGATE_PROXYSETUP_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
+      STAGEGATE_REGISTRY_HOST: edgex-core-consul
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
+      STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
+      STAGEGATE_WAITFOR_TIMEOUT: 60s
       VAULT_ADDR: http://edgex-vault:8200
       VAULT_CONFIG_DIR: /vault/config
+      VAULT_LOCAL_CONFIG: "listener \"tcp\" { \n    address = \"edgex-vault:8200\" \n    tls_disable = \"1\" \n    cluster_address = \"edgex-vault:8201\" \n} backend \"file\" {\n    path = \"/vault/file\"\n} default_lease_ttl = \"168h\"  max_lease_ttl = \"720h\" disable_mlock = true\n"
       VAULT_UI: "true"
-      VAULT_LOCAL_CONFIG: >
-        listener "tcp" { 
-            address = "edgex-vault:8200" 
-            tls_disable = "1" 
-            cluster_address = "edgex-vault:8201" 
-        }
-        backend "file" {
-            path = "/vault/file"
-        }
-        default_lease_ttl = "168h" 
-        max_lease_ttl = "720h"
-        disable_mlock = true
-    volumes:
-      - edgex-init:/edgex-init:ro
-      - vault-file:/vault/file
-      - vault-logs:/vault/logs
-    depends_on:
-      - security-bootstrapper
+    hostname: edgex-vault
+    image: hashicorp/vault:1.14
+    memswap_limit: "1073741824"
+    networks:
+      edgex-network: null
+    ports:
+      - mode: ingress
+        host_ip: 127.0.0.1
+        target: 8200
+        published: "8200"
+        protocol: tcp
     restart: always
+    tmpfs:
+      - /vault/config
+    user: root:root
+    volumes:
+      - type: volume
+        source: edgex-init
+        target: /edgex-init
+        read_only: true
+        volume: {}
+      - type: volume
+        source: vault-file
+        target: /vault/file
+        volume: {}
+      - type: volume
+        source: vault-logs
+        target: /vault/logs
+        volume: {}
 networks:
   edgex-network:
     name: edgex_edgex-network

--- a/docker-compose-zero-trust-arm64.yml
+++ b/docker-compose-zero-trust-arm64.yml
@@ -1134,7 +1134,7 @@ services:
     deploy:
       resources:
         limits:
-          memory: "1073741824"
+          memory: "34032712679424"
     entrypoint:
       - /edgex-init/vault_wait_install.sh
     environment:
@@ -1154,11 +1154,12 @@ services:
       STAGEGATE_WAITFOR_TIMEOUT: 60s
       VAULT_ADDR: http://edgex-vault:8200
       VAULT_CONFIG_DIR: /vault/config
-      VAULT_LOCAL_CONFIG: "listener \"tcp\" { \n    address = \"edgex-vault:8200\" \n    tls_disable = \"1\" \n    cluster_address = \"edgex-vault:8201\" \n} backend \"file\" {\n    path = \"/vault/file\"\n} default_lease_ttl = \"168h\"  max_lease_ttl = \"720h\" disable_mlock = true\n"
+      VAULT_LOCAL_CONFIG: |
+        disable_mlock = true
       VAULT_UI: "true"
     hostname: edgex-vault
     image: hashicorp/vault:1.14
-    memswap_limit: "1073741824"
+    memswap_limit: "34032712679424"
     networks:
       edgex-network: null
     ports:

--- a/docker-compose-zero-trust.yml
+++ b/docker-compose-zero-trust.yml
@@ -1139,6 +1139,7 @@ services:
       - /edgex-init/vault_wait_install.sh
     environment:
       PROXY_SETUP_HOST: edgex-security-proxy-setup
+      SKIP_SETCAP: "true"
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
       STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
@@ -1157,7 +1158,8 @@ services:
       VAULT_LOCAL_CONFIG: |
         backend "file" {
             path = "/vault/file"
-        } disable_mlock = true
+        }
+        disable_mlock = true
       VAULT_UI: "true"
     hostname: edgex-vault
     image: hashicorp/vault:1.14

--- a/docker-compose-zero-trust.yml
+++ b/docker-compose-zero-trust.yml
@@ -1134,7 +1134,7 @@ services:
     deploy:
       resources:
         limits:
-          memory: "34032712679424"
+          memory: "34032716873728"
     entrypoint:
       - /edgex-init/vault_wait_install.sh
     environment:
@@ -1155,11 +1155,13 @@ services:
       VAULT_ADDR: http://edgex-vault:8200
       VAULT_CONFIG_DIR: /vault/config
       VAULT_LOCAL_CONFIG: |
-        disable_mlock = true
+        backend "file" {
+            path = "/vault/file"
+        } disable_mlock = true
       VAULT_UI: "true"
     hostname: edgex-vault
     image: hashicorp/vault:1.14
-    memswap_limit: "34032712679424"
+    memswap_limit: "34032716873728"
     networks:
       edgex-network: null
     ports:

--- a/docker-compose-zero-trust.yml
+++ b/docker-compose-zero-trust.yml
@@ -1155,11 +1155,7 @@ services:
       STAGEGATE_WAITFOR_TIMEOUT: 60s
       VAULT_ADDR: http://edgex-vault:8200
       VAULT_CONFIG_DIR: /vault/config
-      VAULT_LOCAL_CONFIG: |
-        backend "file" {
-            path = "/vault/file"
-        }
-        disable_mlock = true
+      VAULT_LOCAL_CONFIG: "listener \"tcp\" { \n  address = \"edgex-vault:8200\" \n  tls_disable = \"1\" \n  cluster_address = \"edgex-vault:8201\" \n} \nbackend \"file\" {\n  path = \"/vault/file\"\n}\ndefault_lease_ttl = \"168h\" \nmax_lease_ttl = \"720h\"\ndisable_mlock = true\n"
       VAULT_UI: "true"
     hostname: edgex-vault
     image: hashicorp/vault:1.14

--- a/docker-compose-zero-trust.yml
+++ b/docker-compose-zero-trust.yml
@@ -1124,63 +1124,48 @@ services:
           selinux: z
           create_host_path: true
   vault:
-    cap_add:
-      - IPC_LOCK
-    command:
-      - server
+    image: hashicorp/vault:${VAULT_VERSION}
+    user: "root:root" # Note that Vault is run under the 'vault' user, but entry point scripts need to first run as root
     container_name: edgex-vault
-    depends_on:
-      security-bootstrapper:
-        condition: service_started
-        required: true
-    entrypoint:
-      - /edgex-init/vault_wait_install.sh
+    hostname: edgex-vault
+    networks:
+      - edgex-network
+    ports:
+      - "127.0.0.1:8200:8200"
+    deploy:
+      resources:
+        limits:
+          memory: "1024m"
+    memswap_limit: "1024m"
+    tmpfs:
+      - /vault/config
+    entrypoint: [ "/edgex-init/vault_wait_install.sh" ]
+    env_file:
+      - common-sec-stage-gate.env
+    command: server
     environment:
-      PROXY_SETUP_HOST: edgex-security-proxy-setup
-      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
-      STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: "6379"
-      STAGEGATE_DATABASE_READYPORT: "6379"
-      STAGEGATE_PROXYSETUP_READYPORT: "54325"
-      STAGEGATE_READY_TORUNPORT: "54329"
-      STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: "8500"
-      STAGEGATE_REGISTRY_READYPORT: "54324"
-      STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
-      STAGEGATE_WAITFOR_TIMEOUT: 60s
       VAULT_ADDR: http://edgex-vault:8200
       VAULT_CONFIG_DIR: /vault/config
       VAULT_UI: "true"
-    hostname: edgex-vault
-    image: hashicorp/vault:1.14
-    networks:
-      edgex-network: null
-    ports:
-      - mode: ingress
-        host_ip: 127.0.0.1
-        target: 8200
-        published: "8200"
-        protocol: tcp
-    restart: always
-    tmpfs:
-      - /vault/config
-    user: root:root
+      VAULT_LOCAL_CONFIG: >
+        listener "tcp" { 
+            address = "edgex-vault:8200" 
+            tls_disable = "1" 
+            cluster_address = "edgex-vault:8201" 
+        }
+        backend "file" {
+            path = "/vault/file"
+        }
+        default_lease_ttl = "168h" 
+        max_lease_ttl = "720h"
+        disable_mlock = true
     volumes:
-      - type: volume
-        source: edgex-init
-        target: /edgex-init
-        read_only: true
-        volume: {}
-      - type: volume
-        source: vault-file
-        target: /vault/file
-        volume: {}
-      - type: volume
-        source: vault-logs
-        target: /vault/logs
-        volume: {}
+      - edgex-init:/edgex-init:ro
+      - vault-file:/vault/file
+      - vault-logs:/vault/logs
+    depends_on:
+      - security-bootstrapper
+    restart: always
 networks:
   edgex-network:
     name: edgex_edgex-network

--- a/docker-compose-zero-trust.yml
+++ b/docker-compose-zero-trust.yml
@@ -1124,48 +1124,67 @@ services:
           selinux: z
           create_host_path: true
   vault:
-    image: hashicorp/vault:${VAULT_VERSION}
-    user: "root:root" # Note that Vault is run under the 'vault' user, but entry point scripts need to first run as root
+    command:
+      - server
     container_name: edgex-vault
-    hostname: edgex-vault
-    networks:
-      - edgex-network
-    ports:
-      - "127.0.0.1:8200:8200"
+    depends_on:
+      security-bootstrapper:
+        condition: service_started
+        required: true
     deploy:
       resources:
         limits:
-          memory: "1024m"
-    memswap_limit: "1024m"
-    tmpfs:
-      - /vault/config
-    entrypoint: [ "/edgex-init/vault_wait_install.sh" ]
-    env_file:
-      - common-sec-stage-gate.env
-    command: server
+          memory: "1073741824"
+    entrypoint:
+      - /edgex-init/vault_wait_install.sh
     environment:
+      PROXY_SETUP_HOST: edgex-security-proxy-setup
+      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
+      STAGEGATE_DATABASE_HOST: edgex-redis
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
+      STAGEGATE_PROXYSETUP_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
+      STAGEGATE_REGISTRY_HOST: edgex-core-consul
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
+      STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
+      STAGEGATE_WAITFOR_TIMEOUT: 60s
       VAULT_ADDR: http://edgex-vault:8200
       VAULT_CONFIG_DIR: /vault/config
+      VAULT_LOCAL_CONFIG: "listener \"tcp\" { \n    address = \"edgex-vault:8200\" \n    tls_disable = \"1\" \n    cluster_address = \"edgex-vault:8201\" \n} backend \"file\" {\n    path = \"/vault/file\"\n} default_lease_ttl = \"168h\"  max_lease_ttl = \"720h\" disable_mlock = true\n"
       VAULT_UI: "true"
-      VAULT_LOCAL_CONFIG: >
-        listener "tcp" { 
-            address = "edgex-vault:8200" 
-            tls_disable = "1" 
-            cluster_address = "edgex-vault:8201" 
-        }
-        backend "file" {
-            path = "/vault/file"
-        }
-        default_lease_ttl = "168h" 
-        max_lease_ttl = "720h"
-        disable_mlock = true
-    volumes:
-      - edgex-init:/edgex-init:ro
-      - vault-file:/vault/file
-      - vault-logs:/vault/logs
-    depends_on:
-      - security-bootstrapper
+    hostname: edgex-vault
+    image: hashicorp/vault:1.14
+    memswap_limit: "1073741824"
+    networks:
+      edgex-network: null
+    ports:
+      - mode: ingress
+        host_ip: 127.0.0.1
+        target: 8200
+        published: "8200"
+        protocol: tcp
     restart: always
+    tmpfs:
+      - /vault/config
+    user: root:root
+    volumes:
+      - type: volume
+        source: edgex-init
+        target: /edgex-init
+        read_only: true
+        volume: {}
+      - type: volume
+        source: vault-file
+        target: /vault/file
+        volume: {}
+      - type: volume
+        source: vault-logs
+        target: /vault/logs
+        volume: {}
 networks:
   edgex-network:
     name: edgex_edgex-network

--- a/docker-compose-zero-trust.yml
+++ b/docker-compose-zero-trust.yml
@@ -1134,7 +1134,7 @@ services:
     deploy:
       resources:
         limits:
-          memory: "1073741824"
+          memory: "34032712679424"
     entrypoint:
       - /edgex-init/vault_wait_install.sh
     environment:
@@ -1154,11 +1154,12 @@ services:
       STAGEGATE_WAITFOR_TIMEOUT: 60s
       VAULT_ADDR: http://edgex-vault:8200
       VAULT_CONFIG_DIR: /vault/config
-      VAULT_LOCAL_CONFIG: "listener \"tcp\" { \n    address = \"edgex-vault:8200\" \n    tls_disable = \"1\" \n    cluster_address = \"edgex-vault:8201\" \n} backend \"file\" {\n    path = \"/vault/file\"\n} default_lease_ttl = \"168h\"  max_lease_ttl = \"720h\" disable_mlock = true\n"
+      VAULT_LOCAL_CONFIG: |
+        disable_mlock = true
       VAULT_UI: "true"
     hostname: edgex-vault
     image: hashicorp/vault:1.14
-    memswap_limit: "1073741824"
+    memswap_limit: "34032712679424"
     networks:
       edgex-network: null
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1308,6 +1308,7 @@ services:
       - /edgex-init/vault_wait_install.sh
     environment:
       PROXY_SETUP_HOST: edgex-security-proxy-setup
+      SKIP_SETCAP: "true"
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
       STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
@@ -1326,7 +1327,8 @@ services:
       VAULT_LOCAL_CONFIG: |
         backend "file" {
             path = "/vault/file"
-        } disable_mlock = true
+        }
+        disable_mlock = true
       VAULT_UI: "true"
     hostname: edgex-vault
     image: hashicorp/vault:1.14

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1293,63 +1293,48 @@ services:
         bind:
           create_host_path: true
   vault:
-    cap_add:
-      - IPC_LOCK
-    command:
-      - server
+    image: hashicorp/vault:${VAULT_VERSION}
+    user: "root:root" # Note that Vault is run under the 'vault' user, but entry point scripts need to first run as root
     container_name: edgex-vault
-    depends_on:
-      security-bootstrapper:
-        condition: service_started
-        required: true
-    entrypoint:
-      - /edgex-init/vault_wait_install.sh
+    hostname: edgex-vault
+    networks:
+      - edgex-network
+    ports:
+      - "127.0.0.1:8200:8200"
+    deploy:
+      resources:
+        limits:
+          memory: "1024m"
+    memswap_limit: "1024m"
+    tmpfs:
+      - /vault/config
+    entrypoint: [ "/edgex-init/vault_wait_install.sh" ]
+    env_file:
+      - common-sec-stage-gate.env
+    command: server
     environment:
-      PROXY_SETUP_HOST: edgex-security-proxy-setup
-      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
-      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
-      STAGEGATE_DATABASE_HOST: edgex-redis
-      STAGEGATE_DATABASE_PORT: "6379"
-      STAGEGATE_DATABASE_READYPORT: "6379"
-      STAGEGATE_PROXYSETUP_READYPORT: "54325"
-      STAGEGATE_READY_TORUNPORT: "54329"
-      STAGEGATE_REGISTRY_HOST: edgex-core-consul
-      STAGEGATE_REGISTRY_PORT: "8500"
-      STAGEGATE_REGISTRY_READYPORT: "54324"
-      STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
-      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
-      STAGEGATE_WAITFOR_TIMEOUT: 60s
       VAULT_ADDR: http://edgex-vault:8200
       VAULT_CONFIG_DIR: /vault/config
       VAULT_UI: "true"
-    hostname: edgex-vault
-    image: hashicorp/vault:1.14
-    networks:
-      edgex-network: null
-    ports:
-      - mode: ingress
-        host_ip: 127.0.0.1
-        target: 8200
-        published: "8200"
-        protocol: tcp
-    restart: always
-    tmpfs:
-      - /vault/config
-    user: root:root
+      VAULT_LOCAL_CONFIG: >
+        listener "tcp" { 
+            address = "edgex-vault:8200" 
+            tls_disable = "1" 
+            cluster_address = "edgex-vault:8201" 
+        }
+        backend "file" {
+            path = "/vault/file"
+        }
+        default_lease_ttl = "168h" 
+        max_lease_ttl = "720h"
+        disable_mlock = true
     volumes:
-      - type: volume
-        source: edgex-init
-        target: /edgex-init
-        read_only: true
-        volume: {}
-      - type: volume
-        source: vault-file
-        target: /vault/file
-        volume: {}
-      - type: volume
-        source: vault-logs
-        target: /vault/logs
-        volume: {}
+      - edgex-init:/edgex-init:ro
+      - vault-file:/vault/file
+      - vault-logs:/vault/logs
+    depends_on:
+      - security-bootstrapper
+    restart: always
 networks:
   edgex-network:
     name: edgex_edgex-network

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1293,48 +1293,67 @@ services:
         bind:
           create_host_path: true
   vault:
-    image: hashicorp/vault:${VAULT_VERSION}
-    user: "root:root" # Note that Vault is run under the 'vault' user, but entry point scripts need to first run as root
+    command:
+      - server
     container_name: edgex-vault
-    hostname: edgex-vault
-    networks:
-      - edgex-network
-    ports:
-      - "127.0.0.1:8200:8200"
+    depends_on:
+      security-bootstrapper:
+        condition: service_started
+        required: true
     deploy:
       resources:
         limits:
-          memory: "1024m"
-    memswap_limit: "1024m"
-    tmpfs:
-      - /vault/config
-    entrypoint: [ "/edgex-init/vault_wait_install.sh" ]
-    env_file:
-      - common-sec-stage-gate.env
-    command: server
+          memory: "1073741824"
+    entrypoint:
+      - /edgex-init/vault_wait_install.sh
     environment:
+      PROXY_SETUP_HOST: edgex-security-proxy-setup
+      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
+      STAGEGATE_DATABASE_HOST: edgex-redis
+      STAGEGATE_DATABASE_PORT: "6379"
+      STAGEGATE_DATABASE_READYPORT: "6379"
+      STAGEGATE_PROXYSETUP_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
+      STAGEGATE_REGISTRY_HOST: edgex-core-consul
+      STAGEGATE_REGISTRY_PORT: "8500"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
+      STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
+      STAGEGATE_WAITFOR_TIMEOUT: 60s
       VAULT_ADDR: http://edgex-vault:8200
       VAULT_CONFIG_DIR: /vault/config
+      VAULT_LOCAL_CONFIG: "listener \"tcp\" { \n    address = \"edgex-vault:8200\" \n    tls_disable = \"1\" \n    cluster_address = \"edgex-vault:8201\" \n} backend \"file\" {\n    path = \"/vault/file\"\n} default_lease_ttl = \"168h\"  max_lease_ttl = \"720h\" disable_mlock = true\n"
       VAULT_UI: "true"
-      VAULT_LOCAL_CONFIG: >
-        listener "tcp" { 
-            address = "edgex-vault:8200" 
-            tls_disable = "1" 
-            cluster_address = "edgex-vault:8201" 
-        }
-        backend "file" {
-            path = "/vault/file"
-        }
-        default_lease_ttl = "168h" 
-        max_lease_ttl = "720h"
-        disable_mlock = true
-    volumes:
-      - edgex-init:/edgex-init:ro
-      - vault-file:/vault/file
-      - vault-logs:/vault/logs
-    depends_on:
-      - security-bootstrapper
+    hostname: edgex-vault
+    image: hashicorp/vault:1.14
+    memswap_limit: "1073741824"
+    networks:
+      edgex-network: null
+    ports:
+      - mode: ingress
+        host_ip: 127.0.0.1
+        target: 8200
+        published: "8200"
+        protocol: tcp
     restart: always
+    tmpfs:
+      - /vault/config
+    user: root:root
+    volumes:
+      - type: volume
+        source: edgex-init
+        target: /edgex-init
+        read_only: true
+        volume: {}
+      - type: volume
+        source: vault-file
+        target: /vault/file
+        volume: {}
+      - type: volume
+        source: vault-logs
+        target: /vault/logs
+        volume: {}
 networks:
   edgex-network:
     name: edgex_edgex-network

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1303,7 +1303,7 @@ services:
     deploy:
       resources:
         limits:
-          memory: "34032712679424"
+          memory: "34032716873728"
     entrypoint:
       - /edgex-init/vault_wait_install.sh
     environment:
@@ -1324,11 +1324,13 @@ services:
       VAULT_ADDR: http://edgex-vault:8200
       VAULT_CONFIG_DIR: /vault/config
       VAULT_LOCAL_CONFIG: |
-        disable_mlock = true
+        backend "file" {
+            path = "/vault/file"
+        } disable_mlock = true
       VAULT_UI: "true"
     hostname: edgex-vault
     image: hashicorp/vault:1.14
-    memswap_limit: "34032712679424"
+    memswap_limit: "34032716873728"
     networks:
       edgex-network: null
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1324,11 +1324,7 @@ services:
       STAGEGATE_WAITFOR_TIMEOUT: 60s
       VAULT_ADDR: http://edgex-vault:8200
       VAULT_CONFIG_DIR: /vault/config
-      VAULT_LOCAL_CONFIG: |
-        backend "file" {
-            path = "/vault/file"
-        }
-        disable_mlock = true
+      VAULT_LOCAL_CONFIG: "listener \"tcp\" { \n  address = \"edgex-vault:8200\" \n  tls_disable = \"1\" \n  cluster_address = \"edgex-vault:8201\" \n} \nbackend \"file\" {\n  path = \"/vault/file\"\n}\ndefault_lease_ttl = \"168h\" \nmax_lease_ttl = \"720h\"\ndisable_mlock = true\n"
       VAULT_UI: "true"
     hostname: edgex-vault
     image: hashicorp/vault:1.14

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1303,7 +1303,7 @@ services:
     deploy:
       resources:
         limits:
-          memory: "1073741824"
+          memory: "34032712679424"
     entrypoint:
       - /edgex-init/vault_wait_install.sh
     environment:
@@ -1323,11 +1323,12 @@ services:
       STAGEGATE_WAITFOR_TIMEOUT: 60s
       VAULT_ADDR: http://edgex-vault:8200
       VAULT_CONFIG_DIR: /vault/config
-      VAULT_LOCAL_CONFIG: "listener \"tcp\" { \n    address = \"edgex-vault:8200\" \n    tls_disable = \"1\" \n    cluster_address = \"edgex-vault:8201\" \n} backend \"file\" {\n    path = \"/vault/file\"\n} default_lease_ttl = \"168h\"  max_lease_ttl = \"720h\" disable_mlock = true\n"
+      VAULT_LOCAL_CONFIG: |
+        disable_mlock = true
       VAULT_UI: "true"
     hostname: edgex-vault
     image: hashicorp/vault:1.14
-    memswap_limit: "1073741824"
+    memswap_limit: "34032712679424"
     networks:
       edgex-network: null
     ports:

--- a/taf/docker-compose-taf-arm64.yml
+++ b/taf/docker-compose-taf-arm64.yml
@@ -2341,7 +2341,7 @@ services:
     deploy:
       resources:
         limits:
-          memory: "34032712679424"
+          memory: "34032716873728"
     entrypoint:
       - /edgex-init/vault_wait_install.sh
     environment:
@@ -2362,11 +2362,13 @@ services:
       VAULT_ADDR: http://edgex-vault:8200
       VAULT_CONFIG_DIR: /vault/config
       VAULT_LOCAL_CONFIG: |
-        disable_mlock = true
+        backend "file" {
+            path = "/vault/file"
+        } disable_mlock = true
       VAULT_UI: "true"
     hostname: edgex-vault
     image: hashicorp/vault:1.14
-    memswap_limit: "34032712679424"
+    memswap_limit: "34032716873728"
     networks:
       edgex-network: null
     ports:

--- a/taf/docker-compose-taf-arm64.yml
+++ b/taf/docker-compose-taf-arm64.yml
@@ -2362,11 +2362,7 @@ services:
       STAGEGATE_WAITFOR_TIMEOUT: 60s
       VAULT_ADDR: http://edgex-vault:8200
       VAULT_CONFIG_DIR: /vault/config
-      VAULT_LOCAL_CONFIG: |
-        backend "file" {
-            path = "/vault/file"
-        }
-        disable_mlock = true
+      VAULT_LOCAL_CONFIG: "listener \"tcp\" { \n  address = \"edgex-vault:8200\" \n  tls_disable = \"1\" \n  cluster_address = \"edgex-vault:8201\" \n} \nbackend \"file\" {\n  path = \"/vault/file\"\n}\ndefault_lease_ttl = \"168h\" \nmax_lease_ttl = \"720h\"\ndisable_mlock = true\n"
       VAULT_UI: "true"
     hostname: edgex-vault
     image: hashicorp/vault:1.14

--- a/taf/docker-compose-taf-arm64.yml
+++ b/taf/docker-compose-taf-arm64.yml
@@ -2346,6 +2346,7 @@ services:
       - /edgex-init/vault_wait_install.sh
     environment:
       PROXY_SETUP_HOST: edgex-security-proxy-setup
+      SKIP_SETCAP: "true"
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
       STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
@@ -2364,7 +2365,8 @@ services:
       VAULT_LOCAL_CONFIG: |
         backend "file" {
             path = "/vault/file"
-        } disable_mlock = true
+        }
+        disable_mlock = true
       VAULT_UI: "true"
     hostname: edgex-vault
     image: hashicorp/vault:1.14

--- a/taf/docker-compose-taf-arm64.yml
+++ b/taf/docker-compose-taf-arm64.yml
@@ -2331,8 +2331,6 @@ services:
         bind:
           create_host_path: true
   vault:
-    cap_add:
-      - IPC_LOCK
     command:
       - server
     container_name: edgex-vault
@@ -2340,6 +2338,10 @@ services:
       security-bootstrapper:
         condition: service_started
         required: true
+    deploy:
+      resources:
+        limits:
+          memory: "34032712679424"
     entrypoint:
       - /edgex-init/vault_wait_install.sh
     environment:
@@ -2359,9 +2361,12 @@ services:
       STAGEGATE_WAITFOR_TIMEOUT: 60s
       VAULT_ADDR: http://edgex-vault:8200
       VAULT_CONFIG_DIR: /vault/config
+      VAULT_LOCAL_CONFIG: |
+        disable_mlock = true
       VAULT_UI: "true"
     hostname: edgex-vault
     image: hashicorp/vault:1.14
+    memswap_limit: "34032712679424"
     networks:
       edgex-network: null
     ports:

--- a/taf/docker-compose-taf-keeper-arm64.yml
+++ b/taf/docker-compose-taf-keeper-arm64.yml
@@ -2250,8 +2250,6 @@ services:
         bind:
           create_host_path: true
   vault:
-    cap_add:
-      - IPC_LOCK
     command:
       - server
     container_name: edgex-vault
@@ -2259,6 +2257,10 @@ services:
       security-bootstrapper:
         condition: service_started
         required: true
+    deploy:
+      resources:
+        limits:
+          memory: "34032712679424"
     entrypoint:
       - /edgex-init/vault_wait_install.sh
     environment:
@@ -2278,9 +2280,12 @@ services:
       STAGEGATE_WAITFOR_TIMEOUT: 60s
       VAULT_ADDR: http://edgex-vault:8200
       VAULT_CONFIG_DIR: /vault/config
+      VAULT_LOCAL_CONFIG: |
+        disable_mlock = true
       VAULT_UI: "true"
     hostname: edgex-vault
     image: hashicorp/vault:1.14
+    memswap_limit: "34032712679424"
     networks:
       edgex-network: null
     ports:

--- a/taf/docker-compose-taf-keeper-arm64.yml
+++ b/taf/docker-compose-taf-keeper-arm64.yml
@@ -2281,11 +2281,7 @@ services:
       STAGEGATE_WAITFOR_TIMEOUT: 60s
       VAULT_ADDR: http://edgex-vault:8200
       VAULT_CONFIG_DIR: /vault/config
-      VAULT_LOCAL_CONFIG: |
-        backend "file" {
-            path = "/vault/file"
-        }
-        disable_mlock = true
+      VAULT_LOCAL_CONFIG: "listener \"tcp\" { \n  address = \"edgex-vault:8200\" \n  tls_disable = \"1\" \n  cluster_address = \"edgex-vault:8201\" \n} \nbackend \"file\" {\n  path = \"/vault/file\"\n}\ndefault_lease_ttl = \"168h\" \nmax_lease_ttl = \"720h\"\ndisable_mlock = true\n"
       VAULT_UI: "true"
     hostname: edgex-vault
     image: hashicorp/vault:1.14

--- a/taf/docker-compose-taf-keeper-arm64.yml
+++ b/taf/docker-compose-taf-keeper-arm64.yml
@@ -2265,6 +2265,7 @@ services:
       - /edgex-init/vault_wait_install.sh
     environment:
       PROXY_SETUP_HOST: edgex-security-proxy-setup
+      SKIP_SETCAP: "true"
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
       STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
@@ -2283,7 +2284,8 @@ services:
       VAULT_LOCAL_CONFIG: |
         backend "file" {
             path = "/vault/file"
-        } disable_mlock = true
+        }
+        disable_mlock = true
       VAULT_UI: "true"
     hostname: edgex-vault
     image: hashicorp/vault:1.14

--- a/taf/docker-compose-taf-keeper-arm64.yml
+++ b/taf/docker-compose-taf-keeper-arm64.yml
@@ -2260,7 +2260,7 @@ services:
     deploy:
       resources:
         limits:
-          memory: "34032712679424"
+          memory: "34032716873728"
     entrypoint:
       - /edgex-init/vault_wait_install.sh
     environment:
@@ -2281,11 +2281,13 @@ services:
       VAULT_ADDR: http://edgex-vault:8200
       VAULT_CONFIG_DIR: /vault/config
       VAULT_LOCAL_CONFIG: |
-        disable_mlock = true
+        backend "file" {
+            path = "/vault/file"
+        } disable_mlock = true
       VAULT_UI: "true"
     hostname: edgex-vault
     image: hashicorp/vault:1.14
-    memswap_limit: "34032712679424"
+    memswap_limit: "34032716873728"
     networks:
       edgex-network: null
     ports:

--- a/taf/docker-compose-taf-keeper.yml
+++ b/taf/docker-compose-taf-keeper.yml
@@ -2250,8 +2250,6 @@ services:
         bind:
           create_host_path: true
   vault:
-    cap_add:
-      - IPC_LOCK
     command:
       - server
     container_name: edgex-vault
@@ -2259,6 +2257,10 @@ services:
       security-bootstrapper:
         condition: service_started
         required: true
+    deploy:
+      resources:
+        limits:
+          memory: "34032712679424"
     entrypoint:
       - /edgex-init/vault_wait_install.sh
     environment:
@@ -2278,9 +2280,12 @@ services:
       STAGEGATE_WAITFOR_TIMEOUT: 60s
       VAULT_ADDR: http://edgex-vault:8200
       VAULT_CONFIG_DIR: /vault/config
+      VAULT_LOCAL_CONFIG: |
+        disable_mlock = true
       VAULT_UI: "true"
     hostname: edgex-vault
     image: hashicorp/vault:1.14
+    memswap_limit: "34032712679424"
     networks:
       edgex-network: null
     ports:

--- a/taf/docker-compose-taf-keeper.yml
+++ b/taf/docker-compose-taf-keeper.yml
@@ -2281,11 +2281,7 @@ services:
       STAGEGATE_WAITFOR_TIMEOUT: 60s
       VAULT_ADDR: http://edgex-vault:8200
       VAULT_CONFIG_DIR: /vault/config
-      VAULT_LOCAL_CONFIG: |
-        backend "file" {
-            path = "/vault/file"
-        }
-        disable_mlock = true
+      VAULT_LOCAL_CONFIG: "listener \"tcp\" { \n  address = \"edgex-vault:8200\" \n  tls_disable = \"1\" \n  cluster_address = \"edgex-vault:8201\" \n} \nbackend \"file\" {\n  path = \"/vault/file\"\n}\ndefault_lease_ttl = \"168h\" \nmax_lease_ttl = \"720h\"\ndisable_mlock = true\n"
       VAULT_UI: "true"
     hostname: edgex-vault
     image: hashicorp/vault:1.14

--- a/taf/docker-compose-taf-keeper.yml
+++ b/taf/docker-compose-taf-keeper.yml
@@ -2265,6 +2265,7 @@ services:
       - /edgex-init/vault_wait_install.sh
     environment:
       PROXY_SETUP_HOST: edgex-security-proxy-setup
+      SKIP_SETCAP: "true"
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
       STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
@@ -2283,7 +2284,8 @@ services:
       VAULT_LOCAL_CONFIG: |
         backend "file" {
             path = "/vault/file"
-        } disable_mlock = true
+        }
+        disable_mlock = true
       VAULT_UI: "true"
     hostname: edgex-vault
     image: hashicorp/vault:1.14

--- a/taf/docker-compose-taf-keeper.yml
+++ b/taf/docker-compose-taf-keeper.yml
@@ -2260,7 +2260,7 @@ services:
     deploy:
       resources:
         limits:
-          memory: "34032712679424"
+          memory: "34032716873728"
     entrypoint:
       - /edgex-init/vault_wait_install.sh
     environment:
@@ -2281,11 +2281,13 @@ services:
       VAULT_ADDR: http://edgex-vault:8200
       VAULT_CONFIG_DIR: /vault/config
       VAULT_LOCAL_CONFIG: |
-        disable_mlock = true
+        backend "file" {
+            path = "/vault/file"
+        } disable_mlock = true
       VAULT_UI: "true"
     hostname: edgex-vault
     image: hashicorp/vault:1.14
-    memswap_limit: "34032712679424"
+    memswap_limit: "34032716873728"
     networks:
       edgex-network: null
     ports:

--- a/taf/docker-compose-taf-mqtt-bus-arm64.yml
+++ b/taf/docker-compose-taf-mqtt-bus-arm64.yml
@@ -2396,8 +2396,6 @@ services:
         bind:
           create_host_path: true
   vault:
-    cap_add:
-      - IPC_LOCK
     command:
       - server
     container_name: edgex-vault
@@ -2405,6 +2403,10 @@ services:
       security-bootstrapper:
         condition: service_started
         required: true
+    deploy:
+      resources:
+        limits:
+          memory: "34032712679424"
     entrypoint:
       - /edgex-init/vault_wait_install.sh
     environment:
@@ -2424,9 +2426,12 @@ services:
       STAGEGATE_WAITFOR_TIMEOUT: 60s
       VAULT_ADDR: http://edgex-vault:8200
       VAULT_CONFIG_DIR: /vault/config
+      VAULT_LOCAL_CONFIG: |
+        disable_mlock = true
       VAULT_UI: "true"
     hostname: edgex-vault
     image: hashicorp/vault:1.14
+    memswap_limit: "34032712679424"
     networks:
       edgex-network: null
     ports:

--- a/taf/docker-compose-taf-mqtt-bus-arm64.yml
+++ b/taf/docker-compose-taf-mqtt-bus-arm64.yml
@@ -2411,6 +2411,7 @@ services:
       - /edgex-init/vault_wait_install.sh
     environment:
       PROXY_SETUP_HOST: edgex-security-proxy-setup
+      SKIP_SETCAP: "true"
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
       STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
@@ -2429,7 +2430,8 @@ services:
       VAULT_LOCAL_CONFIG: |
         backend "file" {
             path = "/vault/file"
-        } disable_mlock = true
+        }
+        disable_mlock = true
       VAULT_UI: "true"
     hostname: edgex-vault
     image: hashicorp/vault:1.14

--- a/taf/docker-compose-taf-mqtt-bus-arm64.yml
+++ b/taf/docker-compose-taf-mqtt-bus-arm64.yml
@@ -2427,11 +2427,7 @@ services:
       STAGEGATE_WAITFOR_TIMEOUT: 60s
       VAULT_ADDR: http://edgex-vault:8200
       VAULT_CONFIG_DIR: /vault/config
-      VAULT_LOCAL_CONFIG: |
-        backend "file" {
-            path = "/vault/file"
-        }
-        disable_mlock = true
+      VAULT_LOCAL_CONFIG: "listener \"tcp\" { \n  address = \"edgex-vault:8200\" \n  tls_disable = \"1\" \n  cluster_address = \"edgex-vault:8201\" \n} \nbackend \"file\" {\n  path = \"/vault/file\"\n}\ndefault_lease_ttl = \"168h\" \nmax_lease_ttl = \"720h\"\ndisable_mlock = true\n"
       VAULT_UI: "true"
     hostname: edgex-vault
     image: hashicorp/vault:1.14

--- a/taf/docker-compose-taf-mqtt-bus-arm64.yml
+++ b/taf/docker-compose-taf-mqtt-bus-arm64.yml
@@ -2406,7 +2406,7 @@ services:
     deploy:
       resources:
         limits:
-          memory: "34032712679424"
+          memory: "34032716873728"
     entrypoint:
       - /edgex-init/vault_wait_install.sh
     environment:
@@ -2427,11 +2427,13 @@ services:
       VAULT_ADDR: http://edgex-vault:8200
       VAULT_CONFIG_DIR: /vault/config
       VAULT_LOCAL_CONFIG: |
-        disable_mlock = true
+        backend "file" {
+            path = "/vault/file"
+        } disable_mlock = true
       VAULT_UI: "true"
     hostname: edgex-vault
     image: hashicorp/vault:1.14
-    memswap_limit: "34032712679424"
+    memswap_limit: "34032716873728"
     networks:
       edgex-network: null
     ports:

--- a/taf/docker-compose-taf-mqtt-bus-keeper-arm64.yml
+++ b/taf/docker-compose-taf-mqtt-bus-keeper-arm64.yml
@@ -2346,11 +2346,7 @@ services:
       STAGEGATE_WAITFOR_TIMEOUT: 60s
       VAULT_ADDR: http://edgex-vault:8200
       VAULT_CONFIG_DIR: /vault/config
-      VAULT_LOCAL_CONFIG: |
-        backend "file" {
-            path = "/vault/file"
-        }
-        disable_mlock = true
+      VAULT_LOCAL_CONFIG: "listener \"tcp\" { \n  address = \"edgex-vault:8200\" \n  tls_disable = \"1\" \n  cluster_address = \"edgex-vault:8201\" \n} \nbackend \"file\" {\n  path = \"/vault/file\"\n}\ndefault_lease_ttl = \"168h\" \nmax_lease_ttl = \"720h\"\ndisable_mlock = true\n"
       VAULT_UI: "true"
     hostname: edgex-vault
     image: hashicorp/vault:1.14

--- a/taf/docker-compose-taf-mqtt-bus-keeper-arm64.yml
+++ b/taf/docker-compose-taf-mqtt-bus-keeper-arm64.yml
@@ -2325,7 +2325,7 @@ services:
     deploy:
       resources:
         limits:
-          memory: "34032712679424"
+          memory: "34032716873728"
     entrypoint:
       - /edgex-init/vault_wait_install.sh
     environment:
@@ -2346,11 +2346,13 @@ services:
       VAULT_ADDR: http://edgex-vault:8200
       VAULT_CONFIG_DIR: /vault/config
       VAULT_LOCAL_CONFIG: |
-        disable_mlock = true
+        backend "file" {
+            path = "/vault/file"
+        } disable_mlock = true
       VAULT_UI: "true"
     hostname: edgex-vault
     image: hashicorp/vault:1.14
-    memswap_limit: "34032712679424"
+    memswap_limit: "34032716873728"
     networks:
       edgex-network: null
     ports:

--- a/taf/docker-compose-taf-mqtt-bus-keeper-arm64.yml
+++ b/taf/docker-compose-taf-mqtt-bus-keeper-arm64.yml
@@ -2330,6 +2330,7 @@ services:
       - /edgex-init/vault_wait_install.sh
     environment:
       PROXY_SETUP_HOST: edgex-security-proxy-setup
+      SKIP_SETCAP: "true"
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
       STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
@@ -2348,7 +2349,8 @@ services:
       VAULT_LOCAL_CONFIG: |
         backend "file" {
             path = "/vault/file"
-        } disable_mlock = true
+        }
+        disable_mlock = true
       VAULT_UI: "true"
     hostname: edgex-vault
     image: hashicorp/vault:1.14

--- a/taf/docker-compose-taf-mqtt-bus-keeper-arm64.yml
+++ b/taf/docker-compose-taf-mqtt-bus-keeper-arm64.yml
@@ -2315,8 +2315,6 @@ services:
         bind:
           create_host_path: true
   vault:
-    cap_add:
-      - IPC_LOCK
     command:
       - server
     container_name: edgex-vault
@@ -2324,6 +2322,10 @@ services:
       security-bootstrapper:
         condition: service_started
         required: true
+    deploy:
+      resources:
+        limits:
+          memory: "34032712679424"
     entrypoint:
       - /edgex-init/vault_wait_install.sh
     environment:
@@ -2343,9 +2345,12 @@ services:
       STAGEGATE_WAITFOR_TIMEOUT: 60s
       VAULT_ADDR: http://edgex-vault:8200
       VAULT_CONFIG_DIR: /vault/config
+      VAULT_LOCAL_CONFIG: |
+        disable_mlock = true
       VAULT_UI: "true"
     hostname: edgex-vault
     image: hashicorp/vault:1.14
+    memswap_limit: "34032712679424"
     networks:
       edgex-network: null
     ports:

--- a/taf/docker-compose-taf-mqtt-bus-keeper.yml
+++ b/taf/docker-compose-taf-mqtt-bus-keeper.yml
@@ -2346,11 +2346,7 @@ services:
       STAGEGATE_WAITFOR_TIMEOUT: 60s
       VAULT_ADDR: http://edgex-vault:8200
       VAULT_CONFIG_DIR: /vault/config
-      VAULT_LOCAL_CONFIG: |
-        backend "file" {
-            path = "/vault/file"
-        }
-        disable_mlock = true
+      VAULT_LOCAL_CONFIG: "listener \"tcp\" { \n  address = \"edgex-vault:8200\" \n  tls_disable = \"1\" \n  cluster_address = \"edgex-vault:8201\" \n} \nbackend \"file\" {\n  path = \"/vault/file\"\n}\ndefault_lease_ttl = \"168h\" \nmax_lease_ttl = \"720h\"\ndisable_mlock = true\n"
       VAULT_UI: "true"
     hostname: edgex-vault
     image: hashicorp/vault:1.14

--- a/taf/docker-compose-taf-mqtt-bus-keeper.yml
+++ b/taf/docker-compose-taf-mqtt-bus-keeper.yml
@@ -2325,7 +2325,7 @@ services:
     deploy:
       resources:
         limits:
-          memory: "34032712679424"
+          memory: "34032716873728"
     entrypoint:
       - /edgex-init/vault_wait_install.sh
     environment:
@@ -2346,11 +2346,13 @@ services:
       VAULT_ADDR: http://edgex-vault:8200
       VAULT_CONFIG_DIR: /vault/config
       VAULT_LOCAL_CONFIG: |
-        disable_mlock = true
+        backend "file" {
+            path = "/vault/file"
+        } disable_mlock = true
       VAULT_UI: "true"
     hostname: edgex-vault
     image: hashicorp/vault:1.14
-    memswap_limit: "34032712679424"
+    memswap_limit: "34032716873728"
     networks:
       edgex-network: null
     ports:

--- a/taf/docker-compose-taf-mqtt-bus-keeper.yml
+++ b/taf/docker-compose-taf-mqtt-bus-keeper.yml
@@ -2330,6 +2330,7 @@ services:
       - /edgex-init/vault_wait_install.sh
     environment:
       PROXY_SETUP_HOST: edgex-security-proxy-setup
+      SKIP_SETCAP: "true"
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
       STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
@@ -2348,7 +2349,8 @@ services:
       VAULT_LOCAL_CONFIG: |
         backend "file" {
             path = "/vault/file"
-        } disable_mlock = true
+        }
+        disable_mlock = true
       VAULT_UI: "true"
     hostname: edgex-vault
     image: hashicorp/vault:1.14

--- a/taf/docker-compose-taf-mqtt-bus-keeper.yml
+++ b/taf/docker-compose-taf-mqtt-bus-keeper.yml
@@ -2315,8 +2315,6 @@ services:
         bind:
           create_host_path: true
   vault:
-    cap_add:
-      - IPC_LOCK
     command:
       - server
     container_name: edgex-vault
@@ -2324,6 +2322,10 @@ services:
       security-bootstrapper:
         condition: service_started
         required: true
+    deploy:
+      resources:
+        limits:
+          memory: "34032712679424"
     entrypoint:
       - /edgex-init/vault_wait_install.sh
     environment:
@@ -2343,9 +2345,12 @@ services:
       STAGEGATE_WAITFOR_TIMEOUT: 60s
       VAULT_ADDR: http://edgex-vault:8200
       VAULT_CONFIG_DIR: /vault/config
+      VAULT_LOCAL_CONFIG: |
+        disable_mlock = true
       VAULT_UI: "true"
     hostname: edgex-vault
     image: hashicorp/vault:1.14
+    memswap_limit: "34032712679424"
     networks:
       edgex-network: null
     ports:

--- a/taf/docker-compose-taf-mqtt-bus.yml
+++ b/taf/docker-compose-taf-mqtt-bus.yml
@@ -2396,8 +2396,6 @@ services:
         bind:
           create_host_path: true
   vault:
-    cap_add:
-      - IPC_LOCK
     command:
       - server
     container_name: edgex-vault
@@ -2405,6 +2403,10 @@ services:
       security-bootstrapper:
         condition: service_started
         required: true
+    deploy:
+      resources:
+        limits:
+          memory: "34032712679424"
     entrypoint:
       - /edgex-init/vault_wait_install.sh
     environment:
@@ -2424,9 +2426,12 @@ services:
       STAGEGATE_WAITFOR_TIMEOUT: 60s
       VAULT_ADDR: http://edgex-vault:8200
       VAULT_CONFIG_DIR: /vault/config
+      VAULT_LOCAL_CONFIG: |
+        disable_mlock = true
       VAULT_UI: "true"
     hostname: edgex-vault
     image: hashicorp/vault:1.14
+    memswap_limit: "34032712679424"
     networks:
       edgex-network: null
     ports:

--- a/taf/docker-compose-taf-mqtt-bus.yml
+++ b/taf/docker-compose-taf-mqtt-bus.yml
@@ -2411,6 +2411,7 @@ services:
       - /edgex-init/vault_wait_install.sh
     environment:
       PROXY_SETUP_HOST: edgex-security-proxy-setup
+      SKIP_SETCAP: "true"
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
       STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
@@ -2429,7 +2430,8 @@ services:
       VAULT_LOCAL_CONFIG: |
         backend "file" {
             path = "/vault/file"
-        } disable_mlock = true
+        }
+        disable_mlock = true
       VAULT_UI: "true"
     hostname: edgex-vault
     image: hashicorp/vault:1.14

--- a/taf/docker-compose-taf-mqtt-bus.yml
+++ b/taf/docker-compose-taf-mqtt-bus.yml
@@ -2427,11 +2427,7 @@ services:
       STAGEGATE_WAITFOR_TIMEOUT: 60s
       VAULT_ADDR: http://edgex-vault:8200
       VAULT_CONFIG_DIR: /vault/config
-      VAULT_LOCAL_CONFIG: |
-        backend "file" {
-            path = "/vault/file"
-        }
-        disable_mlock = true
+      VAULT_LOCAL_CONFIG: "listener \"tcp\" { \n  address = \"edgex-vault:8200\" \n  tls_disable = \"1\" \n  cluster_address = \"edgex-vault:8201\" \n} \nbackend \"file\" {\n  path = \"/vault/file\"\n}\ndefault_lease_ttl = \"168h\" \nmax_lease_ttl = \"720h\"\ndisable_mlock = true\n"
       VAULT_UI: "true"
     hostname: edgex-vault
     image: hashicorp/vault:1.14

--- a/taf/docker-compose-taf-mqtt-bus.yml
+++ b/taf/docker-compose-taf-mqtt-bus.yml
@@ -2406,7 +2406,7 @@ services:
     deploy:
       resources:
         limits:
-          memory: "34032712679424"
+          memory: "34032716873728"
     entrypoint:
       - /edgex-init/vault_wait_install.sh
     environment:
@@ -2427,11 +2427,13 @@ services:
       VAULT_ADDR: http://edgex-vault:8200
       VAULT_CONFIG_DIR: /vault/config
       VAULT_LOCAL_CONFIG: |
-        disable_mlock = true
+        backend "file" {
+            path = "/vault/file"
+        } disable_mlock = true
       VAULT_UI: "true"
     hostname: edgex-vault
     image: hashicorp/vault:1.14
-    memswap_limit: "34032712679424"
+    memswap_limit: "34032716873728"
     networks:
       edgex-network: null
     ports:

--- a/taf/docker-compose-taf-perf-arm64.yml
+++ b/taf/docker-compose-taf-perf-arm64.yml
@@ -1714,11 +1714,7 @@ services:
       STAGEGATE_WAITFOR_TIMEOUT: 60s
       VAULT_ADDR: http://edgex-vault:8200
       VAULT_CONFIG_DIR: /vault/config
-      VAULT_LOCAL_CONFIG: |
-        backend "file" {
-            path = "/vault/file"
-        }
-        disable_mlock = true
+      VAULT_LOCAL_CONFIG: "listener \"tcp\" { \n  address = \"edgex-vault:8200\" \n  tls_disable = \"1\" \n  cluster_address = \"edgex-vault:8201\" \n} \nbackend \"file\" {\n  path = \"/vault/file\"\n}\ndefault_lease_ttl = \"168h\" \nmax_lease_ttl = \"720h\"\ndisable_mlock = true\n"
       VAULT_UI: "true"
     hostname: edgex-vault
     image: hashicorp/vault:1.14

--- a/taf/docker-compose-taf-perf-arm64.yml
+++ b/taf/docker-compose-taf-perf-arm64.yml
@@ -1683,8 +1683,6 @@ services:
         bind:
           create_host_path: true
   vault:
-    cap_add:
-      - IPC_LOCK
     command:
       - server
     container_name: edgex-vault
@@ -1692,6 +1690,10 @@ services:
       security-bootstrapper:
         condition: service_started
         required: true
+    deploy:
+      resources:
+        limits:
+          memory: "34032712679424"
     entrypoint:
       - /edgex-init/vault_wait_install.sh
     environment:
@@ -1711,9 +1713,12 @@ services:
       STAGEGATE_WAITFOR_TIMEOUT: 60s
       VAULT_ADDR: http://edgex-vault:8200
       VAULT_CONFIG_DIR: /vault/config
+      VAULT_LOCAL_CONFIG: |
+        disable_mlock = true
       VAULT_UI: "true"
     hostname: edgex-vault
     image: hashicorp/vault:1.14
+    memswap_limit: "34032712679424"
     networks:
       edgex-network: null
     ports:

--- a/taf/docker-compose-taf-perf-arm64.yml
+++ b/taf/docker-compose-taf-perf-arm64.yml
@@ -1693,7 +1693,7 @@ services:
     deploy:
       resources:
         limits:
-          memory: "34032712679424"
+          memory: "34032716873728"
     entrypoint:
       - /edgex-init/vault_wait_install.sh
     environment:
@@ -1714,11 +1714,13 @@ services:
       VAULT_ADDR: http://edgex-vault:8200
       VAULT_CONFIG_DIR: /vault/config
       VAULT_LOCAL_CONFIG: |
-        disable_mlock = true
+        backend "file" {
+            path = "/vault/file"
+        } disable_mlock = true
       VAULT_UI: "true"
     hostname: edgex-vault
     image: hashicorp/vault:1.14
-    memswap_limit: "34032712679424"
+    memswap_limit: "34032716873728"
     networks:
       edgex-network: null
     ports:

--- a/taf/docker-compose-taf-perf-arm64.yml
+++ b/taf/docker-compose-taf-perf-arm64.yml
@@ -1698,6 +1698,7 @@ services:
       - /edgex-init/vault_wait_install.sh
     environment:
       PROXY_SETUP_HOST: edgex-security-proxy-setup
+      SKIP_SETCAP: "true"
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
       STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
@@ -1716,7 +1717,8 @@ services:
       VAULT_LOCAL_CONFIG: |
         backend "file" {
             path = "/vault/file"
-        } disable_mlock = true
+        }
+        disable_mlock = true
       VAULT_UI: "true"
     hostname: edgex-vault
     image: hashicorp/vault:1.14

--- a/taf/docker-compose-taf-perf.yml
+++ b/taf/docker-compose-taf-perf.yml
@@ -1714,11 +1714,7 @@ services:
       STAGEGATE_WAITFOR_TIMEOUT: 60s
       VAULT_ADDR: http://edgex-vault:8200
       VAULT_CONFIG_DIR: /vault/config
-      VAULT_LOCAL_CONFIG: |
-        backend "file" {
-            path = "/vault/file"
-        }
-        disable_mlock = true
+      VAULT_LOCAL_CONFIG: "listener \"tcp\" { \n  address = \"edgex-vault:8200\" \n  tls_disable = \"1\" \n  cluster_address = \"edgex-vault:8201\" \n} \nbackend \"file\" {\n  path = \"/vault/file\"\n}\ndefault_lease_ttl = \"168h\" \nmax_lease_ttl = \"720h\"\ndisable_mlock = true\n"
       VAULT_UI: "true"
     hostname: edgex-vault
     image: hashicorp/vault:1.14

--- a/taf/docker-compose-taf-perf.yml
+++ b/taf/docker-compose-taf-perf.yml
@@ -1683,8 +1683,6 @@ services:
         bind:
           create_host_path: true
   vault:
-    cap_add:
-      - IPC_LOCK
     command:
       - server
     container_name: edgex-vault
@@ -1692,6 +1690,10 @@ services:
       security-bootstrapper:
         condition: service_started
         required: true
+    deploy:
+      resources:
+        limits:
+          memory: "34032712679424"
     entrypoint:
       - /edgex-init/vault_wait_install.sh
     environment:
@@ -1711,9 +1713,12 @@ services:
       STAGEGATE_WAITFOR_TIMEOUT: 60s
       VAULT_ADDR: http://edgex-vault:8200
       VAULT_CONFIG_DIR: /vault/config
+      VAULT_LOCAL_CONFIG: |
+        disable_mlock = true
       VAULT_UI: "true"
     hostname: edgex-vault
     image: hashicorp/vault:1.14
+    memswap_limit: "34032712679424"
     networks:
       edgex-network: null
     ports:

--- a/taf/docker-compose-taf-perf.yml
+++ b/taf/docker-compose-taf-perf.yml
@@ -1693,7 +1693,7 @@ services:
     deploy:
       resources:
         limits:
-          memory: "34032712679424"
+          memory: "34032716873728"
     entrypoint:
       - /edgex-init/vault_wait_install.sh
     environment:
@@ -1714,11 +1714,13 @@ services:
       VAULT_ADDR: http://edgex-vault:8200
       VAULT_CONFIG_DIR: /vault/config
       VAULT_LOCAL_CONFIG: |
-        disable_mlock = true
+        backend "file" {
+            path = "/vault/file"
+        } disable_mlock = true
       VAULT_UI: "true"
     hostname: edgex-vault
     image: hashicorp/vault:1.14
-    memswap_limit: "34032712679424"
+    memswap_limit: "34032716873728"
     networks:
       edgex-network: null
     ports:

--- a/taf/docker-compose-taf-perf.yml
+++ b/taf/docker-compose-taf-perf.yml
@@ -1698,6 +1698,7 @@ services:
       - /edgex-init/vault_wait_install.sh
     environment:
       PROXY_SETUP_HOST: edgex-security-proxy-setup
+      SKIP_SETCAP: "true"
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
       STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
@@ -1716,7 +1717,8 @@ services:
       VAULT_LOCAL_CONFIG: |
         backend "file" {
             path = "/vault/file"
-        } disable_mlock = true
+        }
+        disable_mlock = true
       VAULT_UI: "true"
     hostname: edgex-vault
     image: hashicorp/vault:1.14

--- a/taf/docker-compose-taf.yml
+++ b/taf/docker-compose-taf.yml
@@ -2341,7 +2341,7 @@ services:
     deploy:
       resources:
         limits:
-          memory: "34032712679424"
+          memory: "34032716873728"
     entrypoint:
       - /edgex-init/vault_wait_install.sh
     environment:
@@ -2362,11 +2362,13 @@ services:
       VAULT_ADDR: http://edgex-vault:8200
       VAULT_CONFIG_DIR: /vault/config
       VAULT_LOCAL_CONFIG: |
-        disable_mlock = true
+        backend "file" {
+            path = "/vault/file"
+        } disable_mlock = true
       VAULT_UI: "true"
     hostname: edgex-vault
     image: hashicorp/vault:1.14
-    memswap_limit: "34032712679424"
+    memswap_limit: "34032716873728"
     networks:
       edgex-network: null
     ports:

--- a/taf/docker-compose-taf.yml
+++ b/taf/docker-compose-taf.yml
@@ -2362,11 +2362,7 @@ services:
       STAGEGATE_WAITFOR_TIMEOUT: 60s
       VAULT_ADDR: http://edgex-vault:8200
       VAULT_CONFIG_DIR: /vault/config
-      VAULT_LOCAL_CONFIG: |
-        backend "file" {
-            path = "/vault/file"
-        }
-        disable_mlock = true
+      VAULT_LOCAL_CONFIG: "listener \"tcp\" { \n  address = \"edgex-vault:8200\" \n  tls_disable = \"1\" \n  cluster_address = \"edgex-vault:8201\" \n} \nbackend \"file\" {\n  path = \"/vault/file\"\n}\ndefault_lease_ttl = \"168h\" \nmax_lease_ttl = \"720h\"\ndisable_mlock = true\n"
       VAULT_UI: "true"
     hostname: edgex-vault
     image: hashicorp/vault:1.14

--- a/taf/docker-compose-taf.yml
+++ b/taf/docker-compose-taf.yml
@@ -2346,6 +2346,7 @@ services:
       - /edgex-init/vault_wait_install.sh
     environment:
       PROXY_SETUP_HOST: edgex-security-proxy-setup
+      SKIP_SETCAP: "true"
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
       STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-redis
@@ -2364,7 +2365,8 @@ services:
       VAULT_LOCAL_CONFIG: |
         backend "file" {
             path = "/vault/file"
-        } disable_mlock = true
+        }
+        disable_mlock = true
       VAULT_UI: "true"
     hostname: edgex-vault
     image: hashicorp/vault:1.14

--- a/taf/docker-compose-taf.yml
+++ b/taf/docker-compose-taf.yml
@@ -2331,8 +2331,6 @@ services:
         bind:
           create_host_path: true
   vault:
-    cap_add:
-      - IPC_LOCK
     command:
       - server
     container_name: edgex-vault
@@ -2340,6 +2338,10 @@ services:
       security-bootstrapper:
         condition: service_started
         required: true
+    deploy:
+      resources:
+        limits:
+          memory: "34032712679424"
     entrypoint:
       - /edgex-init/vault_wait_install.sh
     environment:
@@ -2359,9 +2361,12 @@ services:
       STAGEGATE_WAITFOR_TIMEOUT: 60s
       VAULT_ADDR: http://edgex-vault:8200
       VAULT_CONFIG_DIR: /vault/config
+      VAULT_LOCAL_CONFIG: |
+        disable_mlock = true
       VAULT_UI: "true"
     hostname: edgex-vault
     image: hashicorp/vault:1.14
+    memswap_limit: "34032712679424"
     networks:
       edgex-network: null
     ports:


### PR DESCRIPTION
Closes #452 

Feat: Run Edgex in a rootless docker environment for added security

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  Docs updates are to come soon


## Testing Instructions
Test on ubuntu linux with both a rootless docker environment, and a rootful docker environment. Start edgex using make run, and start portainer with make portainer from within the compose-builder folder. 

### Get the auth token
```bash
token=$(make get-token)
```


### Ping Core-Data for Connection Testing
```bash
curl -k -H "Authorization: Bearer $token" https://localhost:8443/core-data/api/v3/ping
```

### Get Event Values for Virtual Device
```bash
curl -H "Authorization: Bearer $token" http://localhost:59880/api/v3/event/device/name/Random-Integer-Device
```

### Check Core Command for Available Commands
```bash
curl -H "Authorization: Bearer $token" http://localhost:59882/api/v3/device/name/Random-Integer-Device
```

### Get Current Value for Int16 Device
```bash
curl -H "Authorization: Bearer $token" http://localhost:59882/api/v3/device/name/Random-Integer-Device/Int16
```

### Set the Value of WriteInt16
```bash
curl -H "Authorization: Bearer $token" -X PUT -d '{"Int16":"42", "EnableRandomization_Int16":"false"}' http://localhost:59882/api/v3/device/name/Random-Integer-Device/WriteInt16Value
```

### Verify the Updated Value of Int16
```bash
curl -H "Authorization: Bearer $token" http://localhost:59882/api/v3/device/name/Random-Integer-Device/Int16
```

### Run Modbus Simulator Container using edge-central docs
```bash
docker run --rm -d -e RUN_MODE=RTU -p 50103:50103 --name modbus-sim iotechsys/modbus-sim:1.0
```

### Map TCP to TTY Port File
```bash
sudo socat -dd pty,link=/dev/virtualport,raw,echo=0,mode=666 tcp:localhost:50103
```

### Upload Device Profile
```bash
curl -H "Authorization: Bearer $token" http://localhost:59881/api/v3/deviceprofile/uploadfile -F "file=@/home/vagrant/edgex-compose/compose-builder/modbus.rtu.demo.profile.yml"
```

### Create Device Entity
```bash
curl http://localhost:59881/api/v3/device -H "Authorization: Bearer $token" -H "Content-Type:application/json" -X POST   -d '[
        {
          "apiVersion": "v3",
          "device": {
            "name": "Power-Submeter-Device",
            "description":"Power Submeter device",
            "labels":[
              "power submeter",
              "modbus rtu"
            ],
            "adminState": "UNLOCKED",
            "operatingState": "UP",
            "protocols": {
              "modbus-rtu": {
                "Address": "/dev/virtualport",
                "BaudRate": 19200,
                "DataBits": 8,
                "Parity": "N",
                "StopBits": 1,
                "UnitID": 1,
                "Timeout" : "5",
                "IdleTimeout" : "5"
              }
            },
            "serviceName": "device-modbus",
            "properties": {
              "IOTech_ProtocolName": "modbus-rtu"
            },
            "profileName": "Network-Power-Meter"
          }
        }
      ]'
```

### Test Modbus Device
```bash
curl -H "Authorization: Bearer $token" http://localhost:59882/api/v3/device/name/Power-Submeter-Device/Configuration
```

### Navigate to portainer
Using a web browser, go to localhosty:9000 and log in with default portainer credentials

