### PR TITLE
feat: add version file for custom docker tag

### DIFF
--- a/compose-builder/Makefile
+++ b/compose-builder/Makefile
@@ -37,6 +37,9 @@ BUS=
 NANOMQ=
 REGISTRY=
 
+VERSION=$(shell cat ./VERSION 2>/dev/null || echo 0.0.0)
+DOCKER_TAG=$(VERSION)-dev
+
 # Resolve user ID for rootless docker port mapping
 export USERID:=$(shell id -u)
 
@@ -89,36 +92,36 @@ endif
 
 ifeq (dev, $(filter dev,$(ARGS)))
 	export CORE_EDGEX_REPOSITORY=edgexfoundry
-	export CORE_EDGEX_VERSION=0.0.0-dev
+	export CORE_EDGEX_VERSION=$(DOCKER_TAG)
 	export DEV=-dev # require for the gateways scripts since they look for this
 endif
 ifeq (app-dev, $(filter app-dev,$(ARGS)))
 	export APP_SVC_REPOSITORY=edgexfoundry
 	export APP_SVC_DEV=-dev
-	export APP_SERVICE_CONFIG_VERSION=0.0.0-dev
-	export APP_LLRP_VERSION=0.0.0-dev
+	export APP_SERVICE_CONFIG_VERSION=$(DOCKER_TAG)
+	export APP_LLRP_VERSION=$(DOCKER_TAG)
 endif
 ifeq (device-dev, $(filter device-dev,$(ARGS)))
 	export DEVICE_SVC_REPOSITORY=edgexfoundry
-	export DEVICE_BACNET_VERSION=0.0.0-dev
-	export DEVICE_CAMERA_VERSION=0.0.0-dev
-	export DEVICE_MODBUS_VERSION=0.0.0-dev
-	export DEVICE_MQTT_VERSION=0.0.0-dev
-	export DEVICE_REST_VERSION=0.0.0-dev
-	export DEVICE_SNMP_VERSION=0.0.0-dev
-	export DEVICE_VIRTUAL_VERSION=0.0.0-dev
-	export DEVICE_LLRP_VERSION=0.0.0-dev
-	export DEVICE_COAP_VERSION=0.0.0-dev
-	export DEVICE_GPIO_VERSION=0.0.0-dev
-	export DEVICE_ONVIFCAM_VERSION=0.0.0-dev
-	export DEVICE_USBCAM_VERSION=0.0.0-dev
-	export DEVICE_S7_VERSION=0.0.0-dev
-	export DEVICE_OPCUA_VERSION=0.0.0-dev
-	export DEVICE_CAN_VERSION=0.0.0-dev
+	export DEVICE_BACNET_VERSION=$(DOCKER_TAG)
+	export DEVICE_CAMERA_VERSION=$(DOCKER_TAG)
+	export DEVICE_MODBUS_VERSION=$(DOCKER_TAG)
+	export DEVICE_MQTT_VERSION=$(DOCKER_TAG)
+	export DEVICE_REST_VERSION=$(DOCKER_TAG)
+	export DEVICE_SNMP_VERSION=$(DOCKER_TAG)
+	export DEVICE_VIRTUAL_VERSION=$(DOCKER_TAG)
+	export DEVICE_LLRP_VERSION=$(DOCKER_TAG)
+	export DEVICE_COAP_VERSION=$(DOCKER_TAG)
+	export DEVICE_GPIO_VERSION=$(DOCKER_TAG)
+	export DEVICE_ONVIFCAM_VERSION=$(DOCKER_TAG)
+	export DEVICE_USBCAM_VERSION=$(DOCKER_TAG)
+	export DEVICE_S7_VERSION=$(DOCKER_TAG)
+	export DEVICE_OPCUA_VERSION=$(DOCKER_TAG)
+	export DEVICE_CAN_VERSION=$(DOCKER_TAG)
 endif
 ifeq (ui-dev, $(filter ui-dev,$(ARGS)))
 	export UI_REPOSITORY=edgexfoundry
-	export EDGEX_UI_VERSION=0.0.0-dev
+	export EDGEX_UI_VERSION=$(DOCKER_TAG)
 endif
 ifeq (arm64, $(filter arm64,$(ARGS)))
 	export ARCH=-arm64

--- a/compose-builder/README.md
+++ b/compose-builder/README.md
@@ -5,7 +5,9 @@ This folder contains the `Compose Builder` which is made up of **source** compos
 ### **Note to Developers**: 
 > *Once you have edited and tested your changes to these source files you **MUST** regenerate the standard `pre-release` compose files using the `make build` command.*
 >
-> Any options added or removed to/from the `make gen` and `make run` commands must to also be added/removed to/from the new` tui-generator.sh` script
+> Any options added or removed to/from the `make gen` and `make run` commands must to also be added/removed to/from
+> the new` tui-generator.sh` script. Also, when testing custom images, developers can set a custom version in a file
+> named `VERSION`, which is going to be used as the docker tag, e.g. `VERSION = 4.0.0` `DOCKER_TAG = 4.0.0-dev`.
 >
 
 ### Compose CLI Command


### PR DESCRIPTION
To adhere to other EdgeX's subprojects where custom versions can be set with a VERSION file and this version is fed during a make call, add the same ability to this compose repository, where custom version can be set when building/generating a custom image (e.g. for development) for each image. This ability eases developer's life for setting the docker tag for all the containers that are already built locally.

Closes #518

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [x] I have opened a PR for the related docs change (if not, why?)

