### PR TITLE
fix: override duplicate compose security options

### DIFF
--- a/compose-builder/add-mqtt-broker-mosquitto.yml
+++ b/compose-builder/add-mqtt-broker-mosquitto.yml
@@ -25,6 +25,6 @@ services:
     restart: always
     networks:
       - edgex-network
-    security_opt:
+    security_opt: !override
       - no-new-privileges:true
     user: "${EDGEX_USER}:${EDGEX_GROUP}"

--- a/compose-builder/add-secure-postgres.yml
+++ b/compose-builder/add-secure-postgres.yml
@@ -35,7 +35,7 @@ services:
       DATABASECONFIG_PATH: /tmp/postgres-init-scripts
       DATABASECONFIG_NAME: create-users.sh
       POSTGRES_DB: edgex_db
-    security_opt:
+    security_opt: !override
       - no-new-privileges:true
     tmpfs:
       - /run


### PR DESCRIPTION
Fixes #526.

Compose 5 rejects the `make down` file set because it merges the same `security_opt` value from the mutually exclusive MQTT broker and PostgreSQL definitions. Mark the default Mosquitto and secure PostgreSQL lists as overrides so the generated configuration keeps `no-new-privileges:true` without producing duplicate entries.

## PR Checklist

- [x] I am not introducing a breaking change
- [x] I have fully tested this bug fix
- [ ] I have opened a PR for a related docs change (not applicable)

## Testing Instructions

- Reproduced the duplicate `security_opt` validation failure with Docker Compose 5.5.0
- Verified the complete 35-file `make down` configuration with Compose 2.24.4 and 5.5.0
- Verified the default secure and non-secure configurations with both Compose versions
- Ran the full `make build`, including standard, ARM64, Zero Trust, and TAF variants
- Compared generated files with an unmodified control build using the same Compose version; outputs matched
