### PR TITLE
fix: set ARCHIVE default value to true to disable smoke-test

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,7 +9,7 @@ pipeline {
         timeout(360)
     }
     parameters {
-        booleanParam defaultValue: false, description: 'Archive 3rd Party Images', name: 'ARCHIVE'
+        booleanParam defaultValue: true, description: 'Archive 3rd Party Images', name: 'ARCHIVE'
     }
     triggers {
         issueCommentTrigger('.*^recheck$.*')


### PR DESCRIPTION
Disable smoke-test temporary for breaking change recently

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-compose/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-compose/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [ ] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>


## Testing Instructions
<!-- How can the reviewers test your change? -->
