### PR TITLE
fix: Add CLIENTS_SECURITY_PROXY_AUTH_HOST env var

### DIFF
--- a/compose-builder/add-security.yml
+++ b/compose-builder/add-security.yml
@@ -1,5 +1,6 @@
 # /*******************************************************************************
 #  * Copyright 2024 Intel Corporation.
+#  * Copyright 2025 IOTech Ltd
 #  *
 #  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 #  * in compliance with the License. You may obtain a copy of the License at
@@ -124,6 +125,8 @@ services:
     env_file:
       - common-security.env
       - common-sec-stage-gate.env
+    environment:
+      CLIENTS_SECURITY_PROXY_AUTH_HOST: security-proxy-auth
     volumes:
       - edgex-init:/edgex-init:ro
       - /tmp/edgex/secrets/core-keeper:/tmp/edgex/secrets/core-keeper:ro,z
@@ -200,6 +203,8 @@ services:
     env_file:
       - common-security.env
       - common-sec-stage-gate.env
+    environment:
+      ALL_SERVICES_CLIENTS_SECURITY_PROXY_AUTH_HOST: security-proxy-auth
     entrypoint: ["/edgex-init/ready_to_run_wait_install.sh"]
     command: /entrypoint.sh /core-common-config-bootstrapper --registry ${CP_FLAGS}
     volumes:

--- a/docker-compose-arm64.yml
+++ b/docker-compose-arm64.yml
@@ -201,6 +201,7 @@ services:
     entrypoint:
       - /edgex-init/ready_to_run_wait_install.sh
     environment:
+      ALL_SERVICES_CLIENTS_SECURITY_PROXY_AUTH_HOST: security-proxy-auth
       ALL_SERVICES_DATABASE_HOST: edgex-postgres
       ALL_SERVICES_MESSAGEBUS_AUTHMODE: usernamepassword
       ALL_SERVICES_MESSAGEBUS_HOST: edgex-mqtt-broker
@@ -342,6 +343,7 @@ services:
         condition: service_started
         required: true
     environment:
+      CLIENTS_SECURITY_PROXY_AUTH_HOST: security-proxy-auth
       DATABASE_HOST: edgex-postgres
       EDGEX_SECURITY_SECRET_STORE: "true"
       MESSAGEBUS_AUTHMODE: usernamepassword
@@ -888,7 +890,7 @@ services:
     deploy:
       resources:
         limits:
-          memory: "6353502339072"
+          memory: "6353435230208"
     entrypoint:
       - /edgex-init/secretstore_wait_install.sh
     environment:
@@ -912,7 +914,7 @@ services:
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-secret-store
     image: openbao/openbao:2.1
-    memswap_limit: "6353502339072"
+    memswap_limit: "6353435230208"
     networks:
       edgex-network: null
     ports:

--- a/docker-compose-with-app-sample-arm64.yml
+++ b/docker-compose-with-app-sample-arm64.yml
@@ -278,6 +278,7 @@ services:
     entrypoint:
       - /edgex-init/ready_to_run_wait_install.sh
     environment:
+      ALL_SERVICES_CLIENTS_SECURITY_PROXY_AUTH_HOST: security-proxy-auth
       ALL_SERVICES_DATABASE_HOST: edgex-postgres
       ALL_SERVICES_MESSAGEBUS_AUTHMODE: usernamepassword
       ALL_SERVICES_MESSAGEBUS_HOST: edgex-mqtt-broker
@@ -419,6 +420,7 @@ services:
         condition: service_started
         required: true
     environment:
+      CLIENTS_SECURITY_PROXY_AUTH_HOST: security-proxy-auth
       DATABASE_HOST: edgex-postgres
       EDGEX_SECURITY_SECRET_STORE: "true"
       MESSAGEBUS_AUTHMODE: usernamepassword
@@ -965,7 +967,7 @@ services:
     deploy:
       resources:
         limits:
-          memory: "6353502339072"
+          memory: "6353435230208"
     entrypoint:
       - /edgex-init/secretstore_wait_install.sh
     environment:
@@ -989,7 +991,7 @@ services:
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-secret-store
     image: openbao/openbao:2.1
-    memswap_limit: "6353502339072"
+    memswap_limit: "6353435230208"
     networks:
       edgex-network: null
     ports:

--- a/docker-compose-with-app-sample.yml
+++ b/docker-compose-with-app-sample.yml
@@ -278,6 +278,7 @@ services:
     entrypoint:
       - /edgex-init/ready_to_run_wait_install.sh
     environment:
+      ALL_SERVICES_CLIENTS_SECURITY_PROXY_AUTH_HOST: security-proxy-auth
       ALL_SERVICES_DATABASE_HOST: edgex-postgres
       ALL_SERVICES_MESSAGEBUS_AUTHMODE: usernamepassword
       ALL_SERVICES_MESSAGEBUS_HOST: edgex-mqtt-broker
@@ -419,6 +420,7 @@ services:
         condition: service_started
         required: true
     environment:
+      CLIENTS_SECURITY_PROXY_AUTH_HOST: security-proxy-auth
       DATABASE_HOST: edgex-postgres
       EDGEX_SECURITY_SECRET_STORE: "true"
       MESSAGEBUS_AUTHMODE: usernamepassword
@@ -965,7 +967,7 @@ services:
     deploy:
       resources:
         limits:
-          memory: "6353502339072"
+          memory: "6353435230208"
     entrypoint:
       - /edgex-init/secretstore_wait_install.sh
     environment:
@@ -989,7 +991,7 @@ services:
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-secret-store
     image: openbao/openbao:2.1
-    memswap_limit: "6353502339072"
+    memswap_limit: "6353435230208"
     networks:
       edgex-network: null
     ports:

--- a/docker-compose-zero-trust-arm64.yml
+++ b/docker-compose-zero-trust-arm64.yml
@@ -194,6 +194,7 @@ services:
     entrypoint:
       - /edgex-init/ready_to_run_wait_install.sh
     environment:
+      ALL_SERVICES_CLIENTS_SECURITY_PROXY_AUTH_HOST: security-proxy-auth
       ALL_SERVICES_DATABASE_HOST: edgex-postgres
       ALL_SERVICES_MESSAGEBUS_AUTHMODE: usernamepassword
       ALL_SERVICES_MESSAGEBUS_HOST: edgex-mqtt-broker
@@ -335,6 +336,7 @@ services:
         condition: service_started
         required: true
     environment:
+      CLIENTS_SECURITY_PROXY_AUTH_HOST: security-proxy-auth
       DATABASE_HOST: edgex-postgres
       EDGEX_SECURITY_SECRET_STORE: "true"
       MESSAGEBUS_AUTHMODE: usernamepassword
@@ -808,7 +810,7 @@ services:
     deploy:
       resources:
         limits:
-          memory: "6353502339072"
+          memory: "6353435230208"
     entrypoint:
       - /edgex-init/secretstore_wait_install.sh
     environment:
@@ -832,7 +834,7 @@ services:
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-secret-store
     image: openbao/openbao:2.1
-    memswap_limit: "6353502339072"
+    memswap_limit: "6353435230208"
     networks:
       edgex-network: null
     ports:

--- a/docker-compose-zero-trust.yml
+++ b/docker-compose-zero-trust.yml
@@ -194,6 +194,7 @@ services:
     entrypoint:
       - /edgex-init/ready_to_run_wait_install.sh
     environment:
+      ALL_SERVICES_CLIENTS_SECURITY_PROXY_AUTH_HOST: security-proxy-auth
       ALL_SERVICES_DATABASE_HOST: edgex-postgres
       ALL_SERVICES_MESSAGEBUS_AUTHMODE: usernamepassword
       ALL_SERVICES_MESSAGEBUS_HOST: edgex-mqtt-broker
@@ -335,6 +336,7 @@ services:
         condition: service_started
         required: true
     environment:
+      CLIENTS_SECURITY_PROXY_AUTH_HOST: security-proxy-auth
       DATABASE_HOST: edgex-postgres
       EDGEX_SECURITY_SECRET_STORE: "true"
       MESSAGEBUS_AUTHMODE: usernamepassword
@@ -808,7 +810,7 @@ services:
     deploy:
       resources:
         limits:
-          memory: "6353502339072"
+          memory: "6353435230208"
     entrypoint:
       - /edgex-init/secretstore_wait_install.sh
     environment:
@@ -832,7 +834,7 @@ services:
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-secret-store
     image: openbao/openbao:2.1
-    memswap_limit: "6353502339072"
+    memswap_limit: "6353435230208"
     networks:
       edgex-network: null
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -201,6 +201,7 @@ services:
     entrypoint:
       - /edgex-init/ready_to_run_wait_install.sh
     environment:
+      ALL_SERVICES_CLIENTS_SECURITY_PROXY_AUTH_HOST: security-proxy-auth
       ALL_SERVICES_DATABASE_HOST: edgex-postgres
       ALL_SERVICES_MESSAGEBUS_AUTHMODE: usernamepassword
       ALL_SERVICES_MESSAGEBUS_HOST: edgex-mqtt-broker
@@ -342,6 +343,7 @@ services:
         condition: service_started
         required: true
     environment:
+      CLIENTS_SECURITY_PROXY_AUTH_HOST: security-proxy-auth
       DATABASE_HOST: edgex-postgres
       EDGEX_SECURITY_SECRET_STORE: "true"
       MESSAGEBUS_AUTHMODE: usernamepassword
@@ -888,7 +890,7 @@ services:
     deploy:
       resources:
         limits:
-          memory: "6353502339072"
+          memory: "6353435230208"
     entrypoint:
       - /edgex-init/secretstore_wait_install.sh
     environment:
@@ -912,7 +914,7 @@ services:
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-secret-store
     image: openbao/openbao:2.1
-    memswap_limit: "6353502339072"
+    memswap_limit: "6353435230208"
     networks:
       edgex-network: null
     ports:

--- a/taf/docker-compose-taf-arm64.yml
+++ b/taf/docker-compose-taf-arm64.yml
@@ -667,6 +667,7 @@ services:
     entrypoint:
       - /edgex-init/ready_to_run_wait_install.sh
     environment:
+      ALL_SERVICES_CLIENTS_SECURITY_PROXY_AUTH_HOST: security-proxy-auth
       ALL_SERVICES_DATABASE_HOST: edgex-postgres
       ALL_SERVICES_MESSAGEBUS_AUTHMODE: usernamepassword
       ALL_SERVICES_MESSAGEBUS_HOST: edgex-mqtt-broker
@@ -808,6 +809,7 @@ services:
         condition: service_started
         required: true
     environment:
+      CLIENTS_SECURITY_PROXY_AUTH_HOST: security-proxy-auth
       DATABASE_HOST: edgex-postgres
       EDGEX_SECURITY_SECRET_STORE: "true"
       MESSAGEBUS_AUTHMODE: usernamepassword
@@ -1615,7 +1617,7 @@ services:
     deploy:
       resources:
         limits:
-          memory: "6353502339072"
+          memory: "6353435230208"
     entrypoint:
       - /edgex-init/secretstore_wait_install.sh
     environment:
@@ -1639,7 +1641,7 @@ services:
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-secret-store
     image: openbao/openbao:2.1
-    memswap_limit: "6353502339072"
+    memswap_limit: "6353435230208"
     networks:
       edgex-network: null
     ports:

--- a/taf/docker-compose-taf-perf-arm64.yml
+++ b/taf/docker-compose-taf-perf-arm64.yml
@@ -278,6 +278,7 @@ services:
     entrypoint:
       - /edgex-init/ready_to_run_wait_install.sh
     environment:
+      ALL_SERVICES_CLIENTS_SECURITY_PROXY_AUTH_HOST: security-proxy-auth
       ALL_SERVICES_DATABASE_HOST: edgex-postgres
       ALL_SERVICES_MESSAGEBUS_AUTHMODE: usernamepassword
       ALL_SERVICES_MESSAGEBUS_HOST: edgex-mqtt-broker
@@ -419,6 +420,7 @@ services:
         condition: service_started
         required: true
     environment:
+      CLIENTS_SECURITY_PROXY_AUTH_HOST: security-proxy-auth
       DATABASE_HOST: edgex-postgres
       EDGEX_SECURITY_SECRET_STORE: "true"
       MESSAGEBUS_AUTHMODE: usernamepassword
@@ -986,7 +988,7 @@ services:
     deploy:
       resources:
         limits:
-          memory: "6353502339072"
+          memory: "6353435230208"
     entrypoint:
       - /edgex-init/secretstore_wait_install.sh
     environment:
@@ -1010,7 +1012,7 @@ services:
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-secret-store
     image: openbao/openbao:2.1
-    memswap_limit: "6353502339072"
+    memswap_limit: "6353435230208"
     networks:
       edgex-network: null
     ports:

--- a/taf/docker-compose-taf-perf.yml
+++ b/taf/docker-compose-taf-perf.yml
@@ -278,6 +278,7 @@ services:
     entrypoint:
       - /edgex-init/ready_to_run_wait_install.sh
     environment:
+      ALL_SERVICES_CLIENTS_SECURITY_PROXY_AUTH_HOST: security-proxy-auth
       ALL_SERVICES_DATABASE_HOST: edgex-postgres
       ALL_SERVICES_MESSAGEBUS_AUTHMODE: usernamepassword
       ALL_SERVICES_MESSAGEBUS_HOST: edgex-mqtt-broker
@@ -419,6 +420,7 @@ services:
         condition: service_started
         required: true
     environment:
+      CLIENTS_SECURITY_PROXY_AUTH_HOST: security-proxy-auth
       DATABASE_HOST: edgex-postgres
       EDGEX_SECURITY_SECRET_STORE: "true"
       MESSAGEBUS_AUTHMODE: usernamepassword
@@ -986,7 +988,7 @@ services:
     deploy:
       resources:
         limits:
-          memory: "6353502339072"
+          memory: "6353435230208"
     entrypoint:
       - /edgex-init/secretstore_wait_install.sh
     environment:
@@ -1010,7 +1012,7 @@ services:
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-secret-store
     image: openbao/openbao:2.1
-    memswap_limit: "6353502339072"
+    memswap_limit: "6353435230208"
     networks:
       edgex-network: null
     ports:

--- a/taf/docker-compose-taf.yml
+++ b/taf/docker-compose-taf.yml
@@ -667,6 +667,7 @@ services:
     entrypoint:
       - /edgex-init/ready_to_run_wait_install.sh
     environment:
+      ALL_SERVICES_CLIENTS_SECURITY_PROXY_AUTH_HOST: security-proxy-auth
       ALL_SERVICES_DATABASE_HOST: edgex-postgres
       ALL_SERVICES_MESSAGEBUS_AUTHMODE: usernamepassword
       ALL_SERVICES_MESSAGEBUS_HOST: edgex-mqtt-broker
@@ -808,6 +809,7 @@ services:
         condition: service_started
         required: true
     environment:
+      CLIENTS_SECURITY_PROXY_AUTH_HOST: security-proxy-auth
       DATABASE_HOST: edgex-postgres
       EDGEX_SECURITY_SECRET_STORE: "true"
       MESSAGEBUS_AUTHMODE: usernamepassword
@@ -1615,7 +1617,7 @@ services:
     deploy:
       resources:
         limits:
-          memory: "6353502339072"
+          memory: "6353435230208"
     entrypoint:
       - /edgex-init/secretstore_wait_install.sh
     environment:
@@ -1639,7 +1641,7 @@ services:
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-secret-store
     image: openbao/openbao:2.1
-    memswap_limit: "6353502339072"
+    memswap_limit: "6353435230208"
     networks:
       edgex-network: null
     ports:


### PR DESCRIPTION
Fixes #484. Add CLIENTS_SECURITY_PROXY_AUTH_HOST env var with security enabled.

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-compose/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-compose/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [x] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>


## Testing Instructions
<!-- How can the reviewers test your change? -->
