### PR TITLE
fix: the edge-ui-go cannot run up due to missing secret volumes

### DIFF
--- a/compose-builder/add-security.yml
+++ b/compose-builder/add-security.yml
@@ -229,8 +229,6 @@ services:
       - security-bootstrapper
 
   ui:
-    environment:
-      EDGEX_SECURITY_SECRET_STORE: "true"
     env_file:
       - common-security.env
       - common-sec-stage-gate.env

--- a/compose-builder/add-security.yml
+++ b/compose-builder/add-security.yml
@@ -229,6 +229,8 @@ services:
       - security-bootstrapper
 
   ui:
+    environment:
+      EDGEX_SECURITY_SECRET_STORE: "true"
     env_file:
       - common-security.env
       - common-sec-stage-gate.env

--- a/compose-builder/add-security.yml
+++ b/compose-builder/add-security.yml
@@ -229,5 +229,14 @@ services:
       - security-bootstrapper
 
   ui:
-    environment:
-      EDGEX_SECURITY_SECRET_STORE: "true"
+    env_file:
+      - common-security.env
+      - common-sec-stage-gate.env
+    entrypoint: [ "/edgex-init/ready_to_run_wait_install.sh" ]
+    command: "./edgex-ui-server --configDir=res/docker"
+    volumes:
+      - edgex-init:/edgex-init:ro
+      - /tmp/edgex/secrets/ui:/tmp/edgex/secrets/ui:ro,z
+    depends_on:
+      - security-bootstrapper
+      - security-secretstore-setup

--- a/compose-builder/docker-compose-base.yml
+++ b/compose-builder/docker-compose-base.yml
@@ -277,7 +277,6 @@ services:
     container_name: edgex-ui-go
     hostname: edgex-ui-go
     environment:
-      EDGEX_SECURITY_SECRET_STORE: "false"
       SERVICE_HOST: edgex-ui-go
     read_only: true
     restart: always

--- a/compose-builder/docker-compose-base.yml
+++ b/compose-builder/docker-compose-base.yml
@@ -276,6 +276,8 @@ services:
       - "4000:4000"
     container_name: edgex-ui-go
     hostname: edgex-ui-go
+    env_file:
+      - common-non-security.env
     environment:
       SERVICE_HOST: edgex-ui-go
     read_only: true

--- a/docker-compose-arm64.yml
+++ b/docker-compose-arm64.yml
@@ -1373,7 +1373,7 @@ services:
       - /edgex-init/ready_to_run_wait_install.sh
     environment:
       CLIENTS_SECURITY_SECRETSTORE_SETUP_HOST: edgex-security-secretstore-setup
-      EDGEX_SECURITY_SECRET_STORE: "false"
+      EDGEX_SECURITY_SECRET_STORE: "true"
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       SECRETSTORE_HOST: edgex-secret-store
       SERVICE_HOST: edgex-ui-go

--- a/docker-compose-arm64.yml
+++ b/docker-compose-arm64.yml
@@ -24,7 +24,7 @@
 #
 # From the compose-builder folder use `make build` to regenerate all standard compose files variations
 #
-# Generated with: Docker Compose version v2.29.7
+# Generated with: Docker Compose version v2.33.1
 name: edgex
 services:
   app-rules-engine:
@@ -899,7 +899,7 @@ services:
     deploy:
       resources:
         limits:
-          memory: "6353431035904"
+          memory: "25196148817920"
     entrypoint:
       - /edgex-init/secretstore_wait_install.sh
     environment:
@@ -923,7 +923,7 @@ services:
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-secret-store
     image: openbao/openbao:2.1
-    memswap_limit: "6353431035904"
+    memswap_limit: "25196148817920"
     networks:
       edgex-network: null
     ports:
@@ -1358,10 +1358,38 @@ services:
           selinux: z
           create_host_path: true
   ui:
+    command:
+      - ./edgex-ui-server
+      - --configDir=res/docker
     container_name: edgex-ui-go
+    depends_on:
+      security-bootstrapper:
+        condition: service_started
+        required: true
+      security-secretstore-setup:
+        condition: service_started
+        required: true
+    entrypoint:
+      - /edgex-init/ready_to_run_wait_install.sh
     environment:
-      EDGEX_SECURITY_SECRET_STORE: "true"
+      CLIENTS_SECURITY_SECRETSTORE_SETUP_HOST: edgex-security-secretstore-setup
+      EDGEX_SECURITY_SECRET_STORE: "false"
+      PROXY_SETUP_HOST: edgex-security-proxy-setup
+      SECRETSTORE_HOST: edgex-secret-store
       SERVICE_HOST: edgex-ui-go
+      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
+      STAGEGATE_DATABASE_HOST: edgex-postgres
+      STAGEGATE_DATABASE_PORT: "5432"
+      STAGEGATE_DATABASE_READYPORT: "5432"
+      STAGEGATE_PROXYSETUP_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
+      STAGEGATE_REGISTRY_HOST: edgex-core-keeper
+      STAGEGATE_REGISTRY_PORT: "59890"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
+      STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
+      STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-ui-go
     image: nexus3.edgexfoundry.org:10004/edgex-ui-arm64:latest
     networks:
@@ -1382,6 +1410,18 @@ services:
         target: /etc/localtime
         read_only: true
         bind:
+          create_host_path: true
+      - type: volume
+        source: edgex-init
+        target: /edgex-init
+        read_only: true
+        volume: {}
+      - type: bind
+        source: /tmp/edgex/secrets/ui
+        target: /tmp/edgex/secrets/ui
+        read_only: true
+        bind:
+          selinux: z
           create_host_path: true
 networks:
   edgex-network:

--- a/docker-compose-no-secty-arm64.yml
+++ b/docker-compose-no-secty-arm64.yml
@@ -545,6 +545,7 @@ services:
   ui:
     container_name: edgex-ui-go
     environment:
+      EDGEX_SECURITY_SECRET_STORE: "false"
       SERVICE_HOST: edgex-ui-go
     hostname: edgex-ui-go
     image: nexus3.edgexfoundry.org:10004/edgex-ui-arm64:latest

--- a/docker-compose-no-secty-arm64.yml
+++ b/docker-compose-no-secty-arm64.yml
@@ -545,7 +545,6 @@ services:
   ui:
     container_name: edgex-ui-go
     environment:
-      EDGEX_SECURITY_SECRET_STORE: "false"
       SERVICE_HOST: edgex-ui-go
     hostname: edgex-ui-go
     image: nexus3.edgexfoundry.org:10004/edgex-ui-arm64:latest

--- a/docker-compose-no-secty-arm64.yml
+++ b/docker-compose-no-secty-arm64.yml
@@ -24,7 +24,7 @@
 #
 # From the compose-builder folder use `make build` to regenerate all standard compose files variations
 #
-# Generated with: Docker Compose version v2.29.7
+# Generated with: Docker Compose version v2.33.1
 name: edgex
 services:
   app-rules-engine:

--- a/docker-compose-no-secty-with-app-sample-arm64.yml
+++ b/docker-compose-no-secty-with-app-sample-arm64.yml
@@ -24,7 +24,7 @@
 #
 # From the compose-builder folder use `make build` to regenerate all standard compose files variations
 #
-# Generated with: Docker Compose version v2.29.7
+# Generated with: Docker Compose version v2.33.1
 name: edgex
 services:
   app-rules-engine:

--- a/docker-compose-no-secty-with-app-sample-arm64.yml
+++ b/docker-compose-no-secty-with-app-sample-arm64.yml
@@ -589,6 +589,7 @@ services:
   ui:
     container_name: edgex-ui-go
     environment:
+      EDGEX_SECURITY_SECRET_STORE: "false"
       SERVICE_HOST: edgex-ui-go
     hostname: edgex-ui-go
     image: nexus3.edgexfoundry.org:10004/edgex-ui-arm64:latest

--- a/docker-compose-no-secty-with-app-sample-arm64.yml
+++ b/docker-compose-no-secty-with-app-sample-arm64.yml
@@ -589,7 +589,6 @@ services:
   ui:
     container_name: edgex-ui-go
     environment:
-      EDGEX_SECURITY_SECRET_STORE: "false"
       SERVICE_HOST: edgex-ui-go
     hostname: edgex-ui-go
     image: nexus3.edgexfoundry.org:10004/edgex-ui-arm64:latest

--- a/docker-compose-no-secty-with-app-sample.yml
+++ b/docker-compose-no-secty-with-app-sample.yml
@@ -589,7 +589,6 @@ services:
   ui:
     container_name: edgex-ui-go
     environment:
-      EDGEX_SECURITY_SECRET_STORE: "false"
       SERVICE_HOST: edgex-ui-go
     hostname: edgex-ui-go
     image: nexus3.edgexfoundry.org:10004/edgex-ui:latest

--- a/docker-compose-no-secty-with-app-sample.yml
+++ b/docker-compose-no-secty-with-app-sample.yml
@@ -589,6 +589,7 @@ services:
   ui:
     container_name: edgex-ui-go
     environment:
+      EDGEX_SECURITY_SECRET_STORE: "false"
       SERVICE_HOST: edgex-ui-go
     hostname: edgex-ui-go
     image: nexus3.edgexfoundry.org:10004/edgex-ui:latest

--- a/docker-compose-no-secty-with-app-sample.yml
+++ b/docker-compose-no-secty-with-app-sample.yml
@@ -24,7 +24,7 @@
 #
 # From the compose-builder folder use `make build` to regenerate all standard compose files variations
 #
-# Generated with: Docker Compose version v2.29.7
+# Generated with: Docker Compose version v2.33.1
 name: edgex
 services:
   app-rules-engine:

--- a/docker-compose-no-secty.yml
+++ b/docker-compose-no-secty.yml
@@ -545,7 +545,6 @@ services:
   ui:
     container_name: edgex-ui-go
     environment:
-      EDGEX_SECURITY_SECRET_STORE: "false"
       SERVICE_HOST: edgex-ui-go
     hostname: edgex-ui-go
     image: nexus3.edgexfoundry.org:10004/edgex-ui:latest

--- a/docker-compose-no-secty.yml
+++ b/docker-compose-no-secty.yml
@@ -24,7 +24,7 @@
 #
 # From the compose-builder folder use `make build` to regenerate all standard compose files variations
 #
-# Generated with: Docker Compose version v2.29.7
+# Generated with: Docker Compose version v2.33.1
 name: edgex
 services:
   app-rules-engine:

--- a/docker-compose-no-secty.yml
+++ b/docker-compose-no-secty.yml
@@ -545,6 +545,7 @@ services:
   ui:
     container_name: edgex-ui-go
     environment:
+      EDGEX_SECURITY_SECRET_STORE: "false"
       SERVICE_HOST: edgex-ui-go
     hostname: edgex-ui-go
     image: nexus3.edgexfoundry.org:10004/edgex-ui:latest

--- a/docker-compose-with-app-sample-arm64.yml
+++ b/docker-compose-with-app-sample-arm64.yml
@@ -24,7 +24,7 @@
 #
 # From the compose-builder folder use `make build` to regenerate all standard compose files variations
 #
-# Generated with: Docker Compose version v2.29.7
+# Generated with: Docker Compose version v2.33.1
 name: edgex
 services:
   app-rules-engine:
@@ -977,7 +977,7 @@ services:
     deploy:
       resources:
         limits:
-          memory: "6353431035904"
+          memory: "25196148817920"
     entrypoint:
       - /edgex-init/secretstore_wait_install.sh
     environment:
@@ -1001,7 +1001,7 @@ services:
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-secret-store
     image: openbao/openbao:2.1
-    memswap_limit: "6353431035904"
+    memswap_limit: "25196148817920"
     networks:
       edgex-network: null
     ports:
@@ -1436,10 +1436,38 @@ services:
           selinux: z
           create_host_path: true
   ui:
+    command:
+      - ./edgex-ui-server
+      - --configDir=res/docker
     container_name: edgex-ui-go
+    depends_on:
+      security-bootstrapper:
+        condition: service_started
+        required: true
+      security-secretstore-setup:
+        condition: service_started
+        required: true
+    entrypoint:
+      - /edgex-init/ready_to_run_wait_install.sh
     environment:
-      EDGEX_SECURITY_SECRET_STORE: "true"
+      CLIENTS_SECURITY_SECRETSTORE_SETUP_HOST: edgex-security-secretstore-setup
+      EDGEX_SECURITY_SECRET_STORE: "false"
+      PROXY_SETUP_HOST: edgex-security-proxy-setup
+      SECRETSTORE_HOST: edgex-secret-store
       SERVICE_HOST: edgex-ui-go
+      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
+      STAGEGATE_DATABASE_HOST: edgex-postgres
+      STAGEGATE_DATABASE_PORT: "5432"
+      STAGEGATE_DATABASE_READYPORT: "5432"
+      STAGEGATE_PROXYSETUP_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
+      STAGEGATE_REGISTRY_HOST: edgex-core-keeper
+      STAGEGATE_REGISTRY_PORT: "59890"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
+      STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
+      STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-ui-go
     image: nexus3.edgexfoundry.org:10004/edgex-ui-arm64:latest
     networks:
@@ -1460,6 +1488,18 @@ services:
         target: /etc/localtime
         read_only: true
         bind:
+          create_host_path: true
+      - type: volume
+        source: edgex-init
+        target: /edgex-init
+        read_only: true
+        volume: {}
+      - type: bind
+        source: /tmp/edgex/secrets/ui
+        target: /tmp/edgex/secrets/ui
+        read_only: true
+        bind:
+          selinux: z
           create_host_path: true
 networks:
   edgex-network:

--- a/docker-compose-with-app-sample-arm64.yml
+++ b/docker-compose-with-app-sample-arm64.yml
@@ -1451,7 +1451,7 @@ services:
       - /edgex-init/ready_to_run_wait_install.sh
     environment:
       CLIENTS_SECURITY_SECRETSTORE_SETUP_HOST: edgex-security-secretstore-setup
-      EDGEX_SECURITY_SECRET_STORE: "false"
+      EDGEX_SECURITY_SECRET_STORE: "true"
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       SECRETSTORE_HOST: edgex-secret-store
       SERVICE_HOST: edgex-ui-go

--- a/docker-compose-with-app-sample.yml
+++ b/docker-compose-with-app-sample.yml
@@ -24,7 +24,7 @@
 #
 # From the compose-builder folder use `make build` to regenerate all standard compose files variations
 #
-# Generated with: Docker Compose version v2.29.7
+# Generated with: Docker Compose version v2.33.1
 name: edgex
 services:
   app-rules-engine:
@@ -977,7 +977,7 @@ services:
     deploy:
       resources:
         limits:
-          memory: "6353431035904"
+          memory: "25196148817920"
     entrypoint:
       - /edgex-init/secretstore_wait_install.sh
     environment:
@@ -1001,7 +1001,7 @@ services:
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-secret-store
     image: openbao/openbao:2.1
-    memswap_limit: "6353431035904"
+    memswap_limit: "25196148817920"
     networks:
       edgex-network: null
     ports:
@@ -1436,10 +1436,38 @@ services:
           selinux: z
           create_host_path: true
   ui:
+    command:
+      - ./edgex-ui-server
+      - --configDir=res/docker
     container_name: edgex-ui-go
+    depends_on:
+      security-bootstrapper:
+        condition: service_started
+        required: true
+      security-secretstore-setup:
+        condition: service_started
+        required: true
+    entrypoint:
+      - /edgex-init/ready_to_run_wait_install.sh
     environment:
-      EDGEX_SECURITY_SECRET_STORE: "true"
+      CLIENTS_SECURITY_SECRETSTORE_SETUP_HOST: edgex-security-secretstore-setup
+      EDGEX_SECURITY_SECRET_STORE: "false"
+      PROXY_SETUP_HOST: edgex-security-proxy-setup
+      SECRETSTORE_HOST: edgex-secret-store
       SERVICE_HOST: edgex-ui-go
+      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
+      STAGEGATE_DATABASE_HOST: edgex-postgres
+      STAGEGATE_DATABASE_PORT: "5432"
+      STAGEGATE_DATABASE_READYPORT: "5432"
+      STAGEGATE_PROXYSETUP_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
+      STAGEGATE_REGISTRY_HOST: edgex-core-keeper
+      STAGEGATE_REGISTRY_PORT: "59890"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
+      STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
+      STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-ui-go
     image: nexus3.edgexfoundry.org:10004/edgex-ui:latest
     networks:
@@ -1460,6 +1488,18 @@ services:
         target: /etc/localtime
         read_only: true
         bind:
+          create_host_path: true
+      - type: volume
+        source: edgex-init
+        target: /edgex-init
+        read_only: true
+        volume: {}
+      - type: bind
+        source: /tmp/edgex/secrets/ui
+        target: /tmp/edgex/secrets/ui
+        read_only: true
+        bind:
+          selinux: z
           create_host_path: true
 networks:
   edgex-network:

--- a/docker-compose-with-app-sample.yml
+++ b/docker-compose-with-app-sample.yml
@@ -1451,7 +1451,7 @@ services:
       - /edgex-init/ready_to_run_wait_install.sh
     environment:
       CLIENTS_SECURITY_SECRETSTORE_SETUP_HOST: edgex-security-secretstore-setup
-      EDGEX_SECURITY_SECRET_STORE: "false"
+      EDGEX_SECURITY_SECRET_STORE: "true"
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       SECRETSTORE_HOST: edgex-secret-store
       SERVICE_HOST: edgex-ui-go

--- a/docker-compose-zero-trust-arm64.yml
+++ b/docker-compose-zero-trust-arm64.yml
@@ -1174,7 +1174,7 @@ services:
       CLIENTS_SUPPORT_NOTIFICATIONS_HOST: support-notifications.edgex.ziti
       CLIENTS_SUPPORT_NOTIFICATIONS_PORT: "80"
       CLIENTS_SUPPORT_NOTIFICATIONS_SECURITYOPTIONS_MODE: zerotrust
-      EDGEX_SECURITY_SECRET_STORE: "false"
+      EDGEX_SECURITY_SECRET_STORE: "true"
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       SECRETSTORE_HOST: edgex-secret-store
       SERVICE_HOST: edgex-ui-go

--- a/docker-compose-zero-trust-arm64.yml
+++ b/docker-compose-zero-trust-arm64.yml
@@ -24,7 +24,7 @@
 #
 # From the compose-builder folder use `make build` to regenerate all standard compose files variations
 #
-# Generated with: Docker Compose version v2.29.7
+# Generated with: Docker Compose version v2.33.1
 name: edgex
 services:
   app-rules-engine:
@@ -819,7 +819,7 @@ services:
     deploy:
       resources:
         limits:
-          memory: "6353431035904"
+          memory: "25196148817920"
     entrypoint:
       - /edgex-init/secretstore_wait_install.sh
     environment:
@@ -843,7 +843,7 @@ services:
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-secret-store
     image: openbao/openbao:2.1
-    memswap_limit: "6353431035904"
+    memswap_limit: "25196148817920"
     networks:
       edgex-network: null
     ports:
@@ -1151,6 +1151,9 @@ services:
       security-bootstrapper:
         condition: service_started
         required: true
+      security-secretstore-setup:
+        condition: service_started
+        required: true
     entrypoint:
       - /edgex-init/ready_to_run_wait_install.sh
     environment:
@@ -1171,7 +1174,7 @@ services:
       CLIENTS_SUPPORT_NOTIFICATIONS_HOST: support-notifications.edgex.ziti
       CLIENTS_SUPPORT_NOTIFICATIONS_PORT: "80"
       CLIENTS_SUPPORT_NOTIFICATIONS_SECURITYOPTIONS_MODE: zerotrust
-      EDGEX_SECURITY_SECRET_STORE: "true"
+      EDGEX_SECURITY_SECRET_STORE: "false"
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       SECRETSTORE_HOST: edgex-secret-store
       SERVICE_HOST: edgex-ui-go

--- a/docker-compose-zero-trust.yml
+++ b/docker-compose-zero-trust.yml
@@ -1174,7 +1174,7 @@ services:
       CLIENTS_SUPPORT_NOTIFICATIONS_HOST: support-notifications.edgex.ziti
       CLIENTS_SUPPORT_NOTIFICATIONS_PORT: "80"
       CLIENTS_SUPPORT_NOTIFICATIONS_SECURITYOPTIONS_MODE: zerotrust
-      EDGEX_SECURITY_SECRET_STORE: "false"
+      EDGEX_SECURITY_SECRET_STORE: "true"
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       SECRETSTORE_HOST: edgex-secret-store
       SERVICE_HOST: edgex-ui-go

--- a/docker-compose-zero-trust.yml
+++ b/docker-compose-zero-trust.yml
@@ -24,7 +24,7 @@
 #
 # From the compose-builder folder use `make build` to regenerate all standard compose files variations
 #
-# Generated with: Docker Compose version v2.29.7
+# Generated with: Docker Compose version v2.33.1
 name: edgex
 services:
   app-rules-engine:
@@ -819,7 +819,7 @@ services:
     deploy:
       resources:
         limits:
-          memory: "6353431035904"
+          memory: "25196148817920"
     entrypoint:
       - /edgex-init/secretstore_wait_install.sh
     environment:
@@ -843,7 +843,7 @@ services:
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-secret-store
     image: openbao/openbao:2.1
-    memswap_limit: "6353431035904"
+    memswap_limit: "25196148817920"
     networks:
       edgex-network: null
     ports:
@@ -1151,6 +1151,9 @@ services:
       security-bootstrapper:
         condition: service_started
         required: true
+      security-secretstore-setup:
+        condition: service_started
+        required: true
     entrypoint:
       - /edgex-init/ready_to_run_wait_install.sh
     environment:
@@ -1171,7 +1174,7 @@ services:
       CLIENTS_SUPPORT_NOTIFICATIONS_HOST: support-notifications.edgex.ziti
       CLIENTS_SUPPORT_NOTIFICATIONS_PORT: "80"
       CLIENTS_SUPPORT_NOTIFICATIONS_SECURITYOPTIONS_MODE: zerotrust
-      EDGEX_SECURITY_SECRET_STORE: "true"
+      EDGEX_SECURITY_SECRET_STORE: "false"
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       SECRETSTORE_HOST: edgex-secret-store
       SERVICE_HOST: edgex-ui-go

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1373,7 +1373,7 @@ services:
       - /edgex-init/ready_to_run_wait_install.sh
     environment:
       CLIENTS_SECURITY_SECRETSTORE_SETUP_HOST: edgex-security-secretstore-setup
-      EDGEX_SECURITY_SECRET_STORE: "false"
+      EDGEX_SECURITY_SECRET_STORE: "true"
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       SECRETSTORE_HOST: edgex-secret-store
       SERVICE_HOST: edgex-ui-go

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,7 @@
 #
 # From the compose-builder folder use `make build` to regenerate all standard compose files variations
 #
-# Generated with: Docker Compose version v2.29.7
+# Generated with: Docker Compose version v2.33.1
 name: edgex
 services:
   app-rules-engine:
@@ -899,7 +899,7 @@ services:
     deploy:
       resources:
         limits:
-          memory: "6353431035904"
+          memory: "25196148817920"
     entrypoint:
       - /edgex-init/secretstore_wait_install.sh
     environment:
@@ -923,7 +923,7 @@ services:
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-secret-store
     image: openbao/openbao:2.1
-    memswap_limit: "6353431035904"
+    memswap_limit: "25196148817920"
     networks:
       edgex-network: null
     ports:
@@ -1358,10 +1358,38 @@ services:
           selinux: z
           create_host_path: true
   ui:
+    command:
+      - ./edgex-ui-server
+      - --configDir=res/docker
     container_name: edgex-ui-go
+    depends_on:
+      security-bootstrapper:
+        condition: service_started
+        required: true
+      security-secretstore-setup:
+        condition: service_started
+        required: true
+    entrypoint:
+      - /edgex-init/ready_to_run_wait_install.sh
     environment:
-      EDGEX_SECURITY_SECRET_STORE: "true"
+      CLIENTS_SECURITY_SECRETSTORE_SETUP_HOST: edgex-security-secretstore-setup
+      EDGEX_SECURITY_SECRET_STORE: "false"
+      PROXY_SETUP_HOST: edgex-security-proxy-setup
+      SECRETSTORE_HOST: edgex-secret-store
       SERVICE_HOST: edgex-ui-go
+      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
+      STAGEGATE_DATABASE_HOST: edgex-postgres
+      STAGEGATE_DATABASE_PORT: "5432"
+      STAGEGATE_DATABASE_READYPORT: "5432"
+      STAGEGATE_PROXYSETUP_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
+      STAGEGATE_REGISTRY_HOST: edgex-core-keeper
+      STAGEGATE_REGISTRY_PORT: "59890"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
+      STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
+      STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-ui-go
     image: nexus3.edgexfoundry.org:10004/edgex-ui:latest
     networks:
@@ -1382,6 +1410,18 @@ services:
         target: /etc/localtime
         read_only: true
         bind:
+          create_host_path: true
+      - type: volume
+        source: edgex-init
+        target: /edgex-init
+        read_only: true
+        volume: {}
+      - type: bind
+        source: /tmp/edgex/secrets/ui
+        target: /tmp/edgex/secrets/ui
+        read_only: true
+        bind:
+          selinux: z
           create_host_path: true
 networks:
   edgex-network:

--- a/taf/docker-compose-taf-arm64.yml
+++ b/taf/docker-compose-taf-arm64.yml
@@ -2385,7 +2385,7 @@ services:
       - /edgex-init/ready_to_run_wait_install.sh
     environment:
       CLIENTS_SECURITY_SECRETSTORE_SETUP_HOST: edgex-security-secretstore-setup
-      EDGEX_SECURITY_SECRET_STORE: "false"
+      EDGEX_SECURITY_SECRET_STORE: "true"
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       SECRETSTORE_HOST: edgex-secret-store
       SERVICE_HOST: edgex-ui-go

--- a/taf/docker-compose-taf-arm64.yml
+++ b/taf/docker-compose-taf-arm64.yml
@@ -24,7 +24,7 @@
 #
 # From the compose-builder folder use `make build` to regenerate all standard compose files variations
 #
-# Generated with: Docker Compose version v2.29.7
+# Generated with: Docker Compose version v2.33.1
 name: edgex
 services:
   app-external-mqtt-trigger:
@@ -1636,7 +1636,7 @@ services:
     deploy:
       resources:
         limits:
-          memory: "6353431035904"
+          memory: "25196148817920"
     entrypoint:
       - /edgex-init/secretstore_wait_install.sh
     environment:
@@ -1660,7 +1660,7 @@ services:
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-secret-store
     image: openbao/openbao:2.1
-    memswap_limit: "6353431035904"
+    memswap_limit: "25196148817920"
     networks:
       edgex-network: null
     ports:
@@ -2370,10 +2370,38 @@ services:
           selinux: z
           create_host_path: true
   ui:
+    command:
+      - ./edgex-ui-server
+      - --configDir=res/docker
     container_name: edgex-ui-go
+    depends_on:
+      security-bootstrapper:
+        condition: service_started
+        required: true
+      security-secretstore-setup:
+        condition: service_started
+        required: true
+    entrypoint:
+      - /edgex-init/ready_to_run_wait_install.sh
     environment:
-      EDGEX_SECURITY_SECRET_STORE: "true"
+      CLIENTS_SECURITY_SECRETSTORE_SETUP_HOST: edgex-security-secretstore-setup
+      EDGEX_SECURITY_SECRET_STORE: "false"
+      PROXY_SETUP_HOST: edgex-security-proxy-setup
+      SECRETSTORE_HOST: edgex-secret-store
       SERVICE_HOST: edgex-ui-go
+      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
+      STAGEGATE_DATABASE_HOST: edgex-postgres
+      STAGEGATE_DATABASE_PORT: "5432"
+      STAGEGATE_DATABASE_READYPORT: "5432"
+      STAGEGATE_PROXYSETUP_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
+      STAGEGATE_REGISTRY_HOST: edgex-core-keeper
+      STAGEGATE_REGISTRY_PORT: "59890"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
+      STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
+      STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-ui-go
     image: nexus3.edgexfoundry.org:10004/edgex-ui-arm64:latest
     networks:
@@ -2394,6 +2422,18 @@ services:
         target: /etc/localtime
         read_only: true
         bind:
+          create_host_path: true
+      - type: volume
+        source: edgex-init
+        target: /edgex-init
+        read_only: true
+        volume: {}
+      - type: bind
+        source: /tmp/edgex/secrets/ui
+        target: /tmp/edgex/secrets/ui
+        read_only: true
+        bind:
+          selinux: z
           create_host_path: true
 networks:
   edgex-network:

--- a/taf/docker-compose-taf-no-secty-arm64.yml
+++ b/taf/docker-compose-taf-no-secty-arm64.yml
@@ -961,7 +961,6 @@ services:
   ui:
     container_name: edgex-ui-go
     environment:
-      EDGEX_SECURITY_SECRET_STORE: "false"
       SERVICE_HOST: edgex-ui-go
     hostname: edgex-ui-go
     image: nexus3.edgexfoundry.org:10004/edgex-ui-arm64:latest

--- a/taf/docker-compose-taf-no-secty-arm64.yml
+++ b/taf/docker-compose-taf-no-secty-arm64.yml
@@ -24,7 +24,7 @@
 #
 # From the compose-builder folder use `make build` to regenerate all standard compose files variations
 #
-# Generated with: Docker Compose version v2.29.7
+# Generated with: Docker Compose version v2.33.1
 name: edgex
 services:
   app-external-mqtt-trigger:

--- a/taf/docker-compose-taf-no-secty-arm64.yml
+++ b/taf/docker-compose-taf-no-secty-arm64.yml
@@ -961,6 +961,7 @@ services:
   ui:
     container_name: edgex-ui-go
     environment:
+      EDGEX_SECURITY_SECRET_STORE: "false"
       SERVICE_HOST: edgex-ui-go
     hostname: edgex-ui-go
     image: nexus3.edgexfoundry.org:10004/edgex-ui-arm64:latest

--- a/taf/docker-compose-taf-no-secty.yml
+++ b/taf/docker-compose-taf-no-secty.yml
@@ -961,6 +961,7 @@ services:
   ui:
     container_name: edgex-ui-go
     environment:
+      EDGEX_SECURITY_SECRET_STORE: "false"
       SERVICE_HOST: edgex-ui-go
     hostname: edgex-ui-go
     image: nexus3.edgexfoundry.org:10004/edgex-ui:latest

--- a/taf/docker-compose-taf-no-secty.yml
+++ b/taf/docker-compose-taf-no-secty.yml
@@ -961,7 +961,6 @@ services:
   ui:
     container_name: edgex-ui-go
     environment:
-      EDGEX_SECURITY_SECRET_STORE: "false"
       SERVICE_HOST: edgex-ui-go
     hostname: edgex-ui-go
     image: nexus3.edgexfoundry.org:10004/edgex-ui:latest

--- a/taf/docker-compose-taf-no-secty.yml
+++ b/taf/docker-compose-taf-no-secty.yml
@@ -24,7 +24,7 @@
 #
 # From the compose-builder folder use `make build` to regenerate all standard compose files variations
 #
-# Generated with: Docker Compose version v2.29.7
+# Generated with: Docker Compose version v2.33.1
 name: edgex
 services:
   app-external-mqtt-trigger:

--- a/taf/docker-compose-taf-perf-arm64.yml
+++ b/taf/docker-compose-taf-perf-arm64.yml
@@ -24,7 +24,7 @@
 #
 # From the compose-builder folder use `make build` to regenerate all standard compose files variations
 #
-# Generated with: Docker Compose version v2.29.7
+# Generated with: Docker Compose version v2.33.1
 name: edgex
 services:
   app-mqtt-export:
@@ -998,7 +998,7 @@ services:
     deploy:
       resources:
         limits:
-          memory: "6353431035904"
+          memory: "25196148817920"
     entrypoint:
       - /edgex-init/secretstore_wait_install.sh
     environment:
@@ -1022,7 +1022,7 @@ services:
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-secret-store
     image: openbao/openbao:2.1
-    memswap_limit: "6353431035904"
+    memswap_limit: "25196148817920"
     networks:
       edgex-network: null
     ports:
@@ -1732,10 +1732,38 @@ services:
           selinux: z
           create_host_path: true
   ui:
+    command:
+      - ./edgex-ui-server
+      - --configDir=res/docker
     container_name: edgex-ui-go
+    depends_on:
+      security-bootstrapper:
+        condition: service_started
+        required: true
+      security-secretstore-setup:
+        condition: service_started
+        required: true
+    entrypoint:
+      - /edgex-init/ready_to_run_wait_install.sh
     environment:
-      EDGEX_SECURITY_SECRET_STORE: "true"
+      CLIENTS_SECURITY_SECRETSTORE_SETUP_HOST: edgex-security-secretstore-setup
+      EDGEX_SECURITY_SECRET_STORE: "false"
+      PROXY_SETUP_HOST: edgex-security-proxy-setup
+      SECRETSTORE_HOST: edgex-secret-store
       SERVICE_HOST: edgex-ui-go
+      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
+      STAGEGATE_DATABASE_HOST: edgex-postgres
+      STAGEGATE_DATABASE_PORT: "5432"
+      STAGEGATE_DATABASE_READYPORT: "5432"
+      STAGEGATE_PROXYSETUP_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
+      STAGEGATE_REGISTRY_HOST: edgex-core-keeper
+      STAGEGATE_REGISTRY_PORT: "59890"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
+      STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
+      STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-ui-go
     image: nexus3.edgexfoundry.org:10004/edgex-ui-arm64:latest
     networks:
@@ -1756,6 +1784,18 @@ services:
         target: /etc/localtime
         read_only: true
         bind:
+          create_host_path: true
+      - type: volume
+        source: edgex-init
+        target: /edgex-init
+        read_only: true
+        volume: {}
+      - type: bind
+        source: /tmp/edgex/secrets/ui
+        target: /tmp/edgex/secrets/ui
+        read_only: true
+        bind:
+          selinux: z
           create_host_path: true
 networks:
   edgex-network:

--- a/taf/docker-compose-taf-perf-arm64.yml
+++ b/taf/docker-compose-taf-perf-arm64.yml
@@ -1747,7 +1747,7 @@ services:
       - /edgex-init/ready_to_run_wait_install.sh
     environment:
       CLIENTS_SECURITY_SECRETSTORE_SETUP_HOST: edgex-security-secretstore-setup
-      EDGEX_SECURITY_SECRET_STORE: "false"
+      EDGEX_SECURITY_SECRET_STORE: "true"
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       SECRETSTORE_HOST: edgex-secret-store
       SERVICE_HOST: edgex-ui-go

--- a/taf/docker-compose-taf-perf-no-secty-arm64.yml
+++ b/taf/docker-compose-taf-perf-no-secty-arm64.yml
@@ -610,6 +610,7 @@ services:
   ui:
     container_name: edgex-ui-go
     environment:
+      EDGEX_SECURITY_SECRET_STORE: "false"
       SERVICE_HOST: edgex-ui-go
     hostname: edgex-ui-go
     image: nexus3.edgexfoundry.org:10004/edgex-ui-arm64:latest

--- a/taf/docker-compose-taf-perf-no-secty-arm64.yml
+++ b/taf/docker-compose-taf-perf-no-secty-arm64.yml
@@ -610,7 +610,6 @@ services:
   ui:
     container_name: edgex-ui-go
     environment:
-      EDGEX_SECURITY_SECRET_STORE: "false"
       SERVICE_HOST: edgex-ui-go
     hostname: edgex-ui-go
     image: nexus3.edgexfoundry.org:10004/edgex-ui-arm64:latest

--- a/taf/docker-compose-taf-perf-no-secty-arm64.yml
+++ b/taf/docker-compose-taf-perf-no-secty-arm64.yml
@@ -24,7 +24,7 @@
 #
 # From the compose-builder folder use `make build` to regenerate all standard compose files variations
 #
-# Generated with: Docker Compose version v2.29.7
+# Generated with: Docker Compose version v2.33.1
 name: edgex
 services:
   app-mqtt-export:

--- a/taf/docker-compose-taf-perf-no-secty.yml
+++ b/taf/docker-compose-taf-perf-no-secty.yml
@@ -610,7 +610,6 @@ services:
   ui:
     container_name: edgex-ui-go
     environment:
-      EDGEX_SECURITY_SECRET_STORE: "false"
       SERVICE_HOST: edgex-ui-go
     hostname: edgex-ui-go
     image: nexus3.edgexfoundry.org:10004/edgex-ui:latest

--- a/taf/docker-compose-taf-perf-no-secty.yml
+++ b/taf/docker-compose-taf-perf-no-secty.yml
@@ -24,7 +24,7 @@
 #
 # From the compose-builder folder use `make build` to regenerate all standard compose files variations
 #
-# Generated with: Docker Compose version v2.29.7
+# Generated with: Docker Compose version v2.33.1
 name: edgex
 services:
   app-mqtt-export:

--- a/taf/docker-compose-taf-perf-no-secty.yml
+++ b/taf/docker-compose-taf-perf-no-secty.yml
@@ -610,6 +610,7 @@ services:
   ui:
     container_name: edgex-ui-go
     environment:
+      EDGEX_SECURITY_SECRET_STORE: "false"
       SERVICE_HOST: edgex-ui-go
     hostname: edgex-ui-go
     image: nexus3.edgexfoundry.org:10004/edgex-ui:latest

--- a/taf/docker-compose-taf-perf.yml
+++ b/taf/docker-compose-taf-perf.yml
@@ -24,7 +24,7 @@
 #
 # From the compose-builder folder use `make build` to regenerate all standard compose files variations
 #
-# Generated with: Docker Compose version v2.29.7
+# Generated with: Docker Compose version v2.33.1
 name: edgex
 services:
   app-mqtt-export:
@@ -998,7 +998,7 @@ services:
     deploy:
       resources:
         limits:
-          memory: "6353431035904"
+          memory: "25196148817920"
     entrypoint:
       - /edgex-init/secretstore_wait_install.sh
     environment:
@@ -1022,7 +1022,7 @@ services:
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-secret-store
     image: openbao/openbao:2.1
-    memswap_limit: "6353431035904"
+    memswap_limit: "25196148817920"
     networks:
       edgex-network: null
     ports:
@@ -1732,10 +1732,38 @@ services:
           selinux: z
           create_host_path: true
   ui:
+    command:
+      - ./edgex-ui-server
+      - --configDir=res/docker
     container_name: edgex-ui-go
+    depends_on:
+      security-bootstrapper:
+        condition: service_started
+        required: true
+      security-secretstore-setup:
+        condition: service_started
+        required: true
+    entrypoint:
+      - /edgex-init/ready_to_run_wait_install.sh
     environment:
-      EDGEX_SECURITY_SECRET_STORE: "true"
+      CLIENTS_SECURITY_SECRETSTORE_SETUP_HOST: edgex-security-secretstore-setup
+      EDGEX_SECURITY_SECRET_STORE: "false"
+      PROXY_SETUP_HOST: edgex-security-proxy-setup
+      SECRETSTORE_HOST: edgex-secret-store
       SERVICE_HOST: edgex-ui-go
+      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
+      STAGEGATE_DATABASE_HOST: edgex-postgres
+      STAGEGATE_DATABASE_PORT: "5432"
+      STAGEGATE_DATABASE_READYPORT: "5432"
+      STAGEGATE_PROXYSETUP_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
+      STAGEGATE_REGISTRY_HOST: edgex-core-keeper
+      STAGEGATE_REGISTRY_PORT: "59890"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
+      STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
+      STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-ui-go
     image: nexus3.edgexfoundry.org:10004/edgex-ui:latest
     networks:
@@ -1756,6 +1784,18 @@ services:
         target: /etc/localtime
         read_only: true
         bind:
+          create_host_path: true
+      - type: volume
+        source: edgex-init
+        target: /edgex-init
+        read_only: true
+        volume: {}
+      - type: bind
+        source: /tmp/edgex/secrets/ui
+        target: /tmp/edgex/secrets/ui
+        read_only: true
+        bind:
+          selinux: z
           create_host_path: true
 networks:
   edgex-network:

--- a/taf/docker-compose-taf-perf.yml
+++ b/taf/docker-compose-taf-perf.yml
@@ -1747,7 +1747,7 @@ services:
       - /edgex-init/ready_to_run_wait_install.sh
     environment:
       CLIENTS_SECURITY_SECRETSTORE_SETUP_HOST: edgex-security-secretstore-setup
-      EDGEX_SECURITY_SECRET_STORE: "false"
+      EDGEX_SECURITY_SECRET_STORE: "true"
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       SECRETSTORE_HOST: edgex-secret-store
       SERVICE_HOST: edgex-ui-go

--- a/taf/docker-compose-taf.yml
+++ b/taf/docker-compose-taf.yml
@@ -2385,7 +2385,7 @@ services:
       - /edgex-init/ready_to_run_wait_install.sh
     environment:
       CLIENTS_SECURITY_SECRETSTORE_SETUP_HOST: edgex-security-secretstore-setup
-      EDGEX_SECURITY_SECRET_STORE: "false"
+      EDGEX_SECURITY_SECRET_STORE: "true"
       PROXY_SETUP_HOST: edgex-security-proxy-setup
       SECRETSTORE_HOST: edgex-secret-store
       SERVICE_HOST: edgex-ui-go

--- a/taf/docker-compose-taf.yml
+++ b/taf/docker-compose-taf.yml
@@ -24,7 +24,7 @@
 #
 # From the compose-builder folder use `make build` to regenerate all standard compose files variations
 #
-# Generated with: Docker Compose version v2.29.7
+# Generated with: Docker Compose version v2.33.1
 name: edgex
 services:
   app-external-mqtt-trigger:
@@ -1636,7 +1636,7 @@ services:
     deploy:
       resources:
         limits:
-          memory: "6353431035904"
+          memory: "25196148817920"
     entrypoint:
       - /edgex-init/secretstore_wait_install.sh
     environment:
@@ -1660,7 +1660,7 @@ services:
       STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-secret-store
     image: openbao/openbao:2.1
-    memswap_limit: "6353431035904"
+    memswap_limit: "25196148817920"
     networks:
       edgex-network: null
     ports:
@@ -2370,10 +2370,38 @@ services:
           selinux: z
           create_host_path: true
   ui:
+    command:
+      - ./edgex-ui-server
+      - --configDir=res/docker
     container_name: edgex-ui-go
+    depends_on:
+      security-bootstrapper:
+        condition: service_started
+        required: true
+      security-secretstore-setup:
+        condition: service_started
+        required: true
+    entrypoint:
+      - /edgex-init/ready_to_run_wait_install.sh
     environment:
-      EDGEX_SECURITY_SECRET_STORE: "true"
+      CLIENTS_SECURITY_SECRETSTORE_SETUP_HOST: edgex-security-secretstore-setup
+      EDGEX_SECURITY_SECRET_STORE: "false"
+      PROXY_SETUP_HOST: edgex-security-proxy-setup
+      SECRETSTORE_HOST: edgex-secret-store
       SERVICE_HOST: edgex-ui-go
+      STAGEGATE_BOOTSTRAPPER_HOST: edgex-security-bootstrapper
+      STAGEGATE_BOOTSTRAPPER_STARTPORT: "54321"
+      STAGEGATE_DATABASE_HOST: edgex-postgres
+      STAGEGATE_DATABASE_PORT: "5432"
+      STAGEGATE_DATABASE_READYPORT: "5432"
+      STAGEGATE_PROXYSETUP_READYPORT: "54325"
+      STAGEGATE_READY_TORUNPORT: "54329"
+      STAGEGATE_REGISTRY_HOST: edgex-core-keeper
+      STAGEGATE_REGISTRY_PORT: "59890"
+      STAGEGATE_REGISTRY_READYPORT: "54324"
+      STAGEGATE_SECRETSTORESETUP_HOST: edgex-security-secretstore-setup
+      STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT: "54322"
+      STAGEGATE_WAITFOR_TIMEOUT: 60s
     hostname: edgex-ui-go
     image: nexus3.edgexfoundry.org:10004/edgex-ui:latest
     networks:
@@ -2394,6 +2422,18 @@ services:
         target: /etc/localtime
         read_only: true
         bind:
+          create_host_path: true
+      - type: volume
+        source: edgex-init
+        target: /edgex-init
+        read_only: true
+        volume: {}
+      - type: bind
+        source: /tmp/edgex/secrets/ui
+        target: /tmp/edgex/secrets/ui
+        read_only: true
+        bind:
+          selinux: z
           create_host_path: true
 networks:
   edgex-network:


### PR DESCRIPTION
fixes https://github.com/edgexfoundry/edgex-compose/issues/494

When running `make run ds-virtual`, the edge-ui-go will fail to run up with errors like
"open /tmp/edgex/secrets/ui/secrets-token.json: no such file or directory"

The root of this error is from the missing secret volume mount in add-security.yml

This commit fixes this,

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-compose/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-compose/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [ ] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>


## Testing Instructions
<!-- How can the reviewers test your change? -->
