### PR TITLE
refactor: Replace old Scheduler service with cron Scheduler service

### DIFF
--- a/compose-builder/add-security.yml
+++ b/compose-builder/add-security.yml
@@ -144,15 +144,15 @@ services:
       - security-bootstrapper
       - security-secretstore-setup
 
-  support-cron-scheduler:
+  support-scheduler:
     env_file:
       - common-security.env
       - common-sec-stage-gate.env
     entrypoint: ["/edgex-init/ready_to_run_wait_install.sh"]
-    command: "/support-cron-scheduler --registry ${CP_FLAGS}"
+    command: "/support-scheduler --registry ${CP_FLAGS}"
     volumes:
       - edgex-init:/edgex-init:ro
-      - /tmp/edgex/secrets/support-cron-scheduler:/tmp/edgex/secrets/support-cron-scheduler:ro,z
+      - /tmp/edgex/secrets/support-scheduler:/tmp/edgex/secrets/support-scheduler:ro,z
     depends_on:
       - security-bootstrapper
       - security-secretstore-setup

--- a/compose-builder/docker-compose-base.yml
+++ b/compose-builder/docker-compose-base.yml
@@ -84,14 +84,14 @@ services:
       # use host timezone
       - /etc/localtime:/etc/localtime:ro
 
-  support-cron-scheduler:
-    image: ${CORE_EDGEX_REPOSITORY}/support-cron-scheduler${ARCH}:${CORE_EDGEX_VERSION}
+  support-scheduler:
+    image: ${CORE_EDGEX_REPOSITORY}/support-scheduler${ARCH}:${CORE_EDGEX_VERSION}
     command: --registry ${CP_FLAGS}
     user: "${EDGEX_USER}:${EDGEX_GROUP}"
     ports:
       - "127.0.0.1:59863:59863"
-    container_name: edgex-support-cron-scheduler
-    hostname: edgex-support-cron-scheduler
+    container_name: edgex-support-scheduler
+    hostname: edgex-support-scheduler
     read_only: true
     restart: always
     networks:
@@ -99,7 +99,7 @@ services:
     env_file:
       - common-non-security.env
     environment:
-      SERVICE_HOST: edgex-support-cron-scheduler
+      SERVICE_HOST: edgex-support-scheduler
     depends_on:
       - core-keeper
       - database

--- a/docker-compose-arm64.yml
+++ b/docker-compose-arm64.yml
@@ -1183,12 +1183,12 @@ services:
         source: kuiper-connections
         target: /tmp/kuiper-connections
         volume: {}
-  support-cron-scheduler:
+  support-scheduler:
     command:
-      - /support-cron-scheduler
+      - /support-scheduler
       - --registry
       - -cp=keeper.http://edgex-core-keeper:59890
-    container_name: edgex-support-cron-scheduler
+    container_name: edgex-support-scheduler
     depends_on:
       core-common-config-bootstrapper:
         condition: service_started
@@ -1211,7 +1211,7 @@ services:
       EDGEX_SECURITY_SECRET_STORE: "true"
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       SECRETSTORE_HOST: edgex-secret-store
-      SERVICE_HOST: edgex-support-cron-scheduler
+      SERVICE_HOST: edgex-support-scheduler
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
       STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-postgres
@@ -1225,8 +1225,8 @@ services:
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
       STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
-    hostname: edgex-support-cron-scheduler
-    image: nexus3.edgexfoundry.org:10004/support-cron-scheduler-arm64:latest
+    hostname: edgex-support-scheduler
+    image: nexus3.edgexfoundry.org:10004/support-scheduler-arm64:latest
     networks:
       edgex-network: null
     ports:
@@ -1253,8 +1253,8 @@ services:
         read_only: true
         volume: {}
       - type: bind
-        source: /tmp/edgex/secrets/support-cron-scheduler
-        target: /tmp/edgex/secrets/support-cron-scheduler
+        source: /tmp/edgex/secrets/support-scheduler
+        target: /tmp/edgex/secrets/support-scheduler
         read_only: true
         bind:
           selinux: z

--- a/docker-compose-no-secty-arm64.yml
+++ b/docker-compose-no-secty-arm64.yml
@@ -456,11 +456,11 @@ services:
         source: kuiper-plugins
         target: /kuiper/plugins
         volume: {}
-  support-cron-scheduler:
+  support-scheduler:
     command:
       - --registry
       - -cp=keeper.http://edgex-core-keeper:59890
-    container_name: edgex-support-cron-scheduler
+    container_name: edgex-support-scheduler
     depends_on:
       core-common-config-bootstrapper:
         condition: service_started
@@ -473,9 +473,9 @@ services:
         required: true
     environment:
       EDGEX_SECURITY_SECRET_STORE: "false"
-      SERVICE_HOST: edgex-support-cron-scheduler
-    hostname: edgex-support-cron-scheduler
-    image: nexus3.edgexfoundry.org:10004/support-cron-scheduler-arm64:latest
+      SERVICE_HOST: edgex-support-scheduler
+    hostname: edgex-support-scheduler
+    image: nexus3.edgexfoundry.org:10004/support-scheduler-arm64:latest
     networks:
       edgex-network: null
     ports:

--- a/docker-compose-no-secty-with-app-sample-arm64.yml
+++ b/docker-compose-no-secty-with-app-sample-arm64.yml
@@ -500,11 +500,11 @@ services:
         source: kuiper-plugins
         target: /kuiper/plugins
         volume: {}
-  support-cron-scheduler:
+  support-scheduler:
     command:
       - --registry
       - -cp=keeper.http://edgex-core-keeper:59890
-    container_name: edgex-support-cron-scheduler
+    container_name: edgex-support-scheduler
     depends_on:
       core-common-config-bootstrapper:
         condition: service_started
@@ -517,9 +517,9 @@ services:
         required: true
     environment:
       EDGEX_SECURITY_SECRET_STORE: "false"
-      SERVICE_HOST: edgex-support-cron-scheduler
-    hostname: edgex-support-cron-scheduler
-    image: nexus3.edgexfoundry.org:10004/support-cron-scheduler-arm64:latest
+      SERVICE_HOST: edgex-support-scheduler
+    hostname: edgex-support-scheduler
+    image: nexus3.edgexfoundry.org:10004/support-scheduler-arm64:latest
     networks:
       edgex-network: null
     ports:

--- a/docker-compose-no-secty-with-app-sample.yml
+++ b/docker-compose-no-secty-with-app-sample.yml
@@ -500,11 +500,11 @@ services:
         source: kuiper-plugins
         target: /kuiper/plugins
         volume: {}
-  support-cron-scheduler:
+  support-scheduler:
     command:
       - --registry
       - -cp=keeper.http://edgex-core-keeper:59890
-    container_name: edgex-support-cron-scheduler
+    container_name: edgex-support-scheduler
     depends_on:
       core-common-config-bootstrapper:
         condition: service_started
@@ -517,9 +517,9 @@ services:
         required: true
     environment:
       EDGEX_SECURITY_SECRET_STORE: "false"
-      SERVICE_HOST: edgex-support-cron-scheduler
-    hostname: edgex-support-cron-scheduler
-    image: nexus3.edgexfoundry.org:10004/support-cron-scheduler:latest
+      SERVICE_HOST: edgex-support-scheduler
+    hostname: edgex-support-scheduler
+    image: nexus3.edgexfoundry.org:10004/support-scheduler:latest
     networks:
       edgex-network: null
     ports:

--- a/docker-compose-no-secty.yml
+++ b/docker-compose-no-secty.yml
@@ -456,11 +456,11 @@ services:
         source: kuiper-plugins
         target: /kuiper/plugins
         volume: {}
-  support-cron-scheduler:
+  support-scheduler:
     command:
       - --registry
       - -cp=keeper.http://edgex-core-keeper:59890
-    container_name: edgex-support-cron-scheduler
+    container_name: edgex-support-scheduler
     depends_on:
       core-common-config-bootstrapper:
         condition: service_started
@@ -473,9 +473,9 @@ services:
         required: true
     environment:
       EDGEX_SECURITY_SECRET_STORE: "false"
-      SERVICE_HOST: edgex-support-cron-scheduler
-    hostname: edgex-support-cron-scheduler
-    image: nexus3.edgexfoundry.org:10004/support-cron-scheduler:latest
+      SERVICE_HOST: edgex-support-scheduler
+    hostname: edgex-support-scheduler
+    image: nexus3.edgexfoundry.org:10004/support-scheduler:latest
     networks:
       edgex-network: null
     ports:

--- a/docker-compose-with-app-sample-arm64.yml
+++ b/docker-compose-with-app-sample-arm64.yml
@@ -1260,12 +1260,12 @@ services:
         source: kuiper-connections
         target: /tmp/kuiper-connections
         volume: {}
-  support-cron-scheduler:
+  support-scheduler:
     command:
-      - /support-cron-scheduler
+      - /support-scheduler
       - --registry
       - -cp=keeper.http://edgex-core-keeper:59890
-    container_name: edgex-support-cron-scheduler
+    container_name: edgex-support-scheduler
     depends_on:
       core-common-config-bootstrapper:
         condition: service_started
@@ -1288,7 +1288,7 @@ services:
       EDGEX_SECURITY_SECRET_STORE: "true"
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       SECRETSTORE_HOST: edgex-secret-store
-      SERVICE_HOST: edgex-support-cron-scheduler
+      SERVICE_HOST: edgex-support-scheduler
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
       STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-postgres
@@ -1302,8 +1302,8 @@ services:
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
       STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
-    hostname: edgex-support-cron-scheduler
-    image: nexus3.edgexfoundry.org:10004/support-cron-scheduler-arm64:latest
+    hostname: edgex-support-scheduler
+    image: nexus3.edgexfoundry.org:10004/support-scheduler-arm64:latest
     networks:
       edgex-network: null
     ports:
@@ -1330,8 +1330,8 @@ services:
         read_only: true
         volume: {}
       - type: bind
-        source: /tmp/edgex/secrets/support-cron-scheduler
-        target: /tmp/edgex/secrets/support-cron-scheduler
+        source: /tmp/edgex/secrets/support-scheduler
+        target: /tmp/edgex/secrets/support-scheduler
         read_only: true
         bind:
           selinux: z

--- a/docker-compose-with-app-sample.yml
+++ b/docker-compose-with-app-sample.yml
@@ -1260,12 +1260,12 @@ services:
         source: kuiper-connections
         target: /tmp/kuiper-connections
         volume: {}
-  support-cron-scheduler:
+  support-scheduler:
     command:
-      - /support-cron-scheduler
+      - /support-scheduler
       - --registry
       - -cp=keeper.http://edgex-core-keeper:59890
-    container_name: edgex-support-cron-scheduler
+    container_name: edgex-support-scheduler
     depends_on:
       core-common-config-bootstrapper:
         condition: service_started
@@ -1288,7 +1288,7 @@ services:
       EDGEX_SECURITY_SECRET_STORE: "true"
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       SECRETSTORE_HOST: edgex-secret-store
-      SERVICE_HOST: edgex-support-cron-scheduler
+      SERVICE_HOST: edgex-support-scheduler
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
       STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-postgres
@@ -1302,8 +1302,8 @@ services:
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
       STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
-    hostname: edgex-support-cron-scheduler
-    image: nexus3.edgexfoundry.org:10004/support-cron-scheduler:latest
+    hostname: edgex-support-scheduler
+    image: nexus3.edgexfoundry.org:10004/support-scheduler:latest
     networks:
       edgex-network: null
     ports:
@@ -1330,8 +1330,8 @@ services:
         read_only: true
         volume: {}
       - type: bind
-        source: /tmp/edgex/secrets/support-cron-scheduler
-        target: /tmp/edgex/secrets/support-cron-scheduler
+        source: /tmp/edgex/secrets/support-scheduler
+        target: /tmp/edgex/secrets/support-scheduler
         read_only: true
         bind:
           selinux: z

--- a/docker-compose-zero-trust-arm64.yml
+++ b/docker-compose-zero-trust-arm64.yml
@@ -966,12 +966,12 @@ services:
         source: kuiper-connections
         target: /tmp/kuiper-connections
         volume: {}
-  support-cron-scheduler:
+  support-scheduler:
     command:
-      - /support-cron-scheduler
+      - /support-scheduler
       - --registry
       - -cp=keeper.http://edgex-core-keeper:59890
-    container_name: edgex-support-cron-scheduler
+    container_name: edgex-support-scheduler
     depends_on:
       core-common-config-bootstrapper:
         condition: service_started
@@ -994,7 +994,7 @@ services:
       EDGEX_SECURITY_SECRET_STORE: "true"
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       SECRETSTORE_HOST: edgex-secret-store
-      SERVICE_HOST: edgex-support-cron-scheduler
+      SERVICE_HOST: edgex-support-scheduler
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
       STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-postgres
@@ -1008,8 +1008,8 @@ services:
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
       STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
-    hostname: edgex-support-cron-scheduler
-    image: nexus3.edgexfoundry.org:10004/support-cron-scheduler-arm64:latest
+    hostname: edgex-support-scheduler
+    image: nexus3.edgexfoundry.org:10004/support-scheduler-arm64:latest
     networks:
       edgex-network: null
     ports:
@@ -1036,8 +1036,8 @@ services:
         read_only: true
         volume: {}
       - type: bind
-        source: /tmp/edgex/secrets/support-cron-scheduler
-        target: /tmp/edgex/secrets/support-cron-scheduler
+        source: /tmp/edgex/secrets/support-scheduler
+        target: /tmp/edgex/secrets/support-scheduler
         read_only: true
         bind:
           selinux: z

--- a/docker-compose-zero-trust.yml
+++ b/docker-compose-zero-trust.yml
@@ -966,12 +966,12 @@ services:
         source: kuiper-connections
         target: /tmp/kuiper-connections
         volume: {}
-  support-cron-scheduler:
+  support-scheduler:
     command:
-      - /support-cron-scheduler
+      - /support-scheduler
       - --registry
       - -cp=keeper.http://edgex-core-keeper:59890
-    container_name: edgex-support-cron-scheduler
+    container_name: edgex-support-scheduler
     depends_on:
       core-common-config-bootstrapper:
         condition: service_started
@@ -994,7 +994,7 @@ services:
       EDGEX_SECURITY_SECRET_STORE: "true"
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       SECRETSTORE_HOST: edgex-secret-store
-      SERVICE_HOST: edgex-support-cron-scheduler
+      SERVICE_HOST: edgex-support-scheduler
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
       STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-postgres
@@ -1008,8 +1008,8 @@ services:
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
       STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
-    hostname: edgex-support-cron-scheduler
-    image: nexus3.edgexfoundry.org:10004/support-cron-scheduler:latest
+    hostname: edgex-support-scheduler
+    image: nexus3.edgexfoundry.org:10004/support-scheduler:latest
     networks:
       edgex-network: null
     ports:
@@ -1036,8 +1036,8 @@ services:
         read_only: true
         volume: {}
       - type: bind
-        source: /tmp/edgex/secrets/support-cron-scheduler
-        target: /tmp/edgex/secrets/support-cron-scheduler
+        source: /tmp/edgex/secrets/support-scheduler
+        target: /tmp/edgex/secrets/support-scheduler
         read_only: true
         bind:
           selinux: z

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1183,12 +1183,12 @@ services:
         source: kuiper-connections
         target: /tmp/kuiper-connections
         volume: {}
-  support-cron-scheduler:
+  support-scheduler:
     command:
-      - /support-cron-scheduler
+      - /support-scheduler
       - --registry
       - -cp=keeper.http://edgex-core-keeper:59890
-    container_name: edgex-support-cron-scheduler
+    container_name: edgex-support-scheduler
     depends_on:
       core-common-config-bootstrapper:
         condition: service_started
@@ -1211,7 +1211,7 @@ services:
       EDGEX_SECURITY_SECRET_STORE: "true"
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       SECRETSTORE_HOST: edgex-secret-store
-      SERVICE_HOST: edgex-support-cron-scheduler
+      SERVICE_HOST: edgex-support-scheduler
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
       STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-postgres
@@ -1225,8 +1225,8 @@ services:
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
       STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
-    hostname: edgex-support-cron-scheduler
-    image: nexus3.edgexfoundry.org:10004/support-cron-scheduler:latest
+    hostname: edgex-support-scheduler
+    image: nexus3.edgexfoundry.org:10004/support-scheduler:latest
     networks:
       edgex-network: null
     ports:
@@ -1253,8 +1253,8 @@ services:
         read_only: true
         volume: {}
       - type: bind
-        source: /tmp/edgex/secrets/support-cron-scheduler
-        target: /tmp/edgex/secrets/support-cron-scheduler
+        source: /tmp/edgex/secrets/support-scheduler
+        target: /tmp/edgex/secrets/support-scheduler
         read_only: true
         bind:
           selinux: z

--- a/taf/docker-compose-taf-arm64.yml
+++ b/taf/docker-compose-taf-arm64.yml
@@ -2181,12 +2181,12 @@ services:
         bind:
           selinux: z
           create_host_path: true
-  support-cron-scheduler:
+  support-scheduler:
     command:
-      - /support-cron-scheduler
+      - /support-scheduler
       - --registry
       - -cp=keeper.http://edgex-core-keeper:59890
-    container_name: edgex-support-cron-scheduler
+    container_name: edgex-support-scheduler
     depends_on:
       core-common-config-bootstrapper:
         condition: service_started
@@ -2209,7 +2209,7 @@ services:
       EDGEX_SECURITY_SECRET_STORE: "true"
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       SECRETSTORE_HOST: edgex-secret-store
-      SERVICE_HOST: edgex-support-cron-scheduler
+      SERVICE_HOST: edgex-support-scheduler
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
       STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-postgres
@@ -2223,8 +2223,8 @@ services:
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
       STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
-    hostname: edgex-support-cron-scheduler
-    image: nexus3.edgexfoundry.org:10004/support-cron-scheduler-arm64:latest
+    hostname: edgex-support-scheduler
+    image: nexus3.edgexfoundry.org:10004/support-scheduler-arm64:latest
     networks:
       edgex-network: null
     ports:
@@ -2251,8 +2251,8 @@ services:
         read_only: true
         volume: {}
       - type: bind
-        source: /tmp/edgex/secrets/support-cron-scheduler
-        target: /tmp/edgex/secrets/support-cron-scheduler
+        source: /tmp/edgex/secrets/support-scheduler
+        target: /tmp/edgex/secrets/support-scheduler
         read_only: true
         bind:
           selinux: z

--- a/taf/docker-compose-taf-no-secty-arm64.yml
+++ b/taf/docker-compose-taf-no-secty-arm64.yml
@@ -871,11 +871,11 @@ services:
         source: kuiper-plugins
         target: /kuiper/plugins
         volume: {}
-  support-cron-scheduler:
+  support-scheduler:
     command:
       - --registry
       - -cp=keeper.http://edgex-core-keeper:59890
-    container_name: edgex-support-cron-scheduler
+    container_name: edgex-support-scheduler
     depends_on:
       core-common-config-bootstrapper:
         condition: service_started
@@ -888,9 +888,9 @@ services:
         required: true
     environment:
       EDGEX_SECURITY_SECRET_STORE: "false"
-      SERVICE_HOST: edgex-support-cron-scheduler
-    hostname: edgex-support-cron-scheduler
-    image: nexus3.edgexfoundry.org:10004/support-cron-scheduler-arm64:latest
+      SERVICE_HOST: edgex-support-scheduler
+    hostname: edgex-support-scheduler
+    image: nexus3.edgexfoundry.org:10004/support-scheduler-arm64:latest
     networks:
       edgex-network: null
     ports:

--- a/taf/docker-compose-taf-no-secty.yml
+++ b/taf/docker-compose-taf-no-secty.yml
@@ -871,11 +871,11 @@ services:
         source: kuiper-plugins
         target: /kuiper/plugins
         volume: {}
-  support-cron-scheduler:
+  support-scheduler:
     command:
       - --registry
       - -cp=keeper.http://edgex-core-keeper:59890
-    container_name: edgex-support-cron-scheduler
+    container_name: edgex-support-scheduler
     depends_on:
       core-common-config-bootstrapper:
         condition: service_started
@@ -888,9 +888,9 @@ services:
         required: true
     environment:
       EDGEX_SECURITY_SECRET_STORE: "false"
-      SERVICE_HOST: edgex-support-cron-scheduler
-    hostname: edgex-support-cron-scheduler
-    image: nexus3.edgexfoundry.org:10004/support-cron-scheduler:latest
+      SERVICE_HOST: edgex-support-scheduler
+    hostname: edgex-support-scheduler
+    image: nexus3.edgexfoundry.org:10004/support-scheduler:latest
     networks:
       edgex-network: null
     ports:

--- a/taf/docker-compose-taf-perf-arm64.yml
+++ b/taf/docker-compose-taf-perf-arm64.yml
@@ -1552,12 +1552,12 @@ services:
         bind:
           selinux: z
           create_host_path: true
-  support-cron-scheduler:
+  support-scheduler:
     command:
-      - /support-cron-scheduler
+      - /support-scheduler
       - --registry
       - -cp=keeper.http://edgex-core-keeper:59890
-    container_name: edgex-support-cron-scheduler
+    container_name: edgex-support-scheduler
     depends_on:
       core-common-config-bootstrapper:
         condition: service_started
@@ -1580,7 +1580,7 @@ services:
       EDGEX_SECURITY_SECRET_STORE: "true"
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       SECRETSTORE_HOST: edgex-secret-store
-      SERVICE_HOST: edgex-support-cron-scheduler
+      SERVICE_HOST: edgex-support-scheduler
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
       STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-postgres
@@ -1594,8 +1594,8 @@ services:
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
       STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
-    hostname: edgex-support-cron-scheduler
-    image: nexus3.edgexfoundry.org:10004/support-cron-scheduler-arm64:latest
+    hostname: edgex-support-scheduler
+    image: nexus3.edgexfoundry.org:10004/support-scheduler-arm64:latest
     networks:
       edgex-network: null
     ports:
@@ -1622,8 +1622,8 @@ services:
         read_only: true
         volume: {}
       - type: bind
-        source: /tmp/edgex/secrets/support-cron-scheduler
-        target: /tmp/edgex/secrets/support-cron-scheduler
+        source: /tmp/edgex/secrets/support-scheduler
+        target: /tmp/edgex/secrets/support-scheduler
         read_only: true
         bind:
           selinux: z

--- a/taf/docker-compose-taf-perf-no-secty-arm64.yml
+++ b/taf/docker-compose-taf-perf-no-secty-arm64.yml
@@ -521,11 +521,11 @@ services:
         source: kuiper-plugins
         target: /kuiper/plugins
         volume: {}
-  support-cron-scheduler:
+  support-scheduler:
     command:
       - --registry
       - -cp=keeper.http://edgex-core-keeper:59890
-    container_name: edgex-support-cron-scheduler
+    container_name: edgex-support-scheduler
     depends_on:
       core-common-config-bootstrapper:
         condition: service_started
@@ -538,9 +538,9 @@ services:
         required: true
     environment:
       EDGEX_SECURITY_SECRET_STORE: "false"
-      SERVICE_HOST: edgex-support-cron-scheduler
-    hostname: edgex-support-cron-scheduler
-    image: nexus3.edgexfoundry.org:10004/support-cron-scheduler-arm64:latest
+      SERVICE_HOST: edgex-support-scheduler
+    hostname: edgex-support-scheduler
+    image: nexus3.edgexfoundry.org:10004/support-scheduler-arm64:latest
     networks:
       edgex-network: null
     ports:

--- a/taf/docker-compose-taf-perf-no-secty.yml
+++ b/taf/docker-compose-taf-perf-no-secty.yml
@@ -521,11 +521,11 @@ services:
         source: kuiper-plugins
         target: /kuiper/plugins
         volume: {}
-  support-cron-scheduler:
+  support-scheduler:
     command:
       - --registry
       - -cp=keeper.http://edgex-core-keeper:59890
-    container_name: edgex-support-cron-scheduler
+    container_name: edgex-support-scheduler
     depends_on:
       core-common-config-bootstrapper:
         condition: service_started
@@ -538,9 +538,9 @@ services:
         required: true
     environment:
       EDGEX_SECURITY_SECRET_STORE: "false"
-      SERVICE_HOST: edgex-support-cron-scheduler
-    hostname: edgex-support-cron-scheduler
-    image: nexus3.edgexfoundry.org:10004/support-cron-scheduler:latest
+      SERVICE_HOST: edgex-support-scheduler
+    hostname: edgex-support-scheduler
+    image: nexus3.edgexfoundry.org:10004/support-scheduler:latest
     networks:
       edgex-network: null
     ports:

--- a/taf/docker-compose-taf-perf.yml
+++ b/taf/docker-compose-taf-perf.yml
@@ -1552,12 +1552,12 @@ services:
         bind:
           selinux: z
           create_host_path: true
-  support-cron-scheduler:
+  support-scheduler:
     command:
-      - /support-cron-scheduler
+      - /support-scheduler
       - --registry
       - -cp=keeper.http://edgex-core-keeper:59890
-    container_name: edgex-support-cron-scheduler
+    container_name: edgex-support-scheduler
     depends_on:
       core-common-config-bootstrapper:
         condition: service_started
@@ -1580,7 +1580,7 @@ services:
       EDGEX_SECURITY_SECRET_STORE: "true"
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       SECRETSTORE_HOST: edgex-secret-store
-      SERVICE_HOST: edgex-support-cron-scheduler
+      SERVICE_HOST: edgex-support-scheduler
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
       STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-postgres
@@ -1594,8 +1594,8 @@ services:
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
       STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
-    hostname: edgex-support-cron-scheduler
-    image: nexus3.edgexfoundry.org:10004/support-cron-scheduler:latest
+    hostname: edgex-support-scheduler
+    image: nexus3.edgexfoundry.org:10004/support-scheduler:latest
     networks:
       edgex-network: null
     ports:
@@ -1622,8 +1622,8 @@ services:
         read_only: true
         volume: {}
       - type: bind
-        source: /tmp/edgex/secrets/support-cron-scheduler
-        target: /tmp/edgex/secrets/support-cron-scheduler
+        source: /tmp/edgex/secrets/support-scheduler
+        target: /tmp/edgex/secrets/support-scheduler
         read_only: true
         bind:
           selinux: z

--- a/taf/docker-compose-taf.yml
+++ b/taf/docker-compose-taf.yml
@@ -2181,12 +2181,12 @@ services:
         bind:
           selinux: z
           create_host_path: true
-  support-cron-scheduler:
+  support-scheduler:
     command:
-      - /support-cron-scheduler
+      - /support-scheduler
       - --registry
       - -cp=keeper.http://edgex-core-keeper:59890
-    container_name: edgex-support-cron-scheduler
+    container_name: edgex-support-scheduler
     depends_on:
       core-common-config-bootstrapper:
         condition: service_started
@@ -2209,7 +2209,7 @@ services:
       EDGEX_SECURITY_SECRET_STORE: "true"
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       SECRETSTORE_HOST: edgex-secret-store
-      SERVICE_HOST: edgex-support-cron-scheduler
+      SERVICE_HOST: edgex-support-scheduler
       STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
       STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
       STAGEGATE_DATABASE_HOST: edgex-postgres
@@ -2223,8 +2223,8 @@ services:
       STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
       STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
       STAGEGATE_WAITFOR_TIMEOUT: 60s
-    hostname: edgex-support-cron-scheduler
-    image: nexus3.edgexfoundry.org:10004/support-cron-scheduler:latest
+    hostname: edgex-support-scheduler
+    image: nexus3.edgexfoundry.org:10004/support-scheduler:latest
     networks:
       edgex-network: null
     ports:
@@ -2251,8 +2251,8 @@ services:
         read_only: true
         volume: {}
       - type: bind
-        source: /tmp/edgex/secrets/support-cron-scheduler
-        target: /tmp/edgex/secrets/support-cron-scheduler
+        source: /tmp/edgex/secrets/support-scheduler
+        target: /tmp/edgex/secrets/support-scheduler
         read_only: true
         bind:
           selinux: z


### PR DESCRIPTION
BREAKING CHANGE: the cron scheduler name and key changed

Replace the old Scheduler service with the new cron Scheduler service

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-compose/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-compose/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [ ] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>


## Testing Instructions
<!-- How can the reviewers test your change? -->
