### PR TITLE
fix: portainer docker rootless

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,8 +30,11 @@ DOCKER_COMPOSE=docker compose
 # Resolve user ID for rootless docker port mapping
 export USERID:=$(shell id -u)
 
-# Set default rootful docker socket path
+# Set default rootful docker socket path otherwise detect rootless path
 export DOCKER_SOCKET_PATH=/var/run/docker.sock
+ifneq (,$(wildcard /run/user/$(USERID)/docker.sock))
+    export DOCKER_SOCKET_PATH := /run/user/$(USERID)/docker.sock
+endif
 
 ifeq (arm64, $(filter arm64,$(ARGS)))
 	ARM64=-arm64
@@ -58,9 +61,6 @@ endef
 .PHONY: $(OPTIONS)
 
 portainer:
-	@if [ -e /run/user/${USERID}/docker.sock ]; then \
-    	export DOCKER_SOCKET_PATH=/run/user/${USERID}/docker.sock; \
-    fi
 	${DOCKER_COMPOSE} -p portainer -f docker-compose-portainer.yml up -d
 
 portainer-down:

--- a/compose-builder/Makefile
+++ b/compose-builder/Makefile
@@ -143,7 +143,7 @@ endif
 
 # When in delay-start mode, ensure support services are delay-start-compliant by adding runtime-token configuration
 ifeq (delayed-start,$(filter delayed-start,$(ARGS)))
-    # Ensure Docker is running rootless, as security-spire-agent runs only in Docker rootless mode
+    # Resolve docker rootless environment
     ifneq (,$(wildcard /run/user/$(USERID)/docker.sock))
         export DOCKER_SOCKET_PATH := /run/user/$(USERID)/docker.sock
     endif


### PR DESCRIPTION
Closes #460 

## PR Checklist
- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
docs change not required as this is a bug fix. 


## Testing Instructions
Navigate to the compose-builder folder. Make sure you are running in a rootless docker environment. Run `make portainer`. After portainer has started run `docker inspect portainer`. Make sure the docker socket bind mount is in the user's space instead of the sudo docker socket location. Navigate to the portainer localhost web page and make sure it can connect to the docker socket and see other running containers. 
