### PR TITLE
fix: Modify keeper service to use postgres as database

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ The compose files under the `taf` subfolder are used for the automated TAF tests
 > **Note:** Only the services as listed below support Postgres as the database in EdgeX. More EdgeX services will support Postgres once the development work is done.
 > - **Core Data**
 > - **Core Keeper**
+> - The Store and Forward capability of **app-mqtt-export** App Service
 
   **Start the EdgeX Services using Postgres and Redis as the databases**
 

--- a/README.md
+++ b/README.md
@@ -131,10 +131,12 @@ The compose files under the `taf` subfolder are used for the automated TAF tests
 - **docker-compose-postgres-no-secty.yml** Contains just the services needed to run in non-secure configuration. Includes Postgres, Redis, Device Virtual and MQTT Broker services using a mix of Postgres and Redis as the databases and MQTT as the message bus.
 - **docker-compose-postgres-no-secty-arm64.yml** Contains just the services needed to run in non-secure configuration on `ARM64` system. Includes Postgres, Redis, Device Virtual and MQTT Broker services using a mix of Postgres and Redis as the databases and MQTT as the message bus.
 
-> **Note:** Only **Core Data** supports Postgres as the database in EdgeX. More EdgeX services will support Postgres once the development work is done.
+> **Note:** Only the services as listed below support Postgres as the database in EdgeX. More EdgeX services will support Postgres once the development work is done.
+> - **Core Data**
+> - **Core Keeper**
 
-  **Start the EdgeX Services using Postgres and Redis as the databases** 
+  **Start the EdgeX Services using Postgres and Redis as the databases**
 
-    - Use `docker compose -f docker-compose-postgres-no-secty.yml up -d` to start the services using this compose file.
-    - Use `docker compose -f docker-compose-postgres-no-secty.yml down` to stop the services.
-    - Replace **docker-compose-postgres-no-secty.yml** with **docker-compose-postgres-no-secty-arm64.yml** in the above commands on `ARM64` system.
+  - Use `docker compose -f docker-compose-postgres-no-secty.yml up -d` to start the services using this compose file.
+  - Use `docker compose -f docker-compose-postgres-no-secty.yml down` to stop the services.
+  - Replace **docker-compose-postgres-no-secty.yml** with **docker-compose-postgres-no-secty-arm64.yml** in the above commands on `ARM64` system.

--- a/docker-compose-postgres-no-secty-arm64.yml
+++ b/docker-compose-postgres-no-secty-arm64.yml
@@ -56,7 +56,9 @@ services:
         condition: service_started
         required: true
     environment:
-      ALL_SERVICES_DATABASE_HOST: edgex-redis
+      ALL_SERVICES_DATABASE_HOST: edgex-postgres
+      ALL_SERVICES_DATABASE_PORT: "5432"
+      ALL_SERVICES_DATABASE_TYPE: postgres
       ALL_SERVICES_MESSAGEBUS_AUTHMODE: none
       ALL_SERVICES_MESSAGEBUS_HOST: edgex-mqtt-broker
       ALL_SERVICES_MESSAGEBUS_PORT: "1883"
@@ -65,6 +67,9 @@ services:
       ALL_SERVICES_REGISTRY_HOST: edgex-core-keeper
       ALL_SERVICES_REGISTRY_PORT: "59890"
       ALL_SERVICES_REGISTRY_TYPE: keeper
+      ALL_SERVICES_WRITABLE_INSECURESECRETS_DB_SECRETNAME: postgres
+      ALL_SERVICES_WRITABLE_INSECURESECRETS_DB_SECRETDATA_USERNAME: postgres
+      ALL_SERVICES_WRITABLE_INSECURESECRETS_DB_SECRETDATA_PASSWORD: postgres
       APP_SERVICES_CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
       DEVICE_SERVICES_CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
       EDGEX_SECURITY_SECRET_STORE: "false"
@@ -354,6 +359,52 @@ services:
         host_ip: 127.0.0.1
         target: 59863
         published: "59863"
+        protocol: tcp
+    read_only: true
+    restart: always
+    security_opt:
+      - no-new-privileges:true
+    user: 2002:2001
+    volumes:
+      - type: bind
+        source: /etc/localtime
+        target: /etc/localtime
+        read_only: true
+        bind:
+          create_host_path: true
+  app-mqtt-export:
+    command:
+      - --registry
+      - -cp=keeper.http://edgex-core-keeper:59890
+    container_name: edgex-app-mqtt-export
+    depends_on:
+      core-common-config-bootstrapper:
+        condition: service_started
+        required: true
+      core-metadata:
+        condition: service_started
+        required: true
+      keeper:
+        condition: service_started
+        required: true
+    environment:
+      EDGEX_PROFILE: mqtt-export
+      EDGEX_SECURITY_SECRET_STORE: "false"
+      SERVICE_HOST: edgex-app-mqtt-export
+      WRITABLE_LOGLEVEL: INFO
+      WRITABLE_PIPELINE_FUNCTIONS_MQTTEXPORT_PARAMETERS_BROKERADDRESS: MQTT_BROKER_ADDRESS_PLACE_HOLDER
+      WRITABLE_PIPELINE_FUNCTIONS_MQTTEXPORT_PARAMETERS_TOPIC: edgex-events
+      WRITABLE_PIPELINE_FUNCTIONS_MQTTEXPORT_PARAMETERS_PERSISTONERROR: true
+      WRITABLE_STOREANDFORWARD_ENABLED: true
+    hostname: edgex-app-mqtt-export
+    image: nexus3.edgexfoundry.org:10004/app-service-configurable-arm64:latest
+    networks:
+      edgex-network: null
+    ports:
+      - mode: ingress
+        host_ip: 127.0.0.1
+        target: 59703
+        published: "59703"
         protocol: tcp
     read_only: true
     restart: always

--- a/docker-compose-postgres-no-secty-arm64.yml
+++ b/docker-compose-postgres-no-secty-arm64.yml
@@ -234,11 +234,24 @@ services:
           create_host_path: true
   keeper:
     container_name: edgex-core-keeper
+    depends_on:
+      edgex-postgres:
+        condition: service_started
+        required: true
     environment:
-      DATABASE_HOST: edgex-redis
       EDGEX_SECURITY_SECRET_STORE: "false"
-      MESSAGEBUS_HOST: edgex-redis
+      MESSAGEBUS_HOST: edgex-mqtt-broker
+      MESSAGEBUS_AUTHMODE: none
+      MESSAGEBUS_PORT: "1883"
+      MESSAGEBUS_PROTOCOL: tcp
+      MESSAGEBUS_TYPE: mqtt
       SERVICE_HOST: edgex-core-keeper
+      WRITABLE_INSECURESECRETS_DB_SECRETNAME: postgres
+      WRITABLE_INSECURESECRETS_DB_SECRETDATA_USERNAME: postgres
+      WRITABLE_INSECURESECRETS_DB_SECRETDATA_PASSWORD: postgres
+      DATABASE_HOST: edgex-postgres
+      DATABASE_TYPE: postgres
+      DATABASE_PORT: "5432"
     hostname: edgex-core-keeper
     image: nexus3.edgexfoundry.org:10004/core-keeper-arm64:latest
     networks:

--- a/docker-compose-postgres-no-secty.yml
+++ b/docker-compose-postgres-no-secty.yml
@@ -234,11 +234,24 @@ services:
           create_host_path: true
   keeper:
     container_name: edgex-core-keeper
+    depends_on:
+      edgex-postgres:
+        condition: service_started
+        required: true
     environment:
-      DATABASE_HOST: edgex-redis
       EDGEX_SECURITY_SECRET_STORE: "false"
-      MESSAGEBUS_HOST: edgex-redis
+      MESSAGEBUS_HOST: edgex-mqtt-broker
+      MESSAGEBUS_AUTHMODE: none
+      MESSAGEBUS_PORT: "1883"
+      MESSAGEBUS_PROTOCOL: tcp
+      MESSAGEBUS_TYPE: mqtt
       SERVICE_HOST: edgex-core-keeper
+      WRITABLE_INSECURESECRETS_DB_SECRETNAME: postgres
+      WRITABLE_INSECURESECRETS_DB_SECRETDATA_USERNAME: postgres
+      WRITABLE_INSECURESECRETS_DB_SECRETDATA_PASSWORD: postgres
+      DATABASE_HOST: edgex-postgres
+      DATABASE_TYPE: postgres
+      DATABASE_PORT: "5432"
     hostname: edgex-core-keeper
     image: nexus3.edgexfoundry.org:10004/core-keeper:latest
     networks:

--- a/docker-compose-postgres-no-secty.yml
+++ b/docker-compose-postgres-no-secty.yml
@@ -56,7 +56,9 @@ services:
         condition: service_started
         required: true
     environment:
-      ALL_SERVICES_DATABASE_HOST: edgex-redis
+      ALL_SERVICES_DATABASE_HOST: edgex-postgres
+      ALL_SERVICES_DATABASE_PORT: "5432"
+      ALL_SERVICES_DATABASE_TYPE: postgres
       ALL_SERVICES_MESSAGEBUS_AUTHMODE: none
       ALL_SERVICES_MESSAGEBUS_HOST: edgex-mqtt-broker
       ALL_SERVICES_MESSAGEBUS_PORT: "1883"
@@ -65,6 +67,9 @@ services:
       ALL_SERVICES_REGISTRY_HOST: edgex-core-keeper
       ALL_SERVICES_REGISTRY_PORT: "59890"
       ALL_SERVICES_REGISTRY_TYPE: keeper
+      ALL_SERVICES_WRITABLE_INSECURESECRETS_DB_SECRETNAME: postgres
+      ALL_SERVICES_WRITABLE_INSECURESECRETS_DB_SECRETDATA_USERNAME: postgres
+      ALL_SERVICES_WRITABLE_INSECURESECRETS_DB_SECRETDATA_PASSWORD: postgres
       APP_SERVICES_CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
       DEVICE_SERVICES_CLIENTS_CORE_METADATA_HOST: edgex-core-metadata
       EDGEX_SECURITY_SECRET_STORE: "false"
@@ -354,6 +359,52 @@ services:
         host_ip: 127.0.0.1
         target: 59863
         published: "59863"
+        protocol: tcp
+    read_only: true
+    restart: always
+    security_opt:
+      - no-new-privileges:true
+    user: 2002:2001
+    volumes:
+      - type: bind
+        source: /etc/localtime
+        target: /etc/localtime
+        read_only: true
+        bind:
+          create_host_path: true
+  app-mqtt-export:
+    command:
+      - --registry
+      - -cp=keeper.http://edgex-core-keeper:59890
+    container_name: edgex-app-mqtt-export
+    depends_on:
+      core-common-config-bootstrapper:
+        condition: service_started
+        required: true
+      core-metadata:
+        condition: service_started
+        required: true
+      keeper:
+        condition: service_started
+        required: true
+    environment:
+      EDGEX_PROFILE: mqtt-export
+      EDGEX_SECURITY_SECRET_STORE: "false"
+      SERVICE_HOST: edgex-app-mqtt-export
+      WRITABLE_LOGLEVEL: INFO
+      WRITABLE_PIPELINE_FUNCTIONS_MQTTEXPORT_PARAMETERS_BROKERADDRESS: MQTT_BROKER_ADDRESS_PLACE_HOLDER
+      WRITABLE_PIPELINE_FUNCTIONS_MQTTEXPORT_PARAMETERS_TOPIC: edgex-events
+      WRITABLE_PIPELINE_FUNCTIONS_MQTTEXPORT_PARAMETERS_PERSISTONERROR: true
+      WRITABLE_STOREANDFORWARD_ENABLED: true
+    hostname: edgex-app-mqtt-export
+    image: nexus3.edgexfoundry.org:10004/app-service-configurable:latest
+    networks:
+      edgex-network: null
+    ports:
+      - mode: ingress
+        host_ip: 127.0.0.1
+        target: 59703
+        published: "59703"
         protocol: tcp
     read_only: true
     restart: always


### PR DESCRIPTION
Relates to edgexfoundry/edgex-go/issues/4877. Modify keeper service to use postgres as database in non-sec compose files.

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-compose/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-compose/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>


## Testing Instructions
<!-- How can the reviewers test your change? -->
