### PR TITLE
fix: core-keeper env vars on NATS-enabled build

### DIFF
--- a/compose-builder/add-nats-messagebus.yml
+++ b/compose-builder/add-nats-messagebus.yml
@@ -42,6 +42,12 @@ services:
       ALL_SERVICES_MESSAGEBUS_PORT: "4222"
       ALL_SERVICES_MESSAGEBUS_AUTHMODE: none
 
+  core-keeper:
+    environment:
+      MESSAGEBUS_HOST: edgex-nats-server
+      MESSAGEBUS_PORT: "4222"
+      MESSAGEBUS_TYPE: nats-jetstream
+
   rules-engine:
     environment:
       CONNECTION__EDGEX__NATSMSGBUS__PORT: 4222


### PR DESCRIPTION
When enabling NATS the core-keeper final environment variables does not match what is expected for the NATS server. With this commit correct values are added for MESSAGEBUS_HOST, MESSAGEBUS_PORT and MESSAGEBUS_TYPE according to the docs.

Closes #516

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [x] I have opened a PR for the related docs change (if not, why?) => N/A
