### PR TITLE
fix: Add support-scheduler back to delayed-start function

### DIFF
--- a/compose-builder/Makefile
+++ b/compose-builder/Makefile
@@ -140,6 +140,7 @@ ifeq (delayed-start,$(filter delayed-start,$(ARGS)))
 
     # Generate runtime token config for support services
     ext_file_sup_notif := $(shell ZERO_TRUST="$(MAKE_ZERO_TRUST)" GEN_EXT_DIR="$(GEN_EXT_DIR)" ./gen_runtime_token_config_compose_ext.sh support-notifications)
+	ext_file_sup_sch := $(shell ZERO_TRUST="$(MAKE_ZERO_TRUST)" GEN_EXT_DIR="$(GEN_EXT_DIR)"  ./gen_runtime_token_config_compose_ext.sh support-scheduler)
 
     # Add generated config files to COMPOSE_FILES
     COMPOSE_FILES += -f $(ext_file_sup_notif) -f $(ext_file_sup_sch)


### PR DESCRIPTION
Closes #492 

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-compose/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-compose/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [X] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?) Not necessary.
  <link to docs PR>


## Testing Instructions
<!-- How can the reviewers test your change? -->
